### PR TITLE
Nullable serializers for primitives

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.databind.cfg.PackageVersion
+import com.fasterxml.jackson.databind.deser.std.NumberDeserializers
 import com.fasterxml.jackson.databind.introspect.*
 import com.fasterxml.jackson.databind.module.SimpleModule
 import java.lang.reflect.Constructor
@@ -45,6 +46,17 @@ class KotlinModule() : SimpleModule(PackageVersion.VERSION) {
         addMixin(IntRange::class.java, ClosedRangeMixin::class.java)
         addMixin(CharRange::class.java, ClosedRangeMixin::class.java)
         addMixin(LongRange::class.java, ClosedRangeMixin::class.java)
+    }
+
+    fun setNullablePrimitivesDeserializers() {
+        addDeserializer(Double::class.java, NumberDeserializers.DoubleDeserializer(Double::class.java, null))
+        addDeserializer(Float::class.java, NumberDeserializers.FloatDeserializer(Float::class.java, null))
+        addDeserializer(Long::class.java, NumberDeserializers.LongDeserializer(Long::class.java, null))
+        addDeserializer(Int::class.java, NumberDeserializers.IntegerDeserializer(Int::class.java, null))
+        addDeserializer(Short::class.java, NumberDeserializers.ShortDeserializer(Short::class.java, null))
+        addDeserializer(Byte::class.java, NumberDeserializers.ByteDeserializer(Byte::class.java, null))
+
+        addDeserializer(Char::class.java, NumberDeserializers.CharacterDeserializer(Char::class.java, null))
     }
 }
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.databind.cfg.PackageVersion
 import com.fasterxml.jackson.databind.introspect.*
 import com.fasterxml.jackson.databind.module.SimpleModule
 import java.lang.reflect.Constructor

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullPropertiesMappingTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullPropertiesMappingTest.kt
@@ -1,7 +1,8 @@
 package com.fasterxml.jackson.module.kotlin.test
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -13,7 +14,8 @@ class NonNullPropertiesMappingTest {
     data class TestCaseClass(
             val string: String,
             val javaInteger: Integer,
-            val kotlinInt: Int
+            val kotlinInt: Int,
+            val kotlinChar: Char
     )
 
     @Rule
@@ -21,42 +23,56 @@ class NonNullPropertiesMappingTest {
     val exception: ExpectedException = ExpectedException.none()
 
     @Test fun testFullJSON() {
-        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinInt":2}"""
+        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinInt":2,"kotlinChar":"a"}"""
 
-        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+        val result: TestCaseClass = jacksonObjectMapperWithNullablePrimitives().readValue(json)
 
-        assertThat(result, equalTo(TestCaseClass("STRING_VAL", Integer(1), 2)))
+        assertThat(result, equalTo(TestCaseClass("STRING_VAL", Integer(1), 2, 'a')))
     }
 
     @Test fun testMissingStringProperty() {
         expectMissingParam()
-        val json = """{"javaInteger":1,"kotlinInt":2}"""
+        val json = """{"javaInteger":1,"kotlinInt":2,"kotlinChar":"a"}"""
 
-        jacksonObjectMapper().readValue<TestCaseClass>(json)
+        jacksonObjectMapperWithNullablePrimitives().readValue<TestCaseClass>(json)
     }
 
     @Test fun testMissingJavaIntegerProperty() {
         expectMissingParam()
-        val json = """{"string":"STRING_VAL","kotlinInt":2}"""
+        val json = """{"string":"STRING_VAL","kotlinInt":2,"kotlinChar":"a"}"""
 
-        jacksonObjectMapper().readValue<TestCaseClass>(json)
+        jacksonObjectMapperWithNullablePrimitives().readValue<TestCaseClass>(json)
     }
 
     @Test fun testMissingKotlinIntProperty() {
         expectMissingParam()
-        val json = """{"string":"STRING_VAL","javaInteger":1}"""
+        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinChar":"a"}"""
 
-        jacksonObjectMapper().readValue<TestCaseClass>(json)
+        jacksonObjectMapperWithNullablePrimitives().readValue<TestCaseClass>(json)
+    }
+
+    @Test fun testMissingKotlinCharProperty() {
+        expectMissingParam()
+        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinInt":2}"""
+
+        jacksonObjectMapperWithNullablePrimitives().readValue<TestCaseClass>(json)
     }
 
     @Test fun testMissingAllProperty() {
         expectMissingParam()
         val json = "{}"
 
-        jacksonObjectMapper().readValue<TestCaseClass>(json)
+        jacksonObjectMapperWithNullablePrimitives().readValue<TestCaseClass>(json)
     }
 
     private fun expectMissingParam() {
         exception.expect(JsonMappingException::class.java)
     }
+}
+
+fun jacksonObjectMapperWithNullablePrimitives(): ObjectMapper {
+    val module = KotlinModule()
+    module.setNullablePrimitivesDeserializers()
+
+    return ObjectMapper().registerModule(module)
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullPropertiesMappingTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullPropertiesMappingTest.kt
@@ -1,0 +1,62 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+class NonNullPropertiesMappingTest {
+    data class TestCaseClass(
+            val string: String,
+            val javaInteger: Integer,
+            val kotlinInt: Int
+    )
+
+    @Rule
+    @JvmField
+    val exception: ExpectedException = ExpectedException.none()
+
+    @Test fun testFullJSON() {
+        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinInt":2}"""
+
+        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+
+        assertThat(result, equalTo(TestCaseClass("STRING_VAL", Integer(1), 2)))
+    }
+
+    @Test fun testMissingStringProperty() {
+        expectMissingParam()
+        val json = """{"javaInteger":1,"kotlinInt":2}"""
+
+        jacksonObjectMapper().readValue<TestCaseClass>(json)
+    }
+
+    @Test fun testMissingJavaIntegerProperty() {
+        expectMissingParam()
+        val json = """{"string":"STRING_VAL","kotlinInt":2}"""
+
+        jacksonObjectMapper().readValue<TestCaseClass>(json)
+    }
+
+    @Test fun testMissingKotlinIntProperty() {
+        expectMissingParam()
+        val json = """{"string":"STRING_VAL","javaInteger":1}"""
+
+        jacksonObjectMapper().readValue<TestCaseClass>(json)
+    }
+
+    @Test fun testMissingAllProperty() {
+        expectMissingParam()
+        val json = "{}"
+
+        jacksonObjectMapper().readValue<TestCaseClass>(json)
+    }
+
+    private fun expectMissingParam() {
+        exception.expect(JsonMappingException::class.java)
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullPropertiesWithDefaultValuesMappingTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullPropertiesWithDefaultValuesMappingTest.kt
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.module.kotlin.test
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert.assertThat
@@ -12,7 +11,8 @@ class NonNullPropertiesWithDefaultValuesMappingTest {
     data class TestCaseClass(
             val string: String = "DEFAULT_VAL",
             val javaInteger: Integer = Integer(11),
-            val kotlinInt: Int = 12
+            val kotlinInt: Int = 12,
+            val kotlinChar: Char = 'B'
     )
 
     @Rule
@@ -20,41 +20,49 @@ class NonNullPropertiesWithDefaultValuesMappingTest {
     val exception: ExpectedException = ExpectedException.none()
 
     @Test fun testFullJSON() {
-        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinInt":2}"""
+        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinInt":2,"kotlinChar":"a"}"""
 
-        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+        val result: TestCaseClass = jacksonObjectMapperWithNullablePrimitives().readValue(json)
 
-        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(1), 2)))
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(1), 2, 'a')))
     }
 
     @Test fun testMissingStringProperty() {
-        val json = """{"javaInteger":1,"kotlinInt":2}"""
+        val json = """{"javaInteger":1,"kotlinInt":2,"kotlinChar":"a"}"""
 
-        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+        val result: TestCaseClass = jacksonObjectMapperWithNullablePrimitives().readValue(json)
 
-        assertThat(result, CoreMatchers.equalTo(TestCaseClass("DEFAULT_VAL", Integer(1), 2)))
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("DEFAULT_VAL", Integer(1), 2, 'a')))
     }
 
     @Test fun testMissingJavaIntegerProperty() {
-        val json = """{"string":"STRING_VAL","kotlinInt":2}"""
+        val json = """{"string":"STRING_VAL","kotlinInt":2,"kotlinChar":"a"}"""
 
-        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+        val result: TestCaseClass = jacksonObjectMapperWithNullablePrimitives().readValue(json)
 
-        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(11), 2)))
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(11), 2, 'a')))
     }
 
     @Test fun testMissingKotlinIntProperty() {
-        val json = """{"string":"STRING_VAL","javaInteger":1}"""
+        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinChar":"a"}"""
 
-        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+        val result: TestCaseClass = jacksonObjectMapperWithNullablePrimitives().readValue(json)
 
-        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(1), 12)))
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(1), 12, 'a')))
+    }
+
+    @Test fun testMissingKotlinCharProperty() {
+        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinInt":"2"}"""
+
+        val result: TestCaseClass = jacksonObjectMapperWithNullablePrimitives().readValue(json)
+
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(1), 2, 'B')))
     }
 
     @Test fun testMissingAllProperties() {
         val json = "{}"
 
-        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+        val result: TestCaseClass = jacksonObjectMapperWithNullablePrimitives().readValue(json)
 
         assertThat(result, CoreMatchers.equalTo(TestCaseClass("DEFAULT_VAL", Integer(11), 12)))
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullPropertiesWithDefaultValuesMappingTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullPropertiesWithDefaultValuesMappingTest.kt
@@ -1,0 +1,61 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+class NonNullPropertiesWithDefaultValuesMappingTest {
+    data class TestCaseClass(
+            val string: String = "DEFAULT_VAL",
+            val javaInteger: Integer = Integer(11),
+            val kotlinInt: Int = 12
+    )
+
+    @Rule
+    @JvmField
+    val exception: ExpectedException = ExpectedException.none()
+
+    @Test fun testFullJSON() {
+        val json = """{"string":"STRING_VAL","javaInteger":1,"kotlinInt":2}"""
+
+        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(1), 2)))
+    }
+
+    @Test fun testMissingStringProperty() {
+        val json = """{"javaInteger":1,"kotlinInt":2}"""
+
+        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("DEFAULT_VAL", Integer(1), 2)))
+    }
+
+    @Test fun testMissingJavaIntegerProperty() {
+        val json = """{"string":"STRING_VAL","kotlinInt":2}"""
+
+        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(11), 2)))
+    }
+
+    @Test fun testMissingKotlinIntProperty() {
+        val json = """{"string":"STRING_VAL","javaInteger":1}"""
+
+        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("STRING_VAL", Integer(1), 12)))
+    }
+
+    @Test fun testMissingAllProperties() {
+        val json = "{}"
+
+        val result: TestCaseClass = jacksonObjectMapper().readValue(json)
+
+        assertThat(result, CoreMatchers.equalTo(TestCaseClass("DEFAULT_VAL", Integer(11), 12)))
+    }
+}


### PR DESCRIPTION
Primitives deserializers should be changed to nullables (wrapper instances) since Jackson respects defaults values. In that way user can specify required values on language level:
`data class TestCaseClass(
            val required1: Integer,
            val required2: Int,
            val optional1: Char?,
            val optional2: Int = 5
    )`
In above class when serialized value do not contain fields required1 and required2 (primitive) we get MissingKotlinParameterException while reading value. Fields optional1 and optionl2 will be evaluated to proper default values (null and 5).

Without this change when required2 is missing it will be evaluated to 0 what in my opinion is wrong.