### PR TITLE
Deserialization of kotlin singleton as singletons

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinBeanDeserializerModifier.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinBeanDeserializerModifier.kt
@@ -1,0 +1,26 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.databind.BeanDescription
+import com.fasterxml.jackson.databind.DeserializationConfig
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
+
+object KotlinBeanDeserializerModifier: BeanDeserializerModifier() {
+    override fun modifyDeserializer(
+            config: DeserializationConfig,
+            beanDesc: BeanDescription,
+            deserializer: JsonDeserializer<*>
+    ) = super.modifyDeserializer(config, beanDesc, deserializer)
+            .maybeSingletonDeserializer(objectSingletonInstance(beanDesc.beanClass))
+}
+
+fun JsonDeserializer<*>.maybeSingletonDeserializer(singleton: Any?) = when (singleton) {
+    null -> this
+    else -> this.asSingletonDeserializer(singleton)
+}
+
+private fun objectSingletonInstance(beanClass: Class<*>): Any? = if (!beanClass.isKotlinClass()) {
+    null
+} else {
+    beanClass.kotlin.objectInstance
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -43,6 +43,8 @@ class KotlinModule(val reflectionCacheSize: Int = 512, val nullToEmptyCollection
 
         context.addValueInstantiators(KotlinInstantiators(cache, nullToEmptyCollection, nullToEmptyMap))
 
+        context.addBeanDeserializerModifier(KotlinBeanDeserializerModifier)
+
         fun addMixIn(clazz: Class<*>, mixin: Class<*>) {
             context.setMixInAnnotations(clazz, mixin)
         }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinObjectSingletonDeserializer.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinObjectSingletonDeserializer.kt
@@ -1,0 +1,42 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.BeanProperty
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer
+
+internal fun JsonDeserializer<*>.asSingletonDeserializer(singleton: Any) =
+        KotlinObjectSingletonDeserializer(singleton, this)
+
+/** deserialize as normal, but return the canonical singleton instance. */
+internal class KotlinObjectSingletonDeserializer(
+        private val singletonInstance: Any,
+        private val defaultDeserializer: JsonDeserializer<*>
+) : JsonDeserializer<Any>(),
+        // Additional interfaces of a specific 'JsonDeserializer' must be supported
+        // Kotlin objectInstances are currently handled by a BeanSerializer which
+        // implements 'ContextualDeserializer' and 'ResolvableDeserializer'.
+        ContextualDeserializer,
+        ResolvableDeserializer {
+
+    override fun resolve(ctxt: DeserializationContext?) {
+        if (defaultDeserializer is ResolvableDeserializer) {
+            defaultDeserializer.resolve(ctxt)
+        }
+    }
+
+    override fun createContextual(ctxt: DeserializationContext?, property: BeanProperty?): JsonDeserializer<*> =
+            if (defaultDeserializer is ContextualDeserializer) {
+                defaultDeserializer.createContextual(ctxt, property)
+                        .asSingletonDeserializer(singletonInstance)
+            } else {
+                this
+            }
+
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Any {
+        defaultDeserializer.deserialize(p, ctxt)
+        return singletonInstance
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectSingletonTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectSingletonTest.kt
@@ -1,0 +1,59 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class ObjectSingletonTest {
+
+    val mapper: ObjectMapper = jacksonObjectMapper()
+            .configure(SerializationFeature.INDENT_OUTPUT, false)
+
+    object Singleton {
+        var content = 1 // mutable state
+    }
+
+    @Test
+    fun deserializationPreservesSingletonProperty() {
+        val js = mapper.writeValueAsString(Singleton)
+        val newSingleton = mapper.readValue<Singleton>(js)
+
+        // NOTE: currently not the expected behaviour!
+        // NOTE: kotlin singleton property is not preserved
+        assertThat(newSingleton, not(equalTo(Singleton)))
+    }
+
+    @Test
+    fun deserializationResetsSingletonObjectState() {
+        // persist current singleton state
+        val js = mapper.writeValueAsString(Singleton)
+        val initial = Singleton.content
+
+        // mutate the in-memory singleton state
+        val after = initial + 1
+        Singleton.content = after
+        assertThat(Singleton.content, equalTo(after))
+
+        // read back persisted state resets singleton state
+        val newSingleton = mapper.readValue<Singleton>(js)
+        assertThat(newSingleton.content, equalTo(initial))
+        assertThat(Singleton.content, equalTo(initial))
+    }
+
+    @Test
+    fun deserializedObjectsBehaveLikeSingletons() {
+        val js = mapper.writeValueAsString(Singleton)
+        val newSingleton = mapper.readValue<Singleton>(js)
+        assertThat(newSingleton.content, equalTo(Singleton.content))
+
+        newSingleton.content += 1;
+
+        assertThat(Singleton.content, equalTo(newSingleton.content))
+    }
+
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectSingletonTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectSingletonTest.kt
@@ -23,9 +23,7 @@ class ObjectSingletonTest {
         val js = mapper.writeValueAsString(Singleton)
         val newSingleton = mapper.readValue<Singleton>(js)
 
-        // NOTE: currently not the expected behaviour!
-        // NOTE: kotlin singleton property is not preserved
-        assertThat(newSingleton, not(equalTo(Singleton)))
+        assertThat(newSingleton, equalTo(Singleton))
     }
 
     @Test


### PR DESCRIPTION
Currently, serializing a kotlin 'object' instance and deserializing it again yields a new instance, while it is supposed to be a singleton instance in kotlin. This pull request resolves this problem by deserializing the instance (using the deserializer as before this commit), but returning the "canonical" singleton instance (rather than the newly created one).

I hope this PR gets a chance to be merged since using Sealed Case Classes are extremely valueable. As this PR reuses the original deserializer I think that the deserialization behaviour is unchanged except for the fact that singletons remain singleton. 

The topic has already been discussed in #225 and PR #215. As far as I understand, the open discussion was how to handle singleton objects with internal mutable state. PR #215 completely ignored the internal state and only returned the singleton object. In contrast, this PR does also deserialize the internal state, but returns the "canonical" singleton instance rather than a new instance. 

The PR includes two commit, the first one only includes test to assert the current behaviour, while the second commit ensures that the singleton property is preserved. The first commit shows, that deserialization creates a new instance (`deserializationPreservesSingletonProperty`). However, it also shows that the deserialized (new) instance is actually coupled to the actual singleton and the two instance behave like one (`deserializedObjectsBehaveLikeSingletons`). I'm not sure why exactly this is the case, but probably due to how kotlin defines accessor functions.

The second commit uses a BeanDeserializerModifier to get the desired singleton property. As a result, the canonical singleton is returned (change in `deserializationPreservesSingletonProperty`)
while the other tests remain unchanged. That means, the effects of deserialization on mutable members of an objects are the same as before this PR.

The open disussion in #225 and PR #215 were about whether the state should be handled or not, and if so how. For my purposes (Sealed Case Classes), the solution in PR #215 would have been good enough as that does not involve mutable state. For some reasons, PR #215 did not get merged, however. This PR provides a solution that does not change the previous behaviour with respect to handling internal mutable state.



