### PR TITLE
Issue 368: serialize Sequence as Iterable

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -8,8 +8,14 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer
 
 object SequenceSerializer : StdSerializer<Sequence<*>>(Sequence::class.java) {
     override fun serialize(value: Sequence<*>, gen: JsonGenerator, provider: SerializerProvider) {
-        val materializedList = value.toList()
-        provider.writeValue(gen, materializedList)
+        provider.findTypedValueSerializer(
+            Iterable::class.java,
+            true
+        ).serialize(
+            value.asIterable(),
+            gen,
+            provider
+        )
     }
 }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SequenceSerdesTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SequenceSerdesTests.kt
@@ -7,13 +7,13 @@ import kotlin.test.assertEquals
 
 
 class TestSequenceDeserializer {
-    data class Data(val value: Sequence<String>)
+    data class Data<T>(val value: Sequence<T>)
 
     @Test
     fun deserializeSequence() {
         val list = listOf("Test", "Test1")
         val objectMapper = jacksonObjectMapper()
-        val result = objectMapper.readValue<Data>("{\"value\":[\"Test\",\"Test1\"]}")
+        val result = objectMapper.readValue<Data<String>>("{\"value\":[\"Test\",\"Test1\"]}")
         assertEquals(list, result.value.toList())
     }
 
@@ -21,7 +21,7 @@ class TestSequenceDeserializer {
     fun deserializeEmptySequence() {
         val list = listOf<String>()
         val objectMapper = jacksonObjectMapper()
-        val result = objectMapper.readValue<Data>("{\"value\":[]}")
+        val result = objectMapper.readValue<Data<String>>("{\"value\":[]}")
         assertEquals(list, result.value.toList())
     }
 
@@ -41,5 +41,37 @@ class TestSequenceDeserializer {
         val objectMapper =  jacksonObjectMapper()
         val result = objectMapper.writeValueAsString(data)
         assertEquals("{\"value\":[]}", result)
+    }
+
+    @Test
+    fun testSerializeLazySequence() {
+        val sequence = sequence<Map<String, Any>> {
+            (0..2).forEach { i ->
+                yieldAll((0..2).map { j ->
+                    mapOf("key[$i][$j]" to "value[$i][$j]")
+                })
+            }
+        }
+        val data = Data(sequence)
+        val objectMapper =  jacksonObjectMapper()
+        val result = objectMapper.writeValueAsString(data)
+        assertEquals(
+            """
+                {
+                    "value":[
+                        {"key[0][0]": "value[0][0]"},
+                        {"key[0][1]": "value[0][1]"},
+                        {"key[0][2]": "value[0][2]"},
+                        {"key[1][0]": "value[1][0]"},
+                        {"key[1][1]": "value[1][1]"},
+                        {"key[1][2]": "value[1][2]"},
+                        {"key[2][0]": "value[2][0]"},
+                        {"key[2][1]": "value[2][1]"},
+                        {"key[2][2]": "value[2][2]"}
+                    ]
+                }
+            """.replace("\\s".toRegex(), ""),
+            result
+        )
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.kotlin.test
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -12,7 +12,7 @@ import kotlin.test.assertNull
 
 
 class StrictNullChecksTest {
-    private val mapper = ObjectMapper().registerModule(KotlinModule(strictNullChecks = true))
+    private val mapper = JsonMapper.builder().addModule((KotlinModule(strictNullChecks = true))).build()
 
     /** collection tests */
 


### PR DESCRIPTION
Translating the `Sequence` into an `Iterable` and using the `IterableSerializer`. This will:
* Include handling for `WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED`
* Iterate over the elements in the `Sequence` and serialize them one by one

As explained on [Issue 368](https://github.com/FasterXML/jackson-module-kotlin/issues/368), if `WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED` is enabled the first value of the `Sequence` will be retrieve twice, which means the `Sequence` will have to _produce_ the first element twice. 