### PR TITLE
Always run failing tests, but make them pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If you are going to write code, choose the appropriate base branch:
 
 There are a number of tests for functionality that is broken, mostly in the [failing](https://github.com/FasterXML/jackson-module-kotlin/tree/master/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing)
 package but a few as part of other test suites.  Instead of ignoring these tests (with JUnit's `@Ignore` annotation)
-or excluding them from being run as part of automated testing, the tests are written so as to demonstrate the failure
+or excluding them from being run as part of automated testing, the tests are written to demonstrate the failure
 (either making a call that throws an exception or with an assertion that fails) but not fail the build, except if the
 underlying issue is fixed.  This allows us to know when the tested functionality has been incidentally fixed by
 unrelated code changes.

--- a/README.md
+++ b/README.md
@@ -205,3 +205,14 @@ If you are going to write code, choose the appropriate base branch:
 - `2.12` for bugfixes against the current stable version
 - `2.13` for additive functionality & features or [minor](https://semver.org), backwards compatible changes to existing behavior to be included in the next minor version release
 - `master` for significant changes to existing behavior, which will be part of Jackson 3.0
+
+### Failing tests
+
+There are a number of tests for functionality that is broken, mostly in the [failing](https://github.com/FasterXML/jackson-module-kotlin/tree/master/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing)
+package but a few as part of other test suites.  Instead of ignoring these tests (with JUnit's `@Ignore` annotation)
+or excluding them from being run as part of automated testing, the tests are written so as to demonstrate the failure
+(either making a call that throws an exception or with an assertion that fails) but not fail the build, except if the
+underlying issue is fixed.  This allows us to know when the tested functionality has been incidentally fixed by
+unrelated code changes.
+
+See the [failing tests readme](https://github.com/FasterXML/jackson-module-kotlin/tree/master/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/README.md) for more information.

--- a/pom.xml
+++ b/pom.xml
@@ -148,11 +148,6 @@
             <plugin>
 	      <groupId>org.apache.maven.plugins</groupId>
 	      <artifactId>maven-surefire-plugin</artifactId>
-	      <configuration>
-              <excludes>
-                  <exclude>com/fasterxml/jackson/**/failing/*</exclude>
-              </excludes>
-          </configuration>
 	    </plugin>
             <plugin>
                 <!-- Inherited from oss-base. Generate PackageVersion.java.-->

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/IteratorTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/IteratorTests.kt
@@ -5,43 +5,44 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Ignore
 import org.junit.Test
-
+import kotlin.test.assertEquals
 
 class TestIteratorSubclass {
     class TinyPerson(val name: String, val age: Int)
-    class KotlinPersonIterator(private val personList: List<TinyPerson>) : Iterator<TinyPerson> by personList.iterator() {}
+    class KotlinPersonIterator(private val personList: List<TinyPerson>) : Iterator<TinyPerson> by personList.iterator()
 
     val mapper: ObjectMapper = jacksonObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)
 
-
-    @Test fun testKotlinIterator() {
+    @Test
+    fun testKotlinIteratorWithTypeRef() {
         val expectedJson = """[{"name":"Fred","age":10},{"name":"Max","age":11}]"""
         val people = KotlinPersonIterator(listOf(TinyPerson("Fred", 10), TinyPerson("Max", 11)))
         val typeRef = object : TypeReference<Iterator<TinyPerson>>() {}
         val kotlinJson = mapper.writerFor(typeRef).writeValueAsString(people)
-        assertThat(kotlinJson, equalTo(expectedJson))
+        assertEquals(expectedJson, kotlinJson)
     }
 
-    @Ignore("Failing, but need change in Jackson to allow this to work.")
-    @Test fun testKotlinIteratorFails() {
+    @Test
+    fun testKotlinIterator() {
         val expectedJson = """[{"name":"Fred","age":10},{"name":"Max","age":11}]"""
         val people = KotlinPersonIterator(listOf(TinyPerson("Fred", 10), TinyPerson("Max", 11)))
         val kotlinJson = mapper.writeValueAsString(people)
-        assertThat(kotlinJson, equalTo(expectedJson))
+        assertEquals(expectedJson, kotlinJson)
     }
 
-    class Company(val name: String, @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") @JsonSerialize(`as` = java.util.Iterator::class) val people: KotlinPersonIterator)
+    class Company(
+            val name: String,
+            @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") @JsonSerialize(`as` = java.util.Iterator::class) val people: KotlinPersonIterator
+    )
 
-    @Test fun testKotlinIteratorAsField() {
+    @Test
+    fun testKotlinIteratorAsField() {
         val expectedJson = """{"name":"KidVille","people":[{"name":"Fred","age":10},{"name":"Max","age":11}]}"""
         val people = KotlinPersonIterator(listOf(TinyPerson("Fred", 10), TinyPerson("Max", 11)))
         val company = Company("KidVille", people)
         val kotlinJson = mapper.writeValueAsString(company)
-        assertThat(kotlinJson, equalTo(expectedJson))
+        assertEquals(expectedJson, kotlinJson)
     }
 
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpers.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpers.kt
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.module.kotlin.test
 
-import kotlin.reflect.KClass
 import kotlin.test.fail
 
 /**
@@ -13,18 +12,18 @@ import kotlin.test.fail
  * should make it clear what has happened (i.e. that some previously broken functionality
  * has been fixed).
  *
- * @param throwableType The expected throwable
+ * @param T             The expected throwable
  * @param fixMessage    The message to print when the block succeeds
  * @param block         The block to execute
  */
-fun <T : Throwable> expectFailure(
-        throwableType: KClass<T>,
+inline fun <reified T : Throwable> expectFailure(
         fixMessage: String,
         block: () -> Unit
 ) {
     try {
         block()
     } catch (e: Throwable) {
+        val throwableType = T::class
         if (throwableType.isInstance(e)) {
             // Expected exception, do nothing
         } else {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpers.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpers.kt
@@ -1,0 +1,38 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import kotlin.reflect.KClass
+import kotlin.test.fail
+
+/**
+ * Expect a block to throw an exception.  If a different type of exception is thrown or no
+ * exception is produced by the block, fail the test.  In the latter case, no exception being
+ * thrown, fixMessage is printed.
+ *
+ * This function is intended to allow failing tests to be written and run as part of the build
+ * without causing it to fail, except if the failure is fixed, in which case the fixMessage
+ * should make it clear what has happened (i.e. that some previously broken functionality
+ * has been fixed).
+ *
+ * @param throwableType The expected throwable
+ * @param fixMessage    The message to print when the block succeeds
+ * @param block         The block to execute
+ */
+fun <T : Throwable> expectFailure(
+        throwableType: KClass<T>,
+        fixMessage: String,
+        block: () -> Unit
+) {
+    try {
+        block()
+    } catch (e: Throwable) {
+        if (throwableType.isInstance(e)) {
+            // Expected exception, do nothing
+        } else {
+            fail("Expected $throwableType but got $e")
+        }
+
+        return
+    }
+
+    fail(fixMessage)
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpersTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpersTest.kt
@@ -1,0 +1,37 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TestHelpersTest {
+    @Test
+    fun expectFailure_ExpectedExceptionThrown() {
+        expectFailure(AssertionError::class, "This will not be printed") {
+            throw AssertionError("This is expected")
+        }
+    }
+
+    @Test
+    fun expectFailure_AnotherExceptionThrown() {
+        val throwable = assertThrows(AssertionError::class.java) {
+            expectFailure(AssertionError::class, "This will not be printed") {
+                throw Exception("This is not expected")
+            }
+        }
+
+        assertEquals("Expected class java.lang.AssertionError but got java.lang.Exception: This is not expected", throwable.message)
+    }
+
+    @Test
+    fun expectFailure_NoExceptionThrown() {
+        val fixMessage = "Test will fail with this message"
+        val throwable = assertThrows(AssertionError::class.java) {
+            expectFailure(AssertionError::class, fixMessage) {
+                // Do nothing
+            }
+        }
+
+        assertEquals(fixMessage, throwable.message)
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpersTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpersTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class TestHelpersTest {
     @Test
     fun expectFailure_ExpectedExceptionThrown() {
-        expectFailure(AssertionError::class, "This will not be printed") {
+        expectFailure<AssertionError>("This will not be printed") {
             throw AssertionError("This is expected")
         }
     }
@@ -15,7 +15,7 @@ class TestHelpersTest {
     @Test
     fun expectFailure_AnotherExceptionThrown() {
         val throwable = assertThrows(AssertionError::class.java) {
-            expectFailure(AssertionError::class, "This will not be printed") {
+            expectFailure<AssertionError>("This will not be printed") {
                 throw Exception("This is not expected")
             }
         }
@@ -27,7 +27,7 @@ class TestHelpersTest {
     fun expectFailure_NoExceptionThrown() {
         val fixMessage = "Test will fail with this message"
         val throwable = assertThrows(AssertionError::class.java) {
-            expectFailure(AssertionError::class, fixMessage) {
+            expectFailure<AssertionError>(fixMessage) {
                 // Do nothing
             }
         }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github138.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github138.kt
@@ -8,30 +8,26 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
-import kotlin.test.fail
 
 class TestGithub138 {
     @JacksonXmlRootElement(localName = "sms")
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class Sms(
-        @JacksonXmlProperty(localName = "Phone", isAttribute = true)
-        val phone: String?,
+            @JacksonXmlProperty(localName = "Phone", isAttribute = true)
+            val phone: String?,
 
-        @JacksonXmlText
-        val text: String? = ""
-
-        )
+            @JacksonXmlText
+            val text: String? = ""
+    )
 
     @Test
     fun testDeserProblem() {
         val xml = """<sms Phone="435242423412" Id="43234324">Lorem ipsum</sms>"""
         val xmlMapper = XmlMapper().registerKotlinModule()
-        try {
+        expectFailure(InvalidDefinitionException::class, "GitHub #138 has been fixed!") {
             val jsms = xmlMapper.readValue<Sms>(xml)
-            fail("GitHub #138 has been fixed!")
-        } catch (e: InvalidDefinitionException) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github138.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github138.kt
@@ -1,14 +1,15 @@
-package com.fasterxml.jackson.module.kotlin.test.github
+package com.fasterxml.jackson.module.kotlin.test.failing
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import org.junit.Ignore
 import org.junit.Test
+import kotlin.test.fail
 
 class TestGithub138 {
     @JacksonXmlRootElement(localName = "sms")
@@ -23,11 +24,14 @@ class TestGithub138 {
         )
 
     @Test
-    @Ignore("Not sure the cause of this yet...")
     fun testDeserProblem() {
         val xml = """<sms Phone="435242423412" Id="43234324">Lorem ipsum</sms>"""
         val xmlMapper = XmlMapper().registerKotlinModule()
-        val sms = xmlMapper.readValue<Sms>(xml)
-
+        try {
+            val jsms = xmlMapper.readValue<Sms>(xml)
+            fail("GitHub #138 has been fixed!")
+        } catch (e: InvalidDefinitionException) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github138.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github138.kt
@@ -26,7 +26,7 @@ class TestGithub138 {
     fun testDeserProblem() {
         val xml = """<sms Phone="435242423412" Id="43234324">Lorem ipsum</sms>"""
         val xmlMapper = XmlMapper().registerKotlinModule()
-        expectFailure(InvalidDefinitionException::class, "GitHub #138 has been fixed!") {
+        expectFailure<InvalidDefinitionException>("GitHub #138 has been fixed!") {
             val jsms = xmlMapper.readValue<Sms>(xml)
         }
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github160DisableAnnotations.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github160DisableAnnotations.kt
@@ -1,20 +1,23 @@
 package com.fasterxml.jackson.module.kotlin.test.failing
 
 import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Ignore
 import org.junit.Test
+import kotlin.test.fail
 
 class TestGithub160 {
     data class DataClass(val blah: String)
 
     @Test
-//    @Ignore("This error is caused by annotations being turned off, but in Jackson 2.x we cannot catch this uniformly across the board")
     fun dataClass() {
-        val j = jacksonObjectMapper().configure(
-            MapperFeature.USE_ANNOTATIONS, false
-        )!!
-        j.readValue<DataClass>(""" {"blah":"blah"}""")
+        val mapper = jacksonObjectMapper().configure(MapperFeature.USE_ANNOTATIONS, false)
+        try {
+            mapper.readValue<DataClass>("""{"blah":"blah"}""")
+            fail("GitHub #160 has been fixed!")
+        } catch (e: MismatchedInputException) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github160DisableAnnotations.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github160DisableAnnotations.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
-import kotlin.test.fail
 
 class TestGithub160 {
     data class DataClass(val blah: String)
@@ -13,11 +13,8 @@ class TestGithub160 {
     @Test
     fun dataClass() {
         val mapper = jacksonObjectMapper().configure(MapperFeature.USE_ANNOTATIONS, false)
-        try {
+        expectFailure(MismatchedInputException::class, "GitHub #160 has been fixed!") {
             mapper.readValue<DataClass>("""{"blah":"blah"}""")
-            fail("GitHub #160 has been fixed!")
-        } catch (e: MismatchedInputException) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github160DisableAnnotations.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github160DisableAnnotations.kt
@@ -13,7 +13,7 @@ class TestGithub160 {
     @Test
     fun dataClass() {
         val mapper = jacksonObjectMapper().configure(MapperFeature.USE_ANNOTATIONS, false)
-        expectFailure(MismatchedInputException::class, "GitHub #160 has been fixed!") {
+        expectFailure<MismatchedInputException>("GitHub #160 has been fixed!") {
             mapper.readValue<DataClass>("""{"blah":"blah"}""")
         }
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github271AlphaSortProperties.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github271AlphaSortProperties.kt
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.module.kotlin.test.failing
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.fail
 
 class TestGithub271 {
     @JsonPropertyOrder(alphabetic=true)
@@ -17,11 +17,8 @@ class TestGithub271 {
         val mapper = jacksonObjectMapper()
 
         val json = mapper.writeValueAsString(Foo("a", "c"))
-        try {
+        expectFailure(AssertionError::class, "GitHub #271 has been fixed!") {
             assertEquals("""{"a":"a","b":"b","c":"c"}""", json)
-            fail("GitHub #271 has been fixed!")
-        } catch (e: AssertionError) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github271AlphaSortProperties.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github271AlphaSortProperties.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class TestGithub271 {
     @JsonPropertyOrder(alphabetic=true)
@@ -16,6 +17,11 @@ class TestGithub271 {
         val mapper = jacksonObjectMapper()
 
         val json = mapper.writeValueAsString(Foo("a", "c"))
-        assertEquals("""{"a":"a","b":"b","c":"c"}""", json)
+        try {
+            assertEquals("""{"a":"a","b":"b","c":"c"}""", json)
+            fail("GitHub #271 has been fixed!")
+        } catch (e: AssertionError) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github271AlphaSortProperties.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github271AlphaSortProperties.kt
@@ -17,7 +17,7 @@ class TestGithub271 {
         val mapper = jacksonObjectMapper()
 
         val json = mapper.writeValueAsString(Foo("a", "c"))
-        expectFailure(AssertionError::class, "GitHub #271 has been fixed!") {
+        expectFailure<AssertionError>("GitHub #271 has been fixed!") {
             assertEquals("""{"a":"a","b":"b","c":"c"}""", json)
         }
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github335.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github335.kt
@@ -31,7 +31,7 @@ class Github335Test {
         val newEntity = mapper.readValue<MyEntity>(json)
 
         try {
-            // Returns false: "null" String instead of null
+            // newEntity.type is hte string "null" instead of the null value
             assertNull(newEntity.type)
             fail("GitHub #335 has been fixed!")
         } catch (e: AssertionError) {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github335.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github335.kt
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
 import kotlin.test.assertNull
-import kotlin.test.fail
 
 class Github335Test {
     val mapper = jacksonObjectMapper()
@@ -30,12 +30,9 @@ class Github335Test {
         val json = mapper.writeValueAsString(oldEntity)
         val newEntity = mapper.readValue<MyEntity>(json)
 
-        try {
-            // newEntity.type is hte string "null" instead of the null value
+        expectFailure(AssertionError::class, "GitHub #335 has been fixed!") {
+            // newEntity.type is the string "null" instead of the null value
             assertNull(newEntity.type)
-            fail("GitHub #335 has been fixed!")
-        } catch (e: AssertionError) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github335.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github335.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Test
 import kotlin.test.assertNull
+import kotlin.test.fail
 
 class Github335Test {
     val mapper = jacksonObjectMapper()
@@ -29,7 +30,12 @@ class Github335Test {
         val json = mapper.writeValueAsString(oldEntity)
         val newEntity = mapper.readValue<MyEntity>(json)
 
-        // Returns false: "null" String instead of null
-        assertNull(newEntity.type)
+        try {
+            // Returns false: "null" String instead of null
+            assertNull(newEntity.type)
+            fail("GitHub #335 has been fixed!")
+        } catch (e: AssertionError) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github335.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github335.kt
@@ -30,7 +30,7 @@ class Github335Test {
         val json = mapper.writeValueAsString(oldEntity)
         val newEntity = mapper.readValue<MyEntity>(json)
 
-        expectFailure(AssertionError::class, "GitHub #335 has been fixed!") {
+        expectFailure<AssertionError>("GitHub #335 has been fixed!") {
             // newEntity.type is the string "null" instead of the null value
             assertNull(newEntity.type)
         }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github340.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github340.kt
@@ -1,10 +1,12 @@
 package com.fasterxml.jackson.module.kotlin.test.failing
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class OwnerRequestTest {
     private val jackson = ObjectMapper().registerModule(KotlinModule())
@@ -19,8 +21,13 @@ class OwnerRequestTest {
 
     @Test
     fun testDeserHit340() {
-        val value: IsField = jackson.readValue(json)
-        assertEquals("Got a foo", value.foo)
+        try {
+            val value: IsField = jackson.readValue(json)
+            assertEquals("Got a foo", value.foo)
+            fail("GitHub #340 has been fixed!")
+        } catch (e: UnrecognizedPropertyException) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github340.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github340.kt
@@ -21,7 +21,7 @@ class OwnerRequestTest {
 
     @Test
     fun testDeserHit340() {
-        expectFailure(UnrecognizedPropertyException::class, "GitHub #340 has been fixed!") {
+        expectFailure<UnrecognizedPropertyException>("GitHub #340 has been fixed!") {
             val value: IsField = jackson.readValue(json)
             assertEquals("Got a foo", value.foo)
         }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github340.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github340.kt
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.fail
 
 class OwnerRequestTest {
     private val jackson = ObjectMapper().registerModule(KotlinModule())
@@ -21,12 +21,9 @@ class OwnerRequestTest {
 
     @Test
     fun testDeserHit340() {
-        try {
+        expectFailure(UnrecognizedPropertyException::class, "GitHub #340 has been fixed!") {
             val value: IsField = jackson.readValue(json)
             assertEquals("Got a foo", value.foo)
-            fail("GitHub #340 has been fixed!")
-        } catch (e: UnrecognizedPropertyException) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github396.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github396.kt
@@ -1,9 +1,11 @@
 package com.fasterxml.jackson.module.kotlin.test.failing
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class TestGithub396 {
     /**
@@ -15,9 +17,14 @@ class TestGithub396 {
         val mapper = XmlMapper().registerKotlinModule()
 
         val xml = "<product><stuff></stuff></product>"
-        val product: Product = mapper.readValue(xml, Product::class.java)
+        try {
+            val product: Product = mapper.readValue(xml, Product::class.java)
 
-        assertEquals(Product(null), product)
+            assertEquals(Product(null), product)
+            fail("GitHub #396 has been fixed!")
+        } catch (e: MismatchedInputException) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
 
     private data class Stuff(val str: String?)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github396.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github396.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.fail
 
 class TestGithub396 {
     /**
@@ -18,7 +17,7 @@ class TestGithub396 {
         val mapper = XmlMapper().registerKotlinModule()
 
         val xml = "<product><stuff></stuff></product>"
-        expectFailure(MismatchedInputException::class, "GitHub #396 has been fixed!") {
+        expectFailure<MismatchedInputException>("GitHub #396 has been fixed!") {
             val product: Product = mapper.readValue(xml, Product::class.java)
 
             assertEquals(Product(null), product)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github396.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github396.kt
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.failing
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
@@ -17,13 +18,10 @@ class TestGithub396 {
         val mapper = XmlMapper().registerKotlinModule()
 
         val xml = "<product><stuff></stuff></product>"
-        try {
+        expectFailure(MismatchedInputException::class, "GitHub #396 has been fixed!") {
             val product: Product = mapper.readValue(xml, Product::class.java)
 
             assertEquals(Product(null), product)
-            fail("GitHub #396 has been fixed!")
-        } catch (e: MismatchedInputException) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github50.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github50.kt
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test.failing
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Test
@@ -20,7 +21,7 @@ class TestGithub50 {
         try {
             val obj: Employee = jacksonObjectMapper().readValue(json)
             fail("GitHub #50 has been fixed!")
-        } catch (e: AssertionError) {
+        } catch (e: InvalidDefinitionException) {
             // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github50.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github50.kt
@@ -18,7 +18,7 @@ class TestGithub50 {
     @Test
     fun testGithub50UnwrappedError() {
         val json = """{"firstName":"John","lastName":"Smith","position":"Manager"}"""
-        expectFailure(InvalidDefinitionException::class, "GitHub #50 has been fixed!") {
+        expectFailure<InvalidDefinitionException>("GitHub #50 has been fixed!") {
             val obj: Employee = jacksonObjectMapper().readValue(json)
         }
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github50.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github50.kt
@@ -1,11 +1,10 @@
-package com.fasterxml.jackson.module.kotlin.test.github
+package com.fasterxml.jackson.module.kotlin.test.failing
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Ignore
 import org.junit.Test
-
+import kotlin.test.fail
 
 class TestGithub50 {
     data class Name(val firstName: String, val lastName: String)
@@ -15,11 +14,14 @@ class TestGithub50 {
             val position: String
     )
 
-
     @Test
-    @Ignore("""Fails with: Cannot define Creator property "name" as `@JsonUnwrapped`""")
     fun testGithub50UnwrappedError() {
-        val JSON = """{"firstName":"John","lastName":"Smith","position":"Manager"}"""
-        val obj: Employee = jacksonObjectMapper().readValue(JSON)
+        val json = """{"firstName":"John","lastName":"Smith","position":"Manager"}"""
+        try {
+            val obj: Employee = jacksonObjectMapper().readValue(json)
+            fail("GitHub #50 has been fixed!")
+        } catch (e: AssertionError) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github50.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github50.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
-import kotlin.test.fail
 
 class TestGithub50 {
     data class Name(val firstName: String, val lastName: String)
@@ -18,11 +18,8 @@ class TestGithub50 {
     @Test
     fun testGithub50UnwrappedError() {
         val json = """{"firstName":"John","lastName":"Smith","position":"Manager"}"""
-        try {
+        expectFailure(InvalidDefinitionException::class, "GitHub #50 has been fixed!") {
             val obj: Employee = jacksonObjectMapper().readValue(json)
-            fail("GitHub #50 has been fixed!")
-        } catch (e: InvalidDefinitionException) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github54.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github54.kt
@@ -1,13 +1,14 @@
-package com.fasterxml.jackson.module.kotlin.test.github
+package com.fasterxml.jackson.module.kotlin.test.failing
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo
 import com.fasterxml.jackson.annotation.ObjectIdGenerators
-import com.fasterxml.jackson.module.kotlin.*
-import org.junit.Ignore
+import com.fasterxml.jackson.databind.deser.UnresolvedForwardReference
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Test
+import kotlin.test.fail
 
 class TestGithub54 {
-    @Ignore("TODO: Fix this, Github #54")
     @Test
     fun testDeserWithIdentityInfo() {
         val mapper = jacksonObjectMapper()
@@ -20,7 +21,13 @@ class TestGithub54 {
         entity1.entity2 = entity2
 
         val json = mapper.writeValueAsString(entity1)
-        mapper.readValue<Entity1>(json)
+        try {
+            mapper.readValue<Entity1>(json)
+            fail("GitHub #54 has been fixed!")
+        } catch (e: UnresolvedForwardReference) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
+
     }
 }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github54.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github54.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
-import kotlin.test.fail
 
 class TestGithub54 {
     @Test
@@ -22,7 +21,7 @@ class TestGithub54 {
         entity1.entity2 = entity2
 
         val json = mapper.writeValueAsString(entity1)
-        expectFailure(UnresolvedForwardReference::class, "GitHub #54 has been fixed!") {
+        expectFailure<UnresolvedForwardReference>("GitHub #54 has been fixed!") {
             mapper.readValue<Entity1>(json)
         }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github54.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github54.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators
 import com.fasterxml.jackson.databind.deser.UnresolvedForwardReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
 import kotlin.test.fail
 
@@ -21,11 +22,8 @@ class TestGithub54 {
         entity1.entity2 = entity2
 
         val json = mapper.writeValueAsString(entity1)
-        try {
+        expectFailure(UnresolvedForwardReference::class, "GitHub #54 has been fixed!") {
             mapper.readValue<Entity1>(json)
-            fail("GitHub #54 has been fixed!")
-        } catch (e: UnresolvedForwardReference) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
 
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github71.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github71.kt
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.module.kotlin.test.failing
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.fail
 
 class TestGithub71 {
     open class Identifiable {
@@ -15,13 +15,10 @@ class TestGithub71 {
     fun testInternalPropertySerliazation() {
         val json = jacksonObjectMapper().writeValueAsString(Identifiable())
 
-        try {
+        expectFailure(AssertionError::class, "GitHub #71 has been fixed!") {
             assertEquals("{\"identity\":null}", json) // fails: {"identity$jackson_module_kotlin":null}
             val newInstance = jacksonObjectMapper().readValue<Identifiable>(json)
             assertEquals(Identifiable(), newInstance)
-            fail("GitHub #71 has been fixed!")
-        } catch (e: AssertionError) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github71.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github71.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class TestGithub71 {
     open class Identifiable {
@@ -13,8 +14,14 @@ class TestGithub71 {
     @Test
     fun testInternalPropertySerliazation() {
         val json = jacksonObjectMapper().writeValueAsString(Identifiable())
-        assertEquals("{\"identity\":null}", json) // fails: {"identity$jackson_module_kotlin":null}
-        val newInstance = jacksonObjectMapper().readValue<Identifiable>(json)
-        assertEquals(Identifiable(), newInstance)
+
+        try {
+            assertEquals("{\"identity\":null}", json) // fails: {"identity$jackson_module_kotlin":null}
+            val newInstance = jacksonObjectMapper().readValue<Identifiable>(json)
+            assertEquals(Identifiable(), newInstance)
+            fail("GitHub #71 has been fixed!")
+        } catch (e: AssertionError) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github71.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/Github71.kt
@@ -15,7 +15,7 @@ class TestGithub71 {
     fun testInternalPropertySerliazation() {
         val json = jacksonObjectMapper().writeValueAsString(Identifiable())
 
-        expectFailure(AssertionError::class, "GitHub #71 has been fixed!") {
+        expectFailure<AssertionError>("GitHub #71 has been fixed!") {
             assertEquals("{\"identity\":null}", json) // fails: {"identity$jackson_module_kotlin":null}
             val newInstance = jacksonObjectMapper().readValue<Identifiable>(json)
             assertEquals(Identifiable(), newInstance)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/GithubDatabind1329.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/GithubDatabind1329.kt
@@ -28,7 +28,7 @@ class GithubDatabind1329 {
         )
 
         assertEquals(InviteKind.CONTACT, invite.kind)
-        expectFailure(AssertionError::class, "GitHub Databind issue #1329 has been fixed!") {
+        expectFailure<AssertionError>("GitHub Databind issue #1329 has been fixed!") {
             assertNull(invite.kindForMapper)
         }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/GithubDatabind1329.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/GithubDatabind1329.kt
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.fail
 
 /**
  * Broken in databind 2.8.0+ (not 2.8.0.rc2 which works) and not a problem with the Kotlin module
@@ -28,11 +28,8 @@ class GithubDatabind1329 {
         )
 
         assertEquals(InviteKind.CONTACT, invite.kind)
-        try {
+        expectFailure(AssertionError::class, "GitHub Databind issue #1329 has been fixed!") {
             assertNull(invite.kindForMapper)
-            fail("GitHub Databind issue #1329 has been fixed!")
-        } catch (e: AssertionError) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
 
         assertEquals("Foo", (invite.to as InviteToContact).name)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/README.md
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/README.md
@@ -6,3 +6,45 @@ The tests pass because either the failing assertions have their `AssertionError`
 that throws has its exception caught.  Each of those blocks has a `fail()` call after the call that
 is expected to throw; this `fail()` will fail the build if the associated test case is fixed,
 allowing us to know when an issue has been solved incidentally.
+
+## Writing a failing test
+
+Failing tests are good to have because they can both concisely document known issues with the
+library but also serve as notification for when that functionality has been fixed.
+
+Create a failing test by writing it as you would any other test, making any calls or assertions
+necessary to demonstrate the failing behavior.  Then, suppress that error using a `try/catch`
+block with a descriptive `fail()` statement as the last line of the `try` to act as a
+[canary](https://en.wikipedia.org/wiki/Domestic_canary#Miner's_canary) for when the broken
+functionality is fixed.
+
+See the below examples:
+
+```kotlin
+@Test
+fun failingTest() {
+    try {
+        mapper.callThatFailsWithMismatchedInputException()
+        fail("The call that fails with MismatchedInputException has been fixed!")
+    } catch (e: MismatchedInputException) {
+        // Remove this try/catch and the `fail()` call above when this issue is fixed
+    }
+}
+```
+
+```kotlin
+@Test
+fun serializeAndDeserializeTypeable() {
+    val oldEntity = MyEntity(null, null)
+    val json = mapper.writeValueAsString(oldEntity)
+    val newEntity = mapper.readValue<MyEntity>(json)
+
+    try {
+        // newEntity.type is hte string "null" instead of the null value
+        assertNull(newEntity.type)
+        fail("GitHub #335 has been fixed!")
+    } catch (e: AssertionError) {
+        // Remove this try/catch and the `fail()` call above when this issue is fixed
+    }
+}
+```

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/README.md
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/README.md
@@ -1,33 +1,26 @@
 # Failing tests
 
-These are tests for filed issues on GitHub that have not been fixed.
+These are tests for filed issues on GitHub that have not been fixed. Failing tests are good to
+have because they can both concisely document known issues with the library but also serve as
+notification for when that functionality has been fixed.
 
 The tests pass because either the failing assertions have their `AssertionError` or the Jackson call
-that throws has its exception caught.  Each of those blocks has a `fail()` call after the call that
-is expected to throw; this `fail()` will fail the build if the associated test case is fixed,
-allowing us to know when an issue has been solved incidentally.
+that throws has its exception caught.
 
 ## Writing a failing test
 
-Failing tests are good to have because they can both concisely document known issues with the
-library but also serve as notification for when that functionality has been fixed.
-
 Create a failing test by writing it as you would any other test, making any calls or assertions
-necessary to demonstrate the failing behavior.  Then, suppress that error using a `try/catch`
-block with a descriptive `fail()` statement as the last line of the `try` to act as a
-[canary](https://en.wikipedia.org/wiki/Domestic_canary#Miner's_canary) for when the broken
-functionality is fixed.
+necessary to demonstrate the failing behavior.  Then, surround the failing call with the
+`expectFailure()` function, passing the expected exception and a message that will be printed
+if the failure does _not_ occur, which implies that the functionality has been fixed.
 
 See the below examples:
 
 ```kotlin
 @Test
 fun failingTest() {
-    try {
+    expectFailure(MismatchedInputException::class, "The call that fails with MismatchedInputException has been fixed!") {
         mapper.callThatFailsWithMismatchedInputException()
-        fail("The call that fails with MismatchedInputException has been fixed!")
-    } catch (e: MismatchedInputException) {
-        // Remove this try/catch and the `fail()` call above when this issue is fixed
     }
 }
 ```
@@ -39,12 +32,9 @@ fun serializeAndDeserializeTypeable() {
     val json = mapper.writeValueAsString(oldEntity)
     val newEntity = mapper.readValue<MyEntity>(json)
 
-    try {
+    expectFailure(AssertionError::class, "GitHub #335 has been fixed!") {
         // newEntity.type is hte string "null" instead of the null value
         assertNull(newEntity.type)
-        fail("GitHub #335 has been fixed!")
-    } catch (e: AssertionError) {
-        // Remove this try/catch and the `fail()` call above when this issue is fixed
     }
 }
 ```

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/README.md
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/README.md
@@ -19,7 +19,7 @@ See the below examples:
 ```kotlin
 @Test
 fun failingTest() {
-    expectFailure(MismatchedInputException::class, "The call that fails with MismatchedInputException has been fixed!") {
+    expectFailure<MismatchedInputException>("The call that fails with MismatchedInputException has been fixed!") {
         mapper.callThatFailsWithMismatchedInputException()
     }
 }
@@ -32,7 +32,7 @@ fun serializeAndDeserializeTypeable() {
     val json = mapper.writeValueAsString(oldEntity)
     val newEntity = mapper.readValue<MyEntity>(json)
 
-    expectFailure(AssertionError::class, "GitHub #335 has been fixed!") {
+    expectFailure<AssertionError>("GitHub #335 has been fixed!") {
         // newEntity.type is hte string "null" instead of the null value
         assertNull(newEntity.type)
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/README.md
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/failing/README.md
@@ -1,0 +1,8 @@
+# Failing tests
+
+These are tests for filed issues on GitHub that have not been fixed.
+
+The tests pass because either the failing assertions have their `AssertionError` or the Jackson call
+that throws has its exception caught.  Each of those blocks has a `fail()` call after the call that
+is expected to throw; this `fail()` will fail the build if the associated test case is fixed,
+allowing us to know when an issue has been solved incidentally.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github153.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github153.kt
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.fail
 
 class TestGithub153 {
     @JacksonXmlRootElement(localName = "MyPojo")
@@ -55,7 +55,7 @@ class TestGithub153 {
     @Test
     // Conflict between the annotations that is not current resolvable.
     fun test_data_class() {
-        try {
+        expectFailure(InvalidDefinitionException::class, "Problem with conflicting annotations related to #153 has been fixed!") {
             // I create a pojo from the xml using the data classes
             val pojoFromXml = mapper.readValue(xml, MyDataPojo::class.java)
 
@@ -64,9 +64,6 @@ class TestGithub153 {
 
             // I compare the original xml with the xml generated from the pojo
             assertEquals(xml, xmlFromPojo)
-            fail("Problem with conflicting annotations related to #153 has been fixed!")
-        } catch (e: InvalidDefinitionException) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
         }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github153.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github153.kt
@@ -1,14 +1,14 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertEquals
-
+import kotlin.test.fail
 
 class TestGithub153 {
     @JacksonXmlRootElement(localName = "MyPojo")
@@ -42,31 +42,31 @@ class TestGithub153 {
 
     @Test
     fun test_class() {
-
         // I create a pojo from the xml using the standard classes
         val pojoFromXml = mapper.readValue(xml, MyPojo::class.java)
 
-        //I create a xml from the pojo
+        // I create a xml from the pojo
         val xmlFromPojo = mapper.writeValueAsString(pojoFromXml)
 
         // I compare the original xml with the xml generated from the pojo
         assertEquals(xml, xmlFromPojo)
-
     }
 
     @Test
-    @Ignore("Conflict between the annotations that is not current resolvable.")
+    // Conflict between the annotations that is not current resolvable.
     fun test_data_class() {
+        try {
+            // I create a pojo from the xml using the data classes
+            val pojoFromXml = mapper.readValue(xml, MyDataPojo::class.java)
 
-        // I create a pojo from the xml using the data classes
-        val pojoFromXml = mapper.readValue(xml, MyDataPojo::class.java)
+            // I create a xml from the pojo
+            val xmlFromPojo = mapper.writeValueAsString(pojoFromXml)
 
-        //I create a xml from the pojo
-        val xmlFromPojo = mapper.writeValueAsString(pojoFromXml)
-
-        // I compare the original xml with the xml generated from the pojo
-        assertEquals(xml, xmlFromPojo)
-
+            // I compare the original xml with the xml generated from the pojo
+            assertEquals(xml, xmlFromPojo)
+            fail("Problem with conflicting annotations related to #153 has been fixed!")
+        } catch (e: InvalidDefinitionException) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
-
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github153.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github153.kt
@@ -55,7 +55,7 @@ class TestGithub153 {
     @Test
     // Conflict between the annotations that is not current resolvable.
     fun test_data_class() {
-        expectFailure(InvalidDefinitionException::class, "Problem with conflicting annotations related to #153 has been fixed!") {
+        expectFailure<InvalidDefinitionException>("Problem with conflicting annotations related to #153 has been fixed!") {
             // I create a pojo from the xml using the data classes
             val pojoFromXml = mapper.readValue(xml, MyDataPojo::class.java)
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
@@ -47,7 +47,7 @@ class TestGithub27 {
     fun testListOfInt() {
         val json = """{"samples":[1, null]}"""
         val stateObj = mapper.readValue<ClassWithListOfInt>(json)
-        expectFailure(NullPointerException::class, "Problem with nullable generics related to #27 has been fixed!") {
+        expectFailure<NullPointerException>("Problem with nullable generics related to #27 has been fixed!") {
             assertTrue(stateObj.samples.none {
                 @Suppress("SENSELESS_COMPARISON")
                 (it == null)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
@@ -1,18 +1,19 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 
 class TestGithub27 {
-    val mapper = jacksonObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)
+    val mapper: ObjectMapper = jacksonObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)
 
     private data class ClassWithNullableInt(val sample: Int?)
 
@@ -40,14 +41,20 @@ class TestGithub27 {
 
     private data class ClassWithListOfInt(val samples: List<Int>)
 
-    @Ignore("Would be hard to look into generics of every possible type of collection or generic object to check nullability of each item, maybe only possible for simple known collections")
-    @Test fun testListOfInt() {
+    @Test
+    // Would be hard to look into generics of every possible type of collection or generic object to check nullability of each item, maybe only possible for simple known collections
+    fun testListOfInt() {
         val json = """{"samples":[1, null]}"""
         val stateObj = mapper.readValue<ClassWithListOfInt>(json)
-        assertTrue(stateObj.samples.none {
-            @Suppress("SENSELESS_COMPARISON")
-            (it == null)
-        })
+        try {
+            assertTrue(stateObj.samples.none {
+                @Suppress("SENSELESS_COMPARISON")
+                (it == null)
+            })
+            fail("Problem with nullable generics related to #27 has been fixed!")
+        } catch (e: NullPointerException) {
+            // Remove this try/catch and the `fail()` call above when this issue is fixed
+        }
     }
 
     // work around to above

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -46,14 +47,12 @@ class TestGithub27 {
     fun testListOfInt() {
         val json = """{"samples":[1, null]}"""
         val stateObj = mapper.readValue<ClassWithListOfInt>(json)
-        try {
+        expectFailure(NullPointerException::class, "Problem with nullable generics related to #27 has been fixed!") {
             assertTrue(stateObj.samples.none {
                 @Suppress("SENSELESS_COMPARISON")
                 (it == null)
             })
-            fail("Problem with nullable generics related to #27 has been fixed!")
-        } catch (e: NullPointerException) {
-            // Remove this try/catch and the `fail()` call above when this issue is fixed
+            fail()
         }
     }
 


### PR DESCRIPTION
This un-excludes the failing tests, but makes them pass by catching the exceptions that cause them to fail or error.  This allows us to be notified (by a build failure) when a failing test case is fixed, as #145 was recently.

The [new README in the failing tests dir](https://github.com/FasterXML/jackson-module-kotlin/pull/407/files#diff-7d2fcf0dadb1954f607980f9888081d5ba9c7999f34eadeed7fa3442b0d44172) explains how these are written, and I've called out a few in inline comments.