### PR TITLE
Allow optional primitives when FAIL_ON_NULL_FOR_PRIMITIVES=true

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -12,7 +12,6 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import kotlin.reflect.KParameter
 import kotlin.reflect.jvm.isAccessible
-import kotlin.reflect.jvm.kotlinFunction
 
 internal class KotlinValueInstantiator(src: StdValueInstantiator, private val cache: ReflectionCache) : StdValueInstantiator(src) {
     @Suppress("UNCHECKED_CAST")
@@ -23,62 +22,38 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
             else -> throw IllegalStateException("Expected a constructor or method to create a Kotlin object, instead found ${_withArgsCreator.annotated.javaClass.name}")
         } ?: return super.createFromObjectWith(ctxt, props, buffer) // we cannot reflect this method so do the default Java-ish behavior
 
-        val jsonParmValueList = buffer.getParameters(props) // properties in order, null for missing or actual nulled parameters
-
-        // quick short circuit for special handling for no null checks needed and no optional parameters
-        if (jsonParmValueList.none { it == null } && callable.parameters.none { it.isOptional }) {
-           return super.createFromObjectWith(ctxt, jsonParmValueList)
+        if (callable.parameters.any { it.kind == KParameter.Kind.INSTANCE || it.kind == KParameter.Kind.EXTENSION_RECEIVER }) {
+            // we shouldn't have an instance or receiver parameter and if we do, just go with default Java-ish behavior
+            return super.createFromObjectWith(ctxt, props, buffer)
         }
 
         val callableParametersByName = hashMapOf<KParameter, Any?>()
+        val jsonParamValueList = kotlin.arrayOfNulls<Any>(props.size)
 
         callable.parameters.forEachIndexed { idx, paramDef ->
-            if (paramDef.kind == KParameter.Kind.INSTANCE || paramDef.kind == KParameter.Kind.EXTENSION_RECEIVER) {
-                // we shouldn't have an instance or receiver parameter and if we do, just go with default Java-ish behavior
-                return super.createFromObjectWith(ctxt, jsonParmValueList)
-            } else {
-                val jsonProp = props.get(idx)
-                val isMissing = !buffer.hasParameter(jsonProp)
-                val paramVal = jsonParmValueList.get(idx)
+            val jsonProp = props.get(idx)
+            val isMissing = !buffer.hasParameter(jsonProp)
 
-                if (isMissing) {
-                    if (paramDef.isOptional) {
-                        // this is ok, optional parameter not resolved will have default parameter value of method
-                    } else if (paramVal == null) {
-                        if (paramDef.type.isMarkedNullable) {
-                            // null value for nullable type, is ok
-                            callableParametersByName.put(paramDef, null)
-                        } else {
-                            // missing value coming in as null for non-nullable type
-                            throw MissingKotlinParameterException(
-                                    parameter = paramDef,
-                                    processor = ctxt.parser,
-                                    msg = "Instantiation of ${this.valueTypeDesc} value failed for JSON property ${jsonProp.name} due to missing (therefore NULL) value for creator parameter ${paramDef.name} which is a non-nullable type"
-                            ).wrapWithPath(this.valueClass, jsonProp.name)
-                        }
-                    } else {
-                        // default value for datatype for non nullable type, is ok
-                        callableParametersByName.put(paramDef, paramVal)
-                    }
-                } else {
-                    if (paramVal == null && !paramDef.type.isMarkedNullable) {
-                        // value coming in as null for non-nullable type
-                        throw MissingKotlinParameterException(
-                                parameter = paramDef,
-                                processor = ctxt.parser,
-                                msg = "Instantiation of ${this.valueTypeDesc} value failed for JSON property ${jsonProp.name} due to NULL value for creator parameter ${paramDef.name} which is a non-nullable type"
-                        ).wrapWithPath(this.valueClass, jsonProp.name)
-                    } else {
-                        // value present, and can be set
-                        callableParametersByName.put(paramDef, paramVal)
-                    }
-                }
+            if (isMissing && paramDef.isOptional) {
+                return@forEachIndexed
             }
+
+            val paramVal = buffer.getParameter(jsonProp)
+            jsonParamValueList[idx] = paramVal
+
+            if (paramVal == null && !paramDef.type.isMarkedNullable) {
+                throw MissingKotlinParameterException(
+                        parameter = paramDef,
+                        processor = ctxt.parser,
+                        msg = "Instantiation of ${this.valueTypeDesc} value failed for JSON property ${jsonProp.name} due to missing (therefore NULL) value for creator parameter ${paramDef.name} which is a non-nullable type"
+                ).wrapWithPath(this.valueClass, jsonProp.name)
+            }
+            callableParametersByName.put(paramDef, paramVal)
         }
 
-        return if (callableParametersByName.size == jsonParmValueList.size) {
+        return if (callableParametersByName.size == jsonParamValueList.size) {
             // we didn't do anything special with default parameters, do a normal call
-            super.createFromObjectWith(ctxt, jsonParmValueList)
+            super.createFromObjectWith(ctxt, jsonParamValueList)
         } else {
             val accessible = callable.isAccessible
             if ((!accessible && ctxt.config.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) ||

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/FailOnNullForPrimitivesTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/FailOnNullForPrimitivesTests.kt
@@ -1,0 +1,52 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import kotlin.test.assertEquals
+
+
+class FailOnNullForPrimitivesTests {
+
+    data class OptionalIntRequiredBoolean(val optInt: Int = -1, val reqBool: Boolean)
+
+    val mapper = jacksonObjectMapper().enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+
+    @Rule
+    @JvmField
+    var thrown: ExpectedException = ExpectedException.none()
+
+    @Test fun `optional primitive parameter defaulted if not in json when FAIL_ON_NULL_FOR_PRIMITIVES is true`() {
+        val actualObj: OptionalIntRequiredBoolean = mapper.readValue("""
+        {
+            "reqBool": false
+        }
+        """)
+
+        assertEquals(OptionalIntRequiredBoolean(reqBool = false), actualObj)
+    }
+
+    @Test fun `Exception thrown if required primitive parameter not in json when FAIL_ON_NULL_FOR_PRIMITIVES is true`() {
+        thrown.expect(JsonMappingException::class.java)
+        thrown.expectMessage("Can not map JSON null into type boolean")
+
+        mapper.readValue<OptionalIntRequiredBoolean>("""
+        {"optInt": 2}
+        """)
+    }
+
+    @Test fun `optional parameter has json value if provided when FAIL_ON_NULL_FOR_PRIMITIVES is true`() {
+        val actualObj: OptionalIntRequiredBoolean = mapper.readValue("""
+        {
+            "optInt": 3,
+            "reqBool": true
+        }
+        """)
+
+        assertEquals(OptionalIntRequiredBoolean(3, true), actualObj)
+    }
+}


### PR DESCRIPTION
Use case is to enable `FAIL_ON_NULL_FOR_PRIMITIVES` so that non-nullable and non-optional primitive fields do not default to their platform zero value when they are excluded from the json but instead raise a json mapping exception. However enabling that feature also caused optional primitive fields with default values specified to throw the same exception. 

The problem was the exception for null primitives was thrown inside the `buffer.getParameters(props)` call which was at the beginning of the `createFromObjectWith()` method and was always executed. This commit reorganizes that method to remove the `buffer.getParameters()` call and instead first check each property to see if it is missing in the json and optional in which case the buffer value is not needed. Otherwise if the buffer value is needed `buffer.getParameter()` is used to get only that specific property's value.