### PR TITLE
"Fix Github #176 - Android < API 24 support", resubmission of #197 to 2.10 branch

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -57,8 +57,10 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
         return byAnnotation
     }
 
-    private fun Method.isRequiredByAnnotation(): Boolean? =
-        getAnnotationsByType(JsonProperty::class.java)?.firstOrNull()?.required
+    private fun Method.isRequiredByAnnotation(): Boolean? = annotations
+        ?.firstOrNull { it.annotationClass == JsonProperty::class }
+        ?.let { it as JsonProperty }
+        ?.required
 
     private fun AnnotatedMethod.hasRequiredMarker(): Boolean? {
         // This could be a setter or a getter of a class property or

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -3,11 +3,7 @@ package com.fasterxml.jackson.module.kotlin
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.Module
-import com.fasterxml.jackson.databind.introspect.AnnotatedField
-import com.fasterxml.jackson.databind.introspect.AnnotatedMember
-import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
-import com.fasterxml.jackson.databind.introspect.AnnotatedParameter
-import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
+import com.fasterxml.jackson.databind.introspect.*
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.lang.reflect.Method
@@ -42,7 +38,10 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
         }
 
     private fun AnnotatedField.hasRequiredMarker(): Boolean? {
-        val byAnnotation = (member as Field).getAnnotationsByType(JsonProperty::class.java).firstOrNull()?.required
+        val byAnnotation = (member as Field).annotations
+            .firstOrNull { it.annotationClass == JsonProperty::class }
+            ?.let { it as JsonProperty }
+            ?.required
         val byNullability =  (member as Field).kotlinProperty?.returnType?.isRequired()
 
         return requiredAnnotationOrNullability(byAnnotation, byNullability)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.Module
 import com.fasterxml.jackson.databind.introspect.*
+import java.lang.reflect.AccessibleObject
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.lang.reflect.Method
@@ -38,10 +39,7 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
         }
 
     private fun AnnotatedField.hasRequiredMarker(): Boolean? {
-        val byAnnotation = (member as Field).annotations
-            .firstOrNull { it.annotationClass == JsonProperty::class }
-            ?.let { it as JsonProperty }
-            ?.required
+        val byAnnotation = (member as Field).isRequiredByAnnotation()
         val byNullability =  (member as Field).kotlinProperty?.returnType?.isRequired()
 
         return requiredAnnotationOrNullability(byAnnotation, byNullability)
@@ -56,7 +54,7 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
         return byAnnotation
     }
 
-    private fun Method.isRequiredByAnnotation(): Boolean? = annotations
+    private fun AccessibleObject.isRequiredByAnnotation(): Boolean? = annotations
         ?.firstOrNull { it.annotationClass == JsonProperty::class }
         ?.let { it as JsonProperty }
         ?.required


### PR DESCRIPTION
In #197 @cowtowncoder [said](https://github.com/FasterXML/jackson-module-kotlin/pull/197#issuecomment-497510221):
> Anything merged to master will only go in 3.0, so PR perhaps should be targeted to 2.10 branch.

The author of #197 didn't do it yet, so I'm doing it in this PR (to fix #176)
