### PR TITLE
Add support for null to empty collections

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -23,20 +23,21 @@ import kotlin.reflect.jvm.kotlinFunction
 import kotlin.reflect.jvm.kotlinProperty
 
 
-internal class KotlinAnnotationIntrospector(private val context: Module.SetupContext) : NopAnnotationIntrospector() {
+internal class KotlinAnnotationIntrospector(private val context: Module.SetupContext, private val nullToEmptyCollection: Boolean, private val nullToEmptyMap: Boolean) : NopAnnotationIntrospector() {
 
 
     override fun hasRequiredMarker(m: AnnotatedMember): Boolean? =
-            if (m.member.declaringClass.isKotlinClass()) {
-                when (m) {
-                    is AnnotatedField     -> m.hasRequiredMarker()
-                    is AnnotatedMethod    -> m.hasRequiredMarker()
-                    is AnnotatedParameter -> m.hasRequiredMarker()
-                    else                  -> null
-                }
-            } else {
-                null
+        when {
+            nullToEmptyCollection && m.type.isCollectionLikeType -> false
+            nullToEmptyMap && m.type.isMapLikeType -> false
+            m.member.declaringClass.isKotlinClass() -> when (m) {
+                is AnnotatedField -> m.hasRequiredMarker()
+                is AnnotatedMethod -> m.hasRequiredMarker()
+                is AnnotatedParameter -> m.hasRequiredMarker()
+                else -> null
             }
+            else -> null
+        }
 
     private fun AnnotatedField.hasRequiredMarker(): Boolean? =
             (member as Field).kotlinProperty?.returnType?.isRequired()

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -29,7 +29,7 @@ fun Class<*>.isKotlinClass(): Boolean {
     return this.declaredAnnotations.singleOrNull { it.annotationClass.java.name == metadataFqName } != null
 }
 
-class KotlinModule(val reflectionCacheSize: Int = 512) : SimpleModule(PackageVersion.VERSION) {
+class KotlinModule(val reflectionCacheSize: Int = 512, val nullToEmptyCollection: Boolean = false, val nullToEmptyMap: Boolean = false) : SimpleModule(PackageVersion.VERSION) {
     companion object {
         const val serialVersionUID = 1L
     }
@@ -46,14 +46,14 @@ class KotlinModule(val reflectionCacheSize: Int = 512) : SimpleModule(PackageVer
 
         val cache = ReflectionCache(reflectionCacheSize)
 
-        context.addValueInstantiators(KotlinInstantiators(cache))
+        context.addValueInstantiators(KotlinInstantiators(cache, nullToEmptyCollection, nullToEmptyMap))
 
         fun addMixIn(clazz: Class<*>, mixin: Class<*>) {
             impliedClasses.add(clazz)
             context.setMixInAnnotations(clazz, mixin)
         }
 
-        context.insertAnnotationIntrospector(KotlinAnnotationIntrospector(context))
+        context.insertAnnotationIntrospector(KotlinAnnotationIntrospector(context, nullToEmptyCollection, nullToEmptyMap))
         context.appendAnnotationIntrospector(KotlinNamesAnnotationIntrospector(this, cache))
 
         // ranges

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyCollectionTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyCollectionTest.kt
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NullToEmptyCollectionTest {
+
+    private data class TestClass(val foo: List<Int>)
+
+    @Test
+    fun nonNullCaseStillWorks() {
+        val mapper = createMapper()
+        assertEquals(listOf(1,2), mapper.readValue("""{"foo": [1,2]}""", TestClass::class.java).foo)
+    }
+
+    @Test
+    fun shouldMapNullValuesToEmpty() {
+        val mapper = createMapper()
+        assertEquals(emptyList(), mapper.readValue("{}", TestClass::class.java).foo)
+        assertEquals(emptyList(), mapper.readValue("""{"foo": null}""", TestClass::class.java).foo)
+
+    }
+
+    private fun createMapper(): ObjectMapper {
+        return ObjectMapper().registerModule(KotlinModule(nullToEmptyCollection = true))
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyMapTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyMapTest.kt
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NullToEmptyMapTest {
+
+    private data class TestClass(val foo: Map<String, Int>)
+
+    @Test
+    fun nonNullCaseStillWorks() {
+        val mapper = createMapper()
+        assertEquals(mapOf("bar" to 1), mapper.readValue("""{"foo": {"bar": 1}}""", TestClass::class.java).foo)
+    }
+
+    @Test
+    fun shouldMapNullValuesToEmpty() {
+        val mapper = createMapper()
+        assertEquals(emptyMap(), mapper.readValue("{}", TestClass::class.java).foo)
+        assertEquals(emptyMap(), mapper.readValue("""{"foo": null}""", TestClass::class.java).foo)
+
+    }
+
+    private fun createMapper(): ObjectMapper {
+        return ObjectMapper().registerModule(KotlinModule(nullToEmptyMap = true))
+    }
+}


### PR DESCRIPTION
Take advantage of new core jackson code added in 2.9.0 around null handling so a separate module to convert null lists/maps to empty isn't required. All changes are opt-in and default to disabled, which will result in no changes to existing behavior for existing users. Tests have also been added to cover the new functionality.