### PR TITLE
Bump kotlin version to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <version.junit>4.12</version.junit>
-        <version.kotlin>1.2.51</version.kotlin>
+        <version.kotlin>1.3.0</version.kotlin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
No other changes were needed; tests pass.

I didn't see anything in the 1.3 changelog that would mean things would break when using a version of this module that was compiled against 1.2, but you never know... Anyway, at the very least, this will mean users don't have to override the kotlin-reflect version to match the rest of the kotlin artifacts.