### PR TITLE
Any fields present in the constructor do not have to be null

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ myMemberWithType = mapper.readValue(json)
 
 # Annotations
 
-You can intermix non-field values in the constructor and `JsonProperty` annotation in the constructor.  Any fields not present in the constructor will be set after the constructor call and therefore must be nullable with default value.  An example of these concepts:
+You can intermix non-field values in the constructor and `JsonProperty` annotation in the constructor.  Any fields not present in the constructor will be set after the constructor call.  An example of these concepts:
 
 ```kotlin
+   JsonInclude(JsonInclude.Include.NON_EMPTY)
    class StateObjectWithPartialFieldsInConstructor(val name: String, JsonProperty("age") val years: Int)    {
-        JsonProperty("address") var primaryAddress: String? = null
+        JsonProperty("address") var primaryAddress: String = "" // does not have to be nullable
         var createdDt: DateTime by Delegates.notNull()
     }
 ```


### PR DESCRIPTION
Core code unchanged, but added tests to prove this out.  Also added more to the test of a class that has a primary and secondary constructor to prove that indeed both could be used by to deserialize.

Updated the docs to strike comment about the requirement for nullability of fields not present in the constructor.