### PR TITLE
Add support for injecting default values (such as via modules) when null

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InjectsDefaultValue.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InjectsDefaultValue.kt
@@ -1,0 +1,5 @@
+package com.fasterxml.jackson.module.kotlin
+
+@Target(AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class InjectsDefaultValue

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -27,16 +27,16 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
 
 
     override fun hasRequiredMarker(m: AnnotatedMember): Boolean? =
-            if (m.member.declaringClass.isKotlinClass()) {
-                when (m) {
-                    is AnnotatedField     -> m.hasRequiredMarker()
-                    is AnnotatedMethod    -> m.hasRequiredMarker()
-                    is AnnotatedParameter -> m.hasRequiredMarker()
-                    else                  -> null
-                }
-            } else {
-                null
+        when {
+            m.hasAnnotation(InjectsDefaultValue::class.java) -> false
+            m.member.declaringClass.isKotlinClass() -> when (m) {
+                is AnnotatedField     -> m.hasRequiredMarker()
+                is AnnotatedMethod    -> m.hasRequiredMarker()
+                is AnnotatedParameter -> m.hasRequiredMarker()
+                else                  -> null
             }
+            else -> null
+        }
 
     private fun AnnotatedField.hasRequiredMarker(): Boolean? =
             (member as Field).kotlinProperty?.returnType?.isRequired()

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -42,7 +42,7 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
                 return@forEachIndexed
             }
 
-            val paramVal = if (!isMissing || paramDef.isPrimitive() || jsonProp.hasInjectableValueId()) {
+            val paramVal = if (!isMissing || paramDef.isPrimitive() || jsonProp.hasInjectableValueId() || jsonProp.injectsDefaultValue()) {
                 buffer.getParameter(jsonProp)
             } else {
                 null
@@ -95,6 +95,8 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
     }
 
     private fun SettableBeanProperty.hasInjectableValueId(): Boolean = injectableValueId != null
+
+    private fun SettableBeanProperty.injectsDefaultValue(): Boolean = getAnnotation(InjectsDefaultValue::class.java) != null
 }
 
 internal class KotlinInstantiators(private val cache: ReflectionCache) : ValueInstantiators {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/InjectsDefaultValueTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/InjectsDefaultValueTests.kt
@@ -1,0 +1,72 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.BeanDescription
+import com.fasterxml.jackson.databind.BeanProperty
+import com.fasterxml.jackson.databind.DeserializationConfig
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.type.CollectionType
+import com.fasterxml.jackson.module.kotlin.InjectsDefaultValue
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.Test
+import kotlin.test.assertEquals
+
+
+class InjectsDefaultValueTests {
+
+    private data class TestClass(@get:InjectsDefaultValue val foo: List<Int>)
+
+    @Test
+    fun nonNullCaseStillWorks() {
+        val mapper = jacksonObjectMapper()
+        assertEquals(listOf(1,2), mapper.readValue("""{"foo": [1,2]}""", TestClass::class.java).foo)
+    }
+
+    @Test
+    fun shouldAllowForInjectingDefaultValuesWhenNull() {
+        val mapper = jacksonObjectMapper()
+        mapper.registerModule(NullAwareDeserializationModule())
+        assertEquals(emptyList(), mapper.readValue("{}", TestClass::class.java).foo)
+        assertEquals(emptyList(), mapper.readValue("""{"foo": null}""", TestClass::class.java).foo)
+
+    }
+
+    @Test(expected = MissingKotlinParameterException::class)
+    fun shouldThrowIfDefaultValueIsNotInjected() {
+        val mapper = jacksonObjectMapper()
+        mapper.readValue("""{"foo": null}""", TestClass::class.java)
+    }
+
+    class NullAwareDeserializationModule: SimpleModule() {
+        init {
+            @Suppress("UNCHECKED_CAST")
+            setDeserializerModifier(object: BeanDeserializerModifier() {
+                override fun modifyCollectionDeserializer(config: DeserializationConfig?, type: CollectionType?, beanDesc: BeanDescription?, deserializer: JsonDeserializer<*>): JsonDeserializer<*>? {
+                    return object : JsonDeserializer<Collection<Any>>(), ContextualDeserializer {
+                        override fun deserialize(jp: JsonParser, ctx: DeserializationContext?): Collection<Any>? {
+                            return deserializer.deserialize(jp, ctx) as Collection<Any>?
+                        }
+
+                        override fun createContextual(ctx: DeserializationContext?, property: BeanProperty?): JsonDeserializer<*>? {
+                            val contextualDeserializer = (deserializer as ContextualDeserializer).createContextual(ctx, property)
+                            return modifyCollectionDeserializer(config, type, beanDesc, contextualDeserializer)
+                        }
+
+                        override fun getNullValue(ctx: DeserializationContext?): Collection<Any>? {
+                            return when {
+                                type?.isTypeOrSubTypeOf(Set::class.java) == true -> emptySet()
+                                type?.isTypeOrSubTypeOf(List::class.java) == true -> emptyList()
+                                else -> throw UnsupportedOperationException("Unexpected collection type value: $type")
+                            }
+                        }
+                    }
+                }
+            })
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses the issue I described in https://github.com/FasterXML/jackson-module-kotlin/issues/113. Upon further investigation (and reading the conversation on this PR: https://github.com/FasterXML/jackson-module-kotlin/pull/77), I do understand the context of the change in regards to the required annotation being inferred based on kotlin nullability semantics, which I largely agree with. However, there are cases where that behavior may not be desired, and this PR provides a way to specify that. It's an additive-only change that should not change any existing behavior and there are test to back the change. 