### PR TITLE
Fix KotlinModule constructor ABI

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -26,6 +26,14 @@ class KotlinModule constructor (
         nullToEmptyMap: Boolean = false
     ) : this(reflectionCacheSize, nullToEmptyCollection, nullToEmptyMap, false)
 
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "For ABI compatibility")
+    constructor(
+        reflectionCacheSize: Int = 512,
+        nullToEmptyCollection: Boolean = false,
+        nullToEmptyMap: Boolean = false,
+        nullIsSameAsDefault: Boolean = false
+    ) : this(reflectionCacheSize, nullToEmptyCollection, nullToEmptyMap, nullIsSameAsDefault)
+
     private constructor(builder: Builder) : this(
         builder.reflectionCacheSize,
         builder.nullToEmptyCollection,


### PR DESCRIPTION
Jackson Kotlin module 2.11.0 seems to be binary incompatible with the libraries compiled against 2.10.x. When trying to start an application that has a libraries compiled with Jackson 2.10.x, with Jackson 2.11 on the classpath I get an error
```
The following method did not exist:

    'void com.fasterxml.jackson.module.kotlin.KotlinModule.<init>(int, boolean, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker)'

The method's class, com.fasterxml.jackson.module.kotlin.KotlinModule, is available from the following locations:

    jar:file:/app/application.jar!/BOOT-INF/lib/jackson-module-kotlin-2.11.0.jar!/com/fasterxml/jackson/module/kotlin/KotlinModule.class

It was loaded from the following location:

    jar:file:/app/application.jar!/BOOT-INF/lib/jackson-module-kotlin-2.11.0.jar!/


Action:

Correct the classpath of your application so that it contains a single, compatible version of com.fasterxml.jackson.module.kotlin.KotlinModule
```

Looks like commit 1f5c9fe added a new parameter to the `KotlinModule` constructor and that broke its ABI.

This PR adds a new `@Dreprecated` invisible constructor to match the constructor signature before the 1f5c9fe change, similarly to cc43e14.
