### PR TITLE
Added specific exception for missing/null mandatory Kotlin constructor params

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Exceptions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Exceptions.kt
@@ -1,0 +1,9 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import kotlin.reflect.KParameter
+
+/**
+ * Specialized [JsonMappingException] sub-class used to indicate that a mandatory Kotlin constructor parameter was missing or null.
+ */
+class MissingKotlinParameterException(val parameter: KParameter, val msg: String) : JsonMappingException(null, msg)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -18,7 +18,7 @@ fun Class<*>.isKotlinClass(): Boolean {
 
 class KotlinModule() : SimpleModule(PackageVersion.VERSION) {
     companion object {
-        private val serialVersionUID = 1L;
+        private val serialVersionUID = 1L
     }
 
     val requireJsonCreatorAnnotation: Boolean = false
@@ -31,7 +31,7 @@ class KotlinModule() : SimpleModule(PackageVersion.VERSION) {
     override fun setupModule(context: SetupContext) {
         super.setupModule(context)
 
-        context.addValueInstantiators(KotlinInstantiators());
+        context.addValueInstantiators(KotlinInstantiators())
 
         fun addMixin(clazz: Class<*>, mixin: Class<*>) {
             impliedClasses.add(clazz)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -1,6 +1,9 @@
 package com.fasterxml.jackson.module.kotlin
 
-import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.databind.BeanDescription
+import com.fasterxml.jackson.databind.DeserializationConfig
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty
 import com.fasterxml.jackson.databind.deser.ValueInstantiator
 import com.fasterxml.jackson.databind.deser.ValueInstantiators
@@ -8,13 +11,10 @@ import com.fasterxml.jackson.databind.deser.impl.PropertyValueBuffer
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
-import com.fasterxml.jackson.databind.util.ClassUtil
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import kotlin.reflect.KParameter
 import kotlin.reflect.jvm.isAccessible
-import kotlin.reflect.jvm.javaConstructor
-import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.kotlinFunction
 
 class KotlinValueInstantiator(src: StdValueInstantiator) : StdValueInstantiator(src) {
@@ -53,7 +53,7 @@ class KotlinValueInstantiator(src: StdValueInstantiator) : StdValueInstantiator(
                             callableParametersByName.put(paramDef, null)
                         } else {
                             // missing value coming in as null for non-nullable type
-                            throw JsonMappingException(null, "Instantiation of " + this.getValueTypeDesc() + " value failed for JSON property ${jsonProp.name} due to missing (therefore NULL) value for creator parameter ${paramDef.name} which is a non-nullable type")
+                            throw MissingKotlinParameterException(paramDef, "Instantiation of " + this.getValueTypeDesc() + " value failed for JSON property ${jsonProp.name} due to missing (therefore NULL) value for creator parameter ${paramDef.name} which is a non-nullable type")
                         }
                     } else {
                         // default value for datatype for non nullable type, is ok
@@ -62,7 +62,7 @@ class KotlinValueInstantiator(src: StdValueInstantiator) : StdValueInstantiator(
                 } else {
                     if (paramVal == null && !paramDef.type.isMarkedNullable) {
                         // value coming in as null for non-nullable type
-                        throw JsonMappingException(null, "Instantiation of " + this.getValueTypeDesc() + " value failed for JSON property ${jsonProp.name} due to NULL value for creator parameter ${paramDef.name} which is a non-nullable type")
+                        throw MissingKotlinParameterException(paramDef, "Instantiation of " + this.getValueTypeDesc() + " value failed for JSON property ${jsonProp.name} due to NULL value for creator parameter ${paramDef.name} which is a non-nullable type")
                     } else {
                         // value present, and can be set
                         callableParametersByName.put(paramDef, paramVal)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github25.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github25.kt
@@ -1,12 +1,14 @@
 package com.fasterxml.jackson.module.kotlin.test
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.module.kotlin.*
 import org.junit.Test
 import kotlin.properties.Delegates
 import kotlin.test.assertEquals
 
 class TestGithub25 {
+    @JsonPropertyOrder(alphabetic = true)
     class SomethingWithDelegates(val data: MutableMap<String, String> = hashMapOf()) {
         val name: String by lazy { "fred" }
         @get:JsonIgnore val ignoreMe: String by lazy { "ignored" }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github32.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github32.kt
@@ -1,0 +1,42 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.hamcrest.CustomTypeSafeMatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import kotlin.reflect.KParameter
+
+private data class Github32TestObj(val firstName: String, val lastName: String)
+
+class Github32 {
+
+    @Rule
+    @JvmField
+    var thrown : ExpectedException = ExpectedException.none()
+
+    fun missingFirstNameParameter() = missingConstructorParam(::Github32TestObj.parameters[0])
+
+    fun missingConstructorParam(param: KParameter) = object : CustomTypeSafeMatcher<MissingKotlinParameterException>("MissingKotlinParameterException with missing `${param.name}` parameter") {
+        override fun matchesSafely(e: MissingKotlinParameterException): Boolean {
+            return e.parameter.equals(param)
+        }
+    }
+
+    @Test fun `valid mandatory data class constructor param`() {
+        jacksonObjectMapper().readValue<Github32TestObj>("""{"firstName": "James", "lastName": "Bond"}""")
+    }
+
+    @Test fun `missing mandatory data class constructor param`() {
+        thrown.expect(missingFirstNameParameter())
+        jacksonObjectMapper().readValue<Github32TestObj>("""{"lastName": "Bond"}""")
+    }
+
+    @Test fun `null mandatory data class constructor param`() {
+        thrown.expect(missingFirstNameParameter())
+        jacksonObjectMapper().readValue<Github32TestObj>("""{"firstName": null, "lastName": "Bond"}""")
+    }
+
+}


### PR DESCRIPTION
Allows the handling of missing/null constructor params (currently, a generic `JsonMappingException` is thrown).

Let me know what you think! We would really like this :)