### PR TITLE
Add Kotlin DSL for constructing JsonMapper and KotlinModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ or with the extension functions imported from `import com.fasterxml.jackson.modu
 val mapper = jacksonObjectMapper()
 ```
 
+```kotlin	
+val mapper = ObjectMapper().registerKotlinModule()	
+```	
+
 A simple data class example:
 ```kotlin
 import com.fasterxml.jackson.module.kotlin.*

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ or with the extension functions imported from `import com.fasterxml.jackson.modu
 val mapper = jacksonObjectMapper()
 ```
 
-```kotlin	
+```kotlin
 val mapper = ObjectMapper().registerKotlinModule()	
-```	
+```
 
 A simple data class example:
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ val mapper = jacksonObjectMapper()
 ```
 
 ```kotlin
-val mapper = ObjectMapper().registerKotlinModule()	
+val mapper = ObjectMapper().registerKotlinModule()
 ```
 
 A simple data class example:

--- a/README.md
+++ b/README.md
@@ -38,16 +38,19 @@ To use, just register the Kotlin module with your ObjectMapper instance:
 
 ```kotlin
 val mapper = ObjectMapper().registerModule(KotlinModule())
+// or with 2.10 and later
+val mapper = JsonMapper.builder().addModule(KotlinModule()).build()
+// or with 2.12 and later
+val mapper = jsonMapper {
+  addModule(kotlinModule())
+}
+
 ```
 
 or with the extension functions imported from `import com.fasterxml.jackson.module.kotlin.*`, one of:
 
 ```kotlin
 val mapper = jacksonObjectMapper()
-```
-
-```kotlin
-val mapper = ObjectMapper().registerKotlinModule()
 ```
 
 A simple data class example:
@@ -110,6 +113,13 @@ The Kotlin module may be given a few configuration parameters at construction ti
 val mapper = JsonMapper.builder()
         .addModule(KotlinModule(strictNullChecks = true))
         .build()
+
+// Or, from version 2.12
+val mapper = jsonMapper {
+    addModule(kotlinModule {
+        strictNullChecks(true)
+    })
+}
 ```
 
 If your `ObjectMapper` is constructed in Java, there is a builder method provided for configuring these options:

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -10,14 +10,29 @@ import com.fasterxml.jackson.databind.ObjectReader
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.json.JsonMapper
 import java.io.File
 import java.io.InputStream
 import java.io.Reader
 import java.net.URL
 import kotlin.reflect.KClass
 
-fun jacksonObjectMapper(): ObjectMapper = ObjectMapper().registerKotlinModule()
-fun ObjectMapper.registerKotlinModule(): ObjectMapper = this.registerModule(KotlinModule())
+fun kotlinModule(initializer: KotlinModule.Builder.() -> Unit = {}): KotlinModule {
+    val builder = KotlinModule.Builder()
+    builder.initializer()
+    return builder.build()
+}
+
+fun jsonMapper(initializer: JsonMapper.Builder.() -> Unit = {}): JsonMapper {
+    val builder = JsonMapper.builder()
+    builder.initializer()
+    return builder.build()
+}
+
+fun jacksonObjectMapper(): ObjectMapper = jsonMapper { addModule(kotlinModule()) }
+fun jacksonMapperBuilder(): JsonMapper.Builder = JsonMapper.builder().addModule(kotlinModule())
+
+fun ObjectMapper.registerKotlinModule(): ObjectMapper = this.registerModule(kotlinModule())
 
 inline fun <reified T> jacksonTypeRef(): TypeReference<T> = object: TypeReference<T>() {}
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
@@ -1,0 +1,76 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.core.json.JsonReadFeature
+import com.fasterxml.jackson.core.json.JsonWriteFeature
+import com.fasterxml.jackson.module.kotlin.SingletonSupport.CANONICALIZE
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DslTest {
+
+    @Test
+    fun createModuleWithoutUsingInitializer() {
+        val module = kotlinModule()
+        assertNotNull(module)
+    }
+
+    @Test
+    fun createModuleWithEmptyInitializer() {
+        val module = kotlinModule {}
+        assertNotNull(module)
+    }
+
+    @Test
+    fun createModuleWithBuilderOptions() {
+        val module = kotlinModule {
+            reflectionCacheSize(123)
+            nullToEmptyCollection(true)
+            nullToEmptyMap(true)
+            nullIsSameAsDefault(true)
+            singletonSupport(CANONICALIZE)
+            strictNullChecks(true)
+        }
+
+        assertNotNull(module)
+        assertEquals(module.reflectionCacheSize, 123)
+        assertTrue(module.nullToEmptyCollection)
+        assertTrue(module.nullToEmptyMap)
+        assertTrue(module.nullIsSameAsDefault)
+        assertEquals(module.singletonSupport, CANONICALIZE)
+        assertTrue(module.strictNullChecks)
+    }
+
+    @Test
+    fun createJsonMapperWithoutUsingInitializer() {
+        val mapper = jsonMapper()
+        assertNotNull(mapper)
+    }
+
+    @Test
+    fun creatJsonMappereWithEmptyInitializer() {
+        val mapper = jsonMapper {}
+        assertNotNull(mapper)
+    }
+
+    @Test
+    fun creatJsonMappereWithBuilderOptions() {
+        val mapper = jsonMapper {
+            enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+            disable(JsonWriteFeature.QUOTE_FIELD_NAMES)
+            configure(JsonReadFeature.ALLOW_SINGLE_QUOTES, true)
+
+            addModule(kotlinModule {
+                nullIsSameAsDefault(true)
+            })
+        }
+
+        assertNotNull(mapper)
+        assertTrue(mapper.isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS))
+        assertFalse(mapper.isEnabled(JsonWriteFeature.QUOTE_FIELD_NAMES))
+        assertTrue(mapper.isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES))
+        assertTrue(mapper.registeredModuleIds.any { it == "com.fasterxml.jackson.module.kotlin.KotlinModule" })
+    }
+}


### PR DESCRIPTION
Rebased version of #379 

This enables a Kotlin DSL that allows constructing an ObjectMapper quickly, or configuring it using a function on the *.Builder classes.

In my opinion this is more idiomatic Kotlin than using the *.Builder classes directly.

Documentation has also been added.