### PR TITLE
Replace 'compile' keyword with 'implementation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Releases require that you have included Kotlin stdlib and reflect libraries alre
 
 Gradle:
 ```
-compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+"
+implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.11.+"
 ```
 
 Maven:

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -12,6 +12,9 @@ Authors:
 
 Contributors:
 
+Hideaki Tanabe (tanabe@github)
+* Brought README.md into the modern world of Gradle (compile -> implementation)
+
 Stéphane B (StephaneBg@github)
 * Submitted fix for #176: Version 2.9.7 breaks compatibility with Android minSdk < 24
  (2.10.1)


### PR DESCRIPTION
Hello.
Gradle's `compile` keyword have been deprecated.

* https://docs.gradle.org/current/userguide/java_plugin.html
