### PR TITLE
Upgrade to Kotlin 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.fasterxml.jackson.module</groupId>
     <artifactId>jackson-module-kotlin</artifactId>
     <name>jackson-module-kotlin</name>
-    <version>2.7.10-SNAPSHOT</version>
+    <version>2.7.10-K1.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Add-on module for Jackson (http://jackson.codehaus.org) to support
         Kotlin language, specifically introspection of method/constructor parameter names,
@@ -37,7 +37,7 @@
         <version.jackson.joda>${version.jackson.core}</version.jackson.joda>
 
         <version.junit>4.12</version.junit>
-        <version.kotlin>1.0.6</version.kotlin>
+        <version.kotlin>1.2.0</version.kotlin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.fasterxml.jackson.module</groupId>
     <artifactId>jackson-module-kotlin</artifactId>
     <name>jackson-module-kotlin</name>
-    <version>2.7.10-K1.2-SNAPSHOT</version>
+    <version>2.7.9.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Add-on module for Jackson (http://jackson.codehaus.org) to support
         Kotlin language, specifically introspection of method/constructor parameter names,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -1,13 +1,23 @@
 package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.databind.introspect.*
+import com.fasterxml.jackson.databind.introspect.Annotated
+import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember
+import com.fasterxml.jackson.databind.introspect.AnnotatedParameter
+import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
 import com.fasterxml.jackson.databind.module.SimpleModule
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.HashSet
-import kotlin.reflect.*
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.companionObject
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.defaultType
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.reflect.jvm.kotlinFunction
 
 private val metadataFqName = "kotlin.Metadata"


### PR DESCRIPTION
# Motivation 
For a personal project of mine, I have to absolutely use _Jackson_ `2.7`. Unfortunately, `jackson-module-kotlin` in version `2.7` is not compatible with _Kotlin Reflect_ `1.2.0` since some classes were moved.

# Suggestion
I created a fork an fixed this in the `2.7` branch and deployed to my local _Maven_ for unblocking my project. Here I propose to integrate it and release a new `2.7`.

# Help required!
I am not sure how to manage the versioning. Should I change it to `2.7.11` or will some Continuous Integration server do that for us? For the moment, it is `2.7.10-K1.2-SNAPSHOT`. Please advice in this Pull Request what I should have there instead.
