### PR TITLE
Updated Kotlin version from 1.3.10 to 1.3.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <version.junit>4.12</version.junit>
-        <version.kotlin>1.3.10</version.kotlin>
+        <version.kotlin>1.3.30</version.kotlin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
Hi,

Thanks for this open-source project.

I have updated kotlin version from 1.3.10 to 1.3.30 since Kotlin plugin version before 1.3.30 is affected by CVE-2019-10101, CVE-2019-10102, and CVE-2019-10103.

Regards,
Manjunath