### PR TITLE
Fix #385: add module-info.class using Moditect plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,13 @@
                     <optimize>true</optimize>
                 </configuration>
             </plugin>
+
+	    <!-- 02-Nov-2020, tatu: Add JDK9+ module info with Moditect -->
+	    <plugin>
+                <groupId>org.moditect</groupId>
+		<artifactId>moditect-maven-plugin</artifactId>
+	    </plugin>
+
             <!-- 05-Jul-2020, tatu: Add generation of Gradle Module Metadata -->
             <plugin>
                   <groupId>de.jjohannes</groupId>

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,0 +1,13 @@
+// Manually created 02-Nov-2020 for
+//   https://github.com/FasterXML/jackson-module-kotlin/issues/385
+module com.fasterxml.jackson.kotlin {
+    requires java.base;
+    requires java.desktop;
+    requires kotlin.stdlib;
+
+    requires com.fasterxml.jackson.annotations;
+    requires com.fasterxml.jackson.databind;
+
+    provides com.fasterxml.jackson.databind.Module with
+        com.fasterxml.jackson.module.kotlin.KotlinModule;
+}


### PR DESCRIPTION
As per title, this is for #385, add generation of `module-info.class` using Moditect plugin, same as almost every other Jackson module.
