### PR TITLE
Add test case and special handling for Kotlin's object type

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -43,6 +43,8 @@ class KotlinModule(val reflectionCacheSize: Int = 512, val nullToEmptyCollection
 
         context.addValueInstantiators(KotlinInstantiators(cache, nullToEmptyCollection, nullToEmptyMap))
 
+        context.addDeserializers(KotlinObjectInstanceDeserializers())
+
         fun addMixIn(clazz: Class<*>, mixin: Class<*>) {
             context.setMixInAnnotations(clazz, mixin)
         }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinObjectInstanceDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinObjectInstanceDeserializers.kt
@@ -1,0 +1,69 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.databind.deser.Deserializers
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+import com.fasterxml.jackson.databind.type.*
+
+class KotlinObjectInstanceDeserializers : Deserializers {
+    class StaticDeserializer(val content: Any) : JsonDeserializer<Any>() {
+        override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): Any {
+            return content
+        }
+    }
+
+    override fun findCollectionLikeDeserializer(type: CollectionLikeType?, config: DeserializationConfig?, beanDesc: BeanDescription?, elementTypeDeserializer: TypeDeserializer?, elementDeserializer: JsonDeserializer<*>?): JsonDeserializer<*>? {
+        return null
+    }
+
+    override fun findMapDeserializer(type: MapType?, config: DeserializationConfig?, beanDesc: BeanDescription?, keyDeserializer: KeyDeserializer?, elementTypeDeserializer: TypeDeserializer?, elementDeserializer: JsonDeserializer<*>?): JsonDeserializer<*>? {
+        return null
+    }
+
+    override fun findBeanDeserializer(type: JavaType, config: DeserializationConfig, beanDesc: BeanDescription?): JsonDeserializer<*>? {
+        if (!type.rawClass.isKotlinClass()) {
+            return null
+        }
+
+        val instanceOrNull = try {
+            type.rawClass.kotlin.objectInstance
+        } catch (ex: IllegalAccessException) {
+            // handle private class access
+            val instanceField = type.rawClass.fields.firstOrNull { it.name == "INSTANCE" } ?: throw ex
+            val accessible = instanceField.isAccessible
+            if ((!accessible && config.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) ||
+                    (accessible && config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS))
+            ) {
+                instanceField.isAccessible = true
+            }
+            instanceField.get(null) ?: throw ex
+        }
+
+        return instanceOrNull?.let { StaticDeserializer(it) }
+    }
+
+    override fun findTreeNodeDeserializer(nodeType: Class<out JsonNode>?, config: DeserializationConfig?, beanDesc: BeanDescription?): JsonDeserializer<*>? {
+        return null
+    }
+
+    override fun findReferenceDeserializer(refType: ReferenceType?, config: DeserializationConfig?, beanDesc: BeanDescription?, contentTypeDeserializer: TypeDeserializer?, contentDeserializer: JsonDeserializer<*>?): JsonDeserializer<*>? {
+        return null
+    }
+
+    override fun findMapLikeDeserializer(type: MapLikeType?, config: DeserializationConfig?, beanDesc: BeanDescription?, keyDeserializer: KeyDeserializer?, elementTypeDeserializer: TypeDeserializer?, elementDeserializer: JsonDeserializer<*>?): JsonDeserializer<*>? {
+        return null
+    }
+
+    override fun findEnumDeserializer(type: Class<*>?, config: DeserializationConfig?, beanDesc: BeanDescription?): JsonDeserializer<*>? {
+        return null
+    }
+
+    override fun findArrayDeserializer(type: ArrayType?, config: DeserializationConfig?, beanDesc: BeanDescription?, elementTypeDeserializer: TypeDeserializer?, elementDeserializer: JsonDeserializer<*>?): JsonDeserializer<*>? {
+        return null
+    }
+
+    override fun findCollectionDeserializer(type: CollectionType?, config: DeserializationConfig?, beanDesc: BeanDescription?, elementTypeDeserializer: TypeDeserializer?, elementDeserializer: JsonDeserializer<*>?): JsonDeserializer<*>? {
+        return null
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectDeserializationTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectDeserializationTest.kt
@@ -1,0 +1,72 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.junit.Test
+import java.io.StringWriter
+import kotlin.test.assertSame
+
+class ObjectDeserializationTest {
+    object TestObject
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+    sealed class Parent {
+        object ChildObject : Parent()
+    }
+
+    private object PrivateTestObject
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+    private sealed class PrivateParent {
+        object ChildObject : PrivateParent()
+    }
+
+    @Test
+    fun shouldDeserializeIntoStaticReference() {
+        val mapper = createMapper()
+
+        val writer = StringWriter()
+
+        mapper.writeValue(writer, TestObject)
+
+        assertSame(mapper.readValue(writer.toString(), TestObject::class.java), TestObject)
+    }
+
+    @Test
+    fun shouldDeserializeIntoStaticReferencePolymorphic() {
+        val mapper = createMapper()
+
+        val writer = StringWriter()
+
+        mapper.writeValue(writer, Parent.ChildObject)
+
+        assertSame(mapper.readValue(writer.toString(), Parent::class.java), Parent.ChildObject)
+    }
+
+    @Test
+    fun shouldDeserializeIntoStaticReferencePrivate() {
+        val mapper = createMapper()
+
+        val writer = StringWriter()
+
+        mapper.writeValue(writer, PrivateTestObject)
+
+        assertSame(mapper.readValue(writer.toString(), PrivateTestObject::class.java), PrivateTestObject)
+    }
+
+    @Test
+    fun shouldDeserializeIntoStaticReferencePolymorphicPrivate() {
+        val mapper = createMapper()
+
+        val writer = StringWriter()
+
+        mapper.writeValue(writer, PrivateParent.ChildObject)
+
+        assertSame(mapper.readValue(writer.toString(), PrivateParent::class.java), PrivateParent.ChildObject)
+    }
+
+    private fun createMapper(): ObjectMapper {
+        return ObjectMapper().registerModule(KotlinModule())
+    }
+}


### PR DESCRIPTION
Correctly deserialises
```
object SomeObject
```
into always the same reference instead of instantiating new ones.

Open to any feedback, not really that familiar with the codebase yet.