### PR TITLE
Update to 2.8.0-SNAPSHOT for jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <version.jackson.annotations>2.8.0-SNAPSHOT</version.jackson.annotations>
-        <version.jackson.core>2.7.4</version.jackson.core>
+        <version.jackson.core>2.8.0-SNAPSHOT</version.jackson.core>
 
         <!-- Joda only for testing -->
         <version.jackson.joda>${version.jackson.core}</version.jackson.joda>

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -67,7 +67,7 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule) : Nop
     override public fun hasCreatorAnnotation(member: Annotated): Boolean {
         // don't add a JsonCreator to any constructor if one is declared already
 
-        if (member is AnnotatedConstructor) {
+        if (member is AnnotatedConstructor && !member.declaringClass.isEnum) {
             // if has parameters, is a Kotlin class, and the parameters all have parameter annotations, then pretend we have a JsonCreator
             if (member.getParameterCount() > 0 && member.getDeclaringClass().isKotlinClass()) {
                 val kClass = (member.getDeclaringClass() as Class<Any>).kotlin


### PR DESCRIPTION
Making the pom change by itself broke a few tests:

```
  Tests in error:
    TestCasesFromSlack1.testCzarSpringThing1:64 ▒ JsonMapping Argument #0 of const...
    TestCasesFromSlack2.testCzarSpringThing2:64 ▒ JsonMapping Argument #0 of const...
    TestGithub15.testEnumConstructorWithParm:9 ▒ JsonMapping Argument #0 of constr...
    TestGithub15.testNormEnumWithoutParam:16 ▒ JsonMapping Argument #0 of construc...

  Tests run: 36, Failures: 0, Errors: 4, Skipped: 1
```

They all failed to deserialize enums.  Adding the line to KotlinModule
that skips AnnotatedConstructors for enum classes fixes those tests.
I don't entirely understand why the upgrade to 2.8.0-SNAPSHOT caused
those failures, but the fix sounds safe.  There's never a case where
we would want to try invoking an enum constructor, right?