### PR TITLE
Mangle constructor parameter names to preserve read-after-write

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -30,7 +30,8 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
     // since 2.4
     override fun findImplicitPropertyName(member: AnnotatedMember): String? {
         if (member is AnnotatedParameter) {
-            return findKotlinParameterName(member)
+            val simpleName = findKotlinParameterName(member)
+            return if (simpleName == null) null else BeanUtil.stdManglePropertyName(simpleName, 0)
         }
         return null
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
@@ -163,6 +163,20 @@ class TestJacksonWithKotlin {
 
     // ==================
 
+    private data class NonIdiomaticPascalCasedClass(val Some_Number: Int, val Email_Address: String)
+
+    @Test fun readAfterWriteWithPascalCaseProperties() {
+        val obj = NonIdiomaticPascalCasedClass(6, "nobody@test.com")
+
+        val serialized = normalCasedMapper.writeValueAsString(obj)
+        val deserialized = normalCasedMapper.readValue<NonIdiomaticPascalCasedClass>(serialized)
+
+        assertThat(deserialized, equalTo(obj))
+    }
+
+
+    // ==================
+
     private class StateObjectWithFactory private constructor (override val name: String, override val age: Int, override val primaryAddress: String, override val wrongName: Boolean, override val createdDt: Date) : TestFields {
         var factoryUsed: Boolean = false
         companion object {


### PR DESCRIPTION
NOTE: This is a backport of pull request #350 to the 2.12 line.

Jackson with the Kotlin module does not choose the same json field names for both reading and writing if you have a data class with PascalCase field names, unless you go through a bunch of pain with @JsonProperty annotations. Not being able to read after write seems like a bug, so I fixed it.

Context: I'm working with a code generator that makes data classes based on DB schema. Because {reasons}, this makes classes with PascalCase field names, and it's not viable to change that to be more idiomatic for Kotlin.