### PR TITLE
Make sure we are running all tests during build

### DIFF
--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github124.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github124.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Ignore
 import org.junit.Test
 
-internal class Github124 {
+internal class TestGithub124 {
     // test for [module-kotlin#124]: broken in 2.9.3, fixed in 2.9.6
     @Test
     fun test() {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github46.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github46.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertEquals
 
-class Github46 {
+class TestGithub46 {
     @Test fun `map 32 properties`() {
         // given
         val json = """{"prop1":true,"prop2":true,"prop3":true,"prop4":true,"prop5":true,"prop6":true,"prop7":true,"prop8":true,"prop9":true,"prop10":true,"prop11":true,"prop12":true,"prop13":true,"prop14":true,"prop15":true,"prop16":true,"prop17":true,"prop18":true,"prop19":true,"prop20":true,"prop21":true,"prop22":true,"prop23":true,"prop24":true,"prop25":true,"prop26":true,"prop27":true,"prop28":true,"prop29":true,"prop30":true,"prop31":true,"prop32":true}"""

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github47.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github47.kt
@@ -6,7 +6,7 @@ import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
 
-class Github47 {
+class TestGithub47 {
 
     class ConfigItem(val configItemId: String)
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github50.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github50.kt
@@ -7,7 +7,7 @@ import org.junit.Ignore
 import org.junit.Test
 
 
-class Github50 {
+class TestGithub50 {
     data class Name(val firstName: String, val lastName: String)
 
     data class Employee(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github52.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github52.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
 
 
 @Ignore("As expected, need change to annotations targetting to have better default targets for Kotlin")
-class Github52 {
+class TestGithub52 {
     class Test(
         // This gets serialized as "is_lol", as expected. No issues here.
         @JsonProperty("is_lol")

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github54.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github54.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.*
 import org.junit.Ignore
 import org.junit.Test
 
-class Github54 {
+class TestGithub54 {
     @Ignore("TODO: Fix this, Github #54")
     @Test
     fun testDeserWithIdentityInfo() {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github56.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github56.kt
@@ -37,7 +37,7 @@ private data class TestImage(
         val crops: Map<String, String>? = null
 )
 
-class Github56 {
+class TestGithub56 {
     lateinit var mapper: ObjectMapper
 
     private val gallery = TestGallery(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github57.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github57.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 
 private data class Github57Data(val map: Map<Pair<String, String>, String>)
 
-class Github57 {
+class TestGithub57 {
     @Test
     fun testProblemsWithMaps() {
         val mapper = jacksonObjectMapper().registerModule(KotlinPairKeySerializerModule())

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github62.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github62.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.Test
 import kotlin.test.assertEquals
 
-class Github62 {
+class TestGithub62 {
     @Test
     fun testAnonymousClassSerialization() {
         val externalValue = "ggg"

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github80.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github80.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.Test
 import kotlin.test.assertEquals
 
-class Github80 {
+class TestGithub80 {
 
     @Test
     fun testIsBool() {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/GithubDatabind1328.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/GithubDatabind1328.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class GithubDatabind1328 {
+class TestGithubDatabind1328 {
     @Test
     fun testPolymorphicWithEnum() {
         val mapper = jacksonObjectMapper()

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefault.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefault.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 import org.junit.internal.runners.statements.ExpectException
 
 // @Ignore("not yet implemented, under discussion")
-class NullToDefault {
+class NullToDefaultTest {
 
 	private fun createMapper(allowDefaultingByNull: Boolean) = ObjectMapper().registerModule(KotlinModule(nullisSameAsDefault = allowDefaultingByNull))
 


### PR DESCRIPTION
In order for maven to pick up the tests, there needs to be "test" somewhere in the class name. This PR fixes up all missing instances.