### PR TITLE
Added more details (json location and path) to MissingKotlinParameterException

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Exceptions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Exceptions.kt
@@ -1,9 +1,10 @@
 package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.databind.JsonMappingException
+import java.io.Closeable
 import kotlin.reflect.KParameter
 
 /**
  * Specialized [JsonMappingException] sub-class used to indicate that a mandatory Kotlin constructor parameter was missing or null.
  */
-class MissingKotlinParameterException(val parameter: KParameter, val msg: String) : JsonMappingException(null, msg)
+class MissingKotlinParameterException(val parameter: KParameter, val processor: Closeable? = null, val msg: String) : JsonMappingException(processor, msg)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.module.kotlin
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.TreeNode
 import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.MappingIterator
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectReader
@@ -30,3 +31,7 @@ inline fun <reified T: Any> ObjectMapper.convertValue(from: Any): T = convertVal
 inline fun <reified T: Any> ObjectReader.readValue(jp: JsonParser): T = readValue(jp, object: TypeReference<T>() {})
 inline fun <reified T: Any> ObjectReader.readValues(jp: JsonParser): Iterator<T> = readValues(jp, object: TypeReference<T>() {})
 inline fun <reified T: Any> ObjectReader.treeToValue(n: TreeNode): T = treeToValue(n, T::class.java)
+
+
+internal fun JsonMappingException.wrapWithPath(refFrom: Any?, refFieldName: String) = JsonMappingException.wrapWithPath(this, refFrom, refFieldName)
+internal fun JsonMappingException.wrapWithPath(refFrom: Any?, index: Int) = JsonMappingException.wrapWithPath(this, refFrom, index)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -1,9 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
-import com.fasterxml.jackson.databind.BeanDescription
-import com.fasterxml.jackson.databind.DeserializationConfig
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty
 import com.fasterxml.jackson.databind.deser.ValueInstantiator
 import com.fasterxml.jackson.databind.deser.ValueInstantiators
@@ -53,7 +50,11 @@ class KotlinValueInstantiator(src: StdValueInstantiator) : StdValueInstantiator(
                             callableParametersByName.put(paramDef, null)
                         } else {
                             // missing value coming in as null for non-nullable type
-                            throw MissingKotlinParameterException(paramDef, "Instantiation of " + this.getValueTypeDesc() + " value failed for JSON property ${jsonProp.name} due to missing (therefore NULL) value for creator parameter ${paramDef.name} which is a non-nullable type")
+                            throw MissingKotlinParameterException(
+                                    parameter = paramDef,
+                                    processor = ctxt.parser,
+                                    msg = "Instantiation of ${this.valueTypeDesc} value failed for JSON property ${jsonProp.name} due to missing (therefore NULL) value for creator parameter ${paramDef.name} which is a non-nullable type"
+                            ).wrapWithPath(this.valueClass, jsonProp.name)
                         }
                     } else {
                         // default value for datatype for non nullable type, is ok
@@ -62,7 +63,11 @@ class KotlinValueInstantiator(src: StdValueInstantiator) : StdValueInstantiator(
                 } else {
                     if (paramVal == null && !paramDef.type.isMarkedNullable) {
                         // value coming in as null for non-nullable type
-                        throw MissingKotlinParameterException(paramDef, "Instantiation of " + this.getValueTypeDesc() + " value failed for JSON property ${jsonProp.name} due to NULL value for creator parameter ${paramDef.name} which is a non-nullable type")
+                        throw MissingKotlinParameterException(
+                                parameter = paramDef,
+                                processor = ctxt.parser,
+                                msg = "Instantiation of ${this.valueTypeDesc} value failed for JSON property ${jsonProp.name} due to NULL value for creator parameter ${paramDef.name} which is a non-nullable type"
+                        ).wrapWithPath(this.valueClass, jsonProp.name)
                     } else {
                         // value present, and can be set
                         callableParametersByName.put(paramDef, paramVal)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github32.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github32.kt
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.kotlin.test
 
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -9,34 +10,122 @@ import org.junit.Test
 import org.junit.rules.ExpectedException
 import kotlin.reflect.KParameter
 
-private data class Github32TestObj(val firstName: String, val lastName: String)
+private data class Person(val firstName: String, val lastName: String)
+
+private data class WrapperWithArgsContructor(val person: Person)
+
+private data class WrapperWithDefaultContructor(val person: Person? = null)
+
+private data class Crowd(val people: List<Person>)
 
 class Github32 {
 
     @Rule
     @JvmField
-    var thrown : ExpectedException = ExpectedException.none()
-
-    fun missingFirstNameParameter() = missingConstructorParam(::Github32TestObj.parameters[0])
-
-    fun missingConstructorParam(param: KParameter) = object : CustomTypeSafeMatcher<MissingKotlinParameterException>("MissingKotlinParameterException with missing `${param.name}` parameter") {
-        override fun matchesSafely(e: MissingKotlinParameterException): Boolean {
-            return e.parameter.equals(param)
-        }
-    }
+    var thrown: ExpectedException = ExpectedException.none()
 
     @Test fun `valid mandatory data class constructor param`() {
-        jacksonObjectMapper().readValue<Github32TestObj>("""{"firstName": "James", "lastName": "Bond"}""")
+        jacksonObjectMapper().readValue<Person>("""
+        {
+            "firstName": "James",
+            "lastName": "Bond"
+        }
+        """.trimIndent())
     }
 
     @Test fun `missing mandatory data class constructor param`() {
         thrown.expect(missingFirstNameParameter())
-        jacksonObjectMapper().readValue<Github32TestObj>("""{"lastName": "Bond"}""")
+        thrown.expect(pathMatches("firstName"))
+        thrown.expect(location(line = 3, column = 1))
+        jacksonObjectMapper().readValue<Person>("""
+        {
+            "lastName": "Bond"
+        }
+        """.trimIndent())
     }
 
     @Test fun `null mandatory data class constructor param`() {
         thrown.expect(missingFirstNameParameter())
-        jacksonObjectMapper().readValue<Github32TestObj>("""{"firstName": null, "lastName": "Bond"}""")
+        thrown.expect(pathMatches("firstName"))
+        thrown.expect(location(line = 4, column = 1))
+        jacksonObjectMapper().readValue<Person>("""
+        {
+            "firstName": null,
+            "lastName": "Bond"
+        }
+        """.trimIndent())
     }
 
+    @Test fun `missing mandatory constructor param - nested in class with default constructor`() {
+        thrown.expect(missingFirstNameParameter())
+        thrown.expect(pathMatches("person.firstName"))
+        thrown.expect(location(line = 4, column = 5))
+        jacksonObjectMapper().readValue<WrapperWithDefaultContructor>("""
+        {
+            "person": {
+                "lastName": "Bond"
+            }
+        }
+        """.trimIndent())
+    }
+
+    @Test fun `missing mandatory constructor param - nested in class with single arg constructor`() {
+        thrown.expect(missingFirstNameParameter())
+        thrown.expect(pathMatches("person.firstName"))
+        thrown.expect(location(line = 4, column = 5))
+        jacksonObjectMapper().readValue<WrapperWithArgsContructor>("""
+        {
+            "person": {
+                "lastName": "Bond"
+            }
+        }
+        """.trimIndent())
+    }
+
+    @Test fun `missing mandatory constructor param - nested in class with List arg constructor`() {
+        thrown.expect(missingFirstNameParameter())
+        thrown.expect(pathMatches("people[0].firstName"))
+        thrown.expect(location(line = 7, column = 9))
+        jacksonObjectMapper().readValue<Crowd>("""
+        {
+            "people": [
+                {
+                    "person": {
+                        "lastName": "Bond"
+                    }
+                }
+            ]
+        }
+        """.trimIndent())
+    }
+
+}
+
+private fun missingFirstNameParameter() = missingConstructorParam(::Person.parameters[0])
+
+private fun missingConstructorParam(param: KParameter) = object : CustomTypeSafeMatcher<MissingKotlinParameterException>("MissingKotlinParameterException with missing `${param.name}` parameter") {
+    override fun matchesSafely(e: MissingKotlinParameterException): Boolean = e.parameter.equals(param)
+}
+
+private fun pathMatches(path: String) = object : CustomTypeSafeMatcher<MissingKotlinParameterException>("MissingKotlinParameterException with path `$path`") {
+    override fun matchesSafely(e: MissingKotlinParameterException): Boolean = e.getHumanReadablePath().equals(path)
+}
+
+private fun location(line: Int, column: Int) = object : CustomTypeSafeMatcher<MissingKotlinParameterException>("MissingKotlinParameterException with location (line=$line, column=$column)") {
+    override fun matchesSafely(e: MissingKotlinParameterException): Boolean {
+        return e.location != null && line.equals(e.location.lineNr) && column.equals(e.location.columnNr)
+    }
+}
+
+private fun JsonMappingException.getHumanReadablePath(): String {
+    val builder = StringBuilder()
+    this.path.forEachIndexed { i, reference ->
+        if (reference.index >= 0) {
+            builder.append("[${reference.index}]")
+        } else {
+            if (i > 0) builder.append(".")
+            builder.append("${reference.fieldName}")
+        }
+    }
+    return builder.toString()
 }


### PR DESCRIPTION
Thanks so much for the fast feedback on #33, I really appreciate it :)

After submitting it I noticed that we weren't capturing the JSON location or path in the exception - both of these are extremely valuable both for debugging and programatically handling parsing exceptions.

Is it possible to tack this on to #32 as well?