### PR TITLE
Fix #101 Allow injecting a value

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -41,7 +41,7 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
                 return@forEachIndexed
             }
 
-            val paramVal = if (buffer.hasParameter(jsonProp) || paramDef.isPrimitive()) {
+            val paramVal = if (!isMissing || paramDef.isPrimitive() || jsonProp.hasInjectableValueId()) {
                 buffer.getParameter(jsonProp)
             } else {
                 null
@@ -85,6 +85,8 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
             else -> false
         }
     }
+
+    private fun SettableBeanProperty.hasInjectableValueId(): Boolean = injectableValueId != null
 }
 
 internal class KotlinInstantiators(private val cache: ReflectionCache) : ValueInstantiators {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/GitHub101JacksonInjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/GitHub101JacksonInjectTest.kt
@@ -1,0 +1,22 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.annotation.JacksonInject
+import com.fasterxml.jackson.databind.InjectableValues
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class GitHub101JacksonInjectTest {
+    @Test
+    fun `JacksonInject-annotated parameters are populated when constructing Kotlin data classes`() {
+        val mapper = jacksonObjectMapper()
+        val contextualValue = UUID.randomUUID()
+        assertEquals(SomeDatum("test", contextualValue),
+                mapper.readerFor(SomeDatum::class.java)
+                        .with(InjectableValues.Std(mapOf("context" to contextualValue)))
+                        .readValue("""{ "value": "test" }"""))
+    }
+
+    data class SomeDatum(val value: String, @JacksonInject("context") val contextualValue: UUID)
+}


### PR DESCRIPTION
When `KotlinValueInstantiator` finds a property to be optional it has also to check whether the property has an injectable value configured by `@JacksonInject`.  Other possible solution that came to my mind is to call `buffer.getParameter(jsonProp)`, catch MismatchedInputException and then check whether we should return null as property value or rethrow the exception. However, catching and rethrowing exceptions never seemed elegant to me.