### PR TITLE
Improve performance by avoiding creating callable map unless needed

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -26,15 +26,16 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
             else -> throw IllegalStateException("Expected a constructor or method to create a Kotlin object, instead found ${_withArgsCreator.annotated.javaClass.name}")
         } ?: return super.createFromObjectWith(ctxt, props, buffer) // we cannot reflect this method so do the default Java-ish behavior
 
-        val callableParametersByName = hashMapOf<KParameter, Any?>()
-        val jsonParamValueList = kotlin.arrayOfNulls<Any>(props.size)
+        var numCallableParameters = 0
+        val callableParameters = arrayOfNulls<KParameter>(props.size)
+        val jsonParamValueList = arrayOfNulls<Any>(props.size)
 
         callable.parameters.forEachIndexed { idx, paramDef ->
             if (paramDef.kind == KParameter.Kind.INSTANCE || paramDef.kind == KParameter.Kind.EXTENSION_RECEIVER) {
                 // we shouldn't have an instance or receiver parameter and if we do, just go with default Java-ish behavior
                 return super.createFromObjectWith(ctxt, props, buffer)
             }
-            val jsonProp = props.get(idx)
+            val jsonProp = props[idx]
             val isMissing = !buffer.hasParameter(jsonProp)
 
             if (isMissing && paramDef.isOptional) {
@@ -56,10 +57,12 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
                         msg = "Instantiation of ${this.valueTypeDesc} value failed for JSON property ${jsonProp.name} due to missing (therefore NULL) value for creator parameter ${paramDef.name} which is a non-nullable type"
                 ).wrapWithPath(this.valueClass, jsonProp.name)
             }
-            callableParametersByName.put(paramDef, paramVal)
+
+            numCallableParameters++
+            callableParameters[idx] = paramDef
         }
 
-        return if (callableParametersByName.size == jsonParamValueList.size) {
+        return if (numCallableParameters == jsonParamValueList.size) {
             // we didn't do anything special with default parameters, do a normal call
             super.createFromObjectWith(ctxt, jsonParamValueList)
         } else {
@@ -68,7 +71,12 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
                     (accessible && ctxt.config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS))) {
                 callable.isAccessible = true
             }
-
+            val callableParametersByName = linkedMapOf<KParameter, Any?>()
+            callableParameters.mapIndexed { idx, paramDef ->
+                if (paramDef != null) {
+                    callableParametersByName[paramDef] = jsonParamValueList[idx]
+                }
+            }
             callable.callBy(callableParametersByName)
         }
 


### PR DESCRIPTION
Calculating `hashCode` for `KParameter` adds up under heavy deserialization workloads:

<img width="1361" alt="screen shot 2017-08-12 at 11 00 22 pm" src="https://user-images.githubusercontent.com/1479220/29246525-5ba1b6d6-7fb2-11e7-97ba-416ef92372d4.png">
