### PR TITLE
Fix Github #87, default value is not used if the provided value is null

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -96,8 +96,14 @@ internal class KotlinValueInstantiator(
                 jsonProp.valueDeserializer?.getNullValue(ctxt)
             }
 
-            if (paramVal == null && ((nullToEmptyCollection && jsonProp.type.isCollectionLikeType) || (nullToEmptyMap && jsonProp.type.isMapLikeType))) {
-                paramVal = NullsAsEmptyProvider(jsonProp.valueDeserializer).getNullValue(ctxt)
+            if (paramVal == null) {
+                if (paramDef.isOptional && !paramDef.type.isMarkedNullable) {
+                    //use the default argument
+                    return@forEachIndexed
+                }
+                if ((nullToEmptyCollection && jsonProp.type.isCollectionLikeType) || (nullToEmptyMap && jsonProp.type.isMapLikeType)) {
+                    paramVal = NullsAsEmptyProvider(jsonProp.valueDeserializer).getNullValue(ctxt)
+                }
             }
 
             val isGenericTypeVar = paramDef.type.javaType is TypeVariable<*>

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github87.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github87.kt
@@ -1,0 +1,17 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TestGithub87 {
+    data class DataClassWithDefaults(val bar: String = "default", val baz: String = "default")
+
+    @Test
+    fun testCompanionObjectCreatorWithDefaultParameters() {
+        assertEquals(DataClassWithDefaults("default", "bazValue"),
+            jacksonObjectMapper().readValue("""{"baz": "bazValue", "bar":null}"""))
+    }
+
+}


### PR DESCRIPTION
When using default values in combination with non nullable parameters, users expect the default value to be taken, even if the serialized value is 'null'.
This allows users to remove any fallack logic they currently need to have, which can be

1. dedicated JsonCreator
2. passing nullToEmptyCollection or nullToEmptyMap in KotlinModule (only covers some of the cases)
3. using ?: after unmarshall 