### PR TITLE
Fix ABI compatibility of KotlinModule constructor

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -10,7 +10,20 @@ fun Class<*>.isKotlinClass(): Boolean {
     return declaredAnnotations.any { it.annotationClass.java.name == metadataFqName }
 }
 
-class KotlinModule @JvmOverloads constructor (val reflectionCacheSize: Int = 512, val nullToEmptyCollection: Boolean = false, val nullToEmptyMap: Boolean = false, val nullisSameAsDefault: Boolean = false) : SimpleModule(PackageVersion.VERSION) {
+class KotlinModule constructor (
+    val reflectionCacheSize: Int = 512,
+    val nullToEmptyCollection: Boolean = false,
+    val nullToEmptyMap: Boolean = false,
+    val nullisSameAsDefault: Boolean = false
+) : SimpleModule(PackageVersion.VERSION) {
+
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "For ABI compatibility")
+    constructor(
+        reflectionCacheSize: Int = 512,
+        nullToEmptyCollection: Boolean = false,
+        nullToEmptyMap: Boolean = false
+    ) : this(reflectionCacheSize, nullToEmptyCollection, nullToEmptyMap, false)
+
     companion object {
         const val serialVersionUID = 1L
     }


### PR DESCRIPTION
This PR adds a hidden constructor to `KotlinModule` with an old signature (before 45676cee263403ff0497d27ec1df94d783393778).
`@JvmOverloads` is removed, because it generates an overload that clashes with the new (old) constructor. Anyway, it is useless outside Java code.
Fixes #279.