### PR TITLE
Fix null to empty mapping for enum sets

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.lang.reflect.TypeVariable
+import java.util.EnumSet
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.*
 import kotlin.reflect.jvm.isAccessible
@@ -102,7 +103,10 @@ internal class KotlinValueInstantiator(
             }
 
             if (paramVal == null && ((nullToEmptyCollection && jsonProp.type.isCollectionLikeType) || (nullToEmptyMap && jsonProp.type.isMapLikeType))) {
-                paramVal = NullsAsEmptyProvider(jsonProp.valueDeserializer).getNullValue(ctxt)
+                paramVal = when {
+                    jsonProp.type.isTypeOrSubTypeOf(EnumSet::class.java) -> EnumSet.noneOf(EmptyEnum::class.java)
+                    else -> NullsAsEmptyProvider(jsonProp.valueDeserializer).getNullValue(ctxt)
+                }
             }
 
             val isGenericTypeVar = paramDef.type.javaType is TypeVariable<*>
@@ -153,6 +157,8 @@ internal class KotlinValueInstantiator(
             else -> false
         }
     }
+
+    private enum class EmptyEnum
 
     private fun SettableBeanProperty.hasInjectableValueId(): Boolean = injectableValueId != null
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyCollectionTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyCollectionTest.kt
@@ -3,16 +3,21 @@ package com.fasterxml.jackson.module.kotlin.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.junit.Test
+import java.util.EnumSet
 import kotlin.test.assertEquals
 
 class NullToEmptyCollectionTest {
 
     private data class TestClass(val foo: List<Int>)
 
+    private data class TestClassWithEnumSet(val foo: EnumSet<TestEnum>)
+
+    private enum class TestEnum { Foo, Bar }
+
     @Test
     fun nonNullCaseStillWorks() {
         val mapper = createMapper()
-        assertEquals(listOf(1,2), mapper.readValue("""{"foo": [1,2]}""", TestClass::class.java).foo)
+        assertEquals(listOf(1, 2), mapper.readValue("""{"foo": [1,2]}""", TestClass::class.java).foo)
     }
 
     @Test
@@ -21,6 +26,13 @@ class NullToEmptyCollectionTest {
         assertEquals(emptyList(), mapper.readValue("{}", TestClass::class.java).foo)
         assertEquals(emptyList(), mapper.readValue("""{"foo": null}""", TestClass::class.java).foo)
 
+    }
+
+    @Test
+    fun shouldMapNullValuesToEmptyEnumSet() {
+        val mapper = createMapper()
+        assertEquals(EnumSet.noneOf(TestEnum::class.java), mapper.readValue("{}", TestClassWithEnumSet::class.java).foo)
+        assertEquals(EnumSet.noneOf(TestEnum::class.java), mapper.readValue("""{"foo": null}""", TestClassWithEnumSet::class.java).foo)
     }
 
     private fun createMapper(): ObjectMapper {


### PR DESCRIPTION
The ideal fix here would probably be in jackson core and specifically that NullsAsEmptyProvider works with EnumSet, but it currently does not, so this is a workaround that solves the problem for now.