### PR TITLE
Fix issue #176 - Remove Java 8 method not compatible with Android API < 24

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -59,11 +59,16 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
     }
 
     private fun AnnotatedField.hasRequiredMarker(): Boolean? {
-        val byAnnotation = (member as Field).getAnnotationsByType(JsonProperty::class.java).firstOrNull()?.required
+        val byAnnotation = (member as Field).isRequiredByAnnotation()
         val byNullability =  (member as Field).kotlinProperty?.returnType?.isRequired()
 
         return requiredAnnotationOrNullability(byAnnotation, byNullability)
     }
+
+    private fun AccessibleObject.isRequiredByAnnotation(): Boolean? = annotations
+        ?.firstOrNull { it.annotationClass == JsonProperty::class }
+        ?.let { it as JsonProperty }
+        ?.required
 
     private fun requiredAnnotationOrNullability(byAnnotation: Boolean?, byNullability: Boolean?): Boolean? {
         if (byAnnotation != null && byNullability != null) {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.Module
 import com.fasterxml.jackson.databind.introspect.*
 import com.fasterxml.jackson.databind.jsontype.NamedType
+import java.lang.reflect.AccessibleObject
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.lang.reflect.Method


### PR DESCRIPTION
Resubmission of PRs #197 and #230 

Java 8 method getAnnotationsByType is available only on Android API 24 and above.
Android projects are stuck to version 2.9.6 before this method was introduced.

https://developer.android.com/studio/write/java8-support

Credits go to previous authors that submitted this fix but wasn't accepted so far. Please accept it for next maintenance revision.