### PR TITLE
Honor nullability semantics of collection types

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -111,6 +111,15 @@ internal class KotlinValueInstantiator(
                 ).wrapWithPath(this.valueClass, jsonProp.name)
             }
 
+            if (jsonProp.type.isCollectionLikeType && paramDef.type.arguments.getOrNull(0)?.type?.isMarkedNullable == false && (paramVal as Collection<*>).any { it == null }) {
+                val listType = paramDef.type.arguments[0].type
+                throw MissingKotlinParameterException(
+                    parameter = paramDef,
+                    processor = ctxt.parser,
+                    msg = "Instantiation of $listType collection failed for JSON property ${jsonProp.name} due to null value in a collection that does not allow null values"
+                ).wrapWithPath(this.valueClass, jsonProp.name)
+            }
+
             jsonParamValueList[numCallableParameters] = paramVal
             callableParameters[numCallableParameters] = paramDef
             numCallableParameters++

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github27.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github27.kt
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers.equalTo
@@ -34,20 +35,24 @@ class TestGithub27 {
 
     @Test fun testListOfNullableInt() {
         val json = """{"samples":[1, null]}"""
-        val stateObj = mapper.readValue<ClassWithListOfInt>(json)
+        val stateObj = mapper.readValue<ClassWithListOfNullableInt>(json)
         assertThat(stateObj.samples, equalTo(listOf(1, null)))
     }
 
     private data class ClassWithListOfInt(val samples: List<Int>)
 
-    @Ignore("Would be hard to look into generics of every possible type of collection or generic object to check nullability of each item, maybe only possible for simple known collections")
-    @Test fun testListOfInt() {
+    @Test(expected = MissingKotlinParameterException::class)
+    fun testListOfInt() {
         val json = """{"samples":[1, null]}"""
-        val stateObj = mapper.readValue<ClassWithListOfInt>(json)
-        assertTrue(stateObj.samples.none {
-            @Suppress("SENSELESS_COMPARISON")
-            (it == null)
-        })
+        mapper.readValue<ClassWithListOfInt>(json)
+    }
+
+    private data class TestClass<T>(val samples: T)
+
+    @Test fun testListOfGeneric() {
+        val json = """{"samples":[1, 2]}"""
+        val stateObj = mapper.readValue<TestClass<List<Int>>>(json)
+        assertThat(stateObj.samples, equalTo(listOf(1, 2)))
     }
 
     // work around to above


### PR DESCRIPTION
This partially addresses the issue in Github 27 that I also encountered. For my specific case, the issue was that I had a property typed as something like List<Int> (so non-nullable), but no error would be thrown during deserialization if you passed in something like [null]. Instead, later on after deserialization you would get a somewhat cryptic NPE like exception when you tried to access an element in the list. There is some performance impact to this solution so I understand if you'd prefer to wrap this in some option that has to be enabled.  Although we have been using these changes in a local fork for months without any noticeable issues and would be willing to tolerate a minor performance hit to avoid the above mentioned errors. This issue does not address nullability of a list of generics as that is a harder problem to solve.