### PR TITLE
Add const keyword to inline primitive.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -30,8 +30,8 @@ fun Class<*>.isKotlinClass(): Boolean {
 }
 
 class KotlinModule(val reflectionCacheSize: Int = 512) : SimpleModule(PackageVersion.VERSION) {
-    companion object {
-        private val serialVersionUID = 1L
+    private companion object {
+        const val serialVersionUID = 1L
     }
 
     val requireJsonCreatorAnnotation: Boolean = false


### PR DESCRIPTION
Const make strings and primitives get inlined, rather than needing a generated getter method.