### PR TITLE
Added Test and Documentation for the sealed-classes-without-@JsonSubT…

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ These Kotlin classes are supported with the following fields for serialization/d
 
 (others are likely to work, but may not be tuned for Jackson)
 
+# Sealed classes without @JsonSubTypes
+Subclasses can be detected automatically for sealed classes, since all possible subclasses are known
+at compile-time to Kotlin. This makes `com.fasterxml.jackson.annotation.JsonSubTypes` redundant.
+A `com.fasterxml.jackson.annotation.@JsonTypeInfo` annotation at the base-class is still necessary. 
+
+```kotlin
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+  sealed class SuperClass{
+      class A:SuperClass()
+      class B:SuperClass()
+  }
+
+...
+val mapper = jacksonObjectMapper()
+val root:SuperClass = mapper.readValue(json)
+when(root){
+    is A -> "It's A"
+    is B -> "It's B"
+}
+```
+
+
 # Configuration
 
 The Kotlin module may be given a few configuration parameters at construction time;

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SealedClassTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SealedClassTest.kt
@@ -1,0 +1,35 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.test.SealedClassTest.SuperClass.A
+import com.fasterxml.jackson.module.kotlin.test.SealedClassTest.SuperClass.B
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class SealedClassTest {
+
+
+    private val mapper = jacksonObjectMapper()
+
+    /**
+     * Json of a Serialized B-Object.
+     */
+    private val jsonB = "{\"@type\":\"SealedClassTest\$SuperClass\$B\"}"
+
+    /**
+     * Tests that the @JsonSubTypes-Annotation is not necessary when working with Sealed-Classes.
+     *
+     */
+    @Test fun SealedClassWithoutSubTypes(){
+        val result =  mapper.readValue(jsonB, SuperClass::class.java)
+        assertTrue { result is B }
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+    sealed class SuperClass{
+        class A:SuperClass()
+        class B:SuperClass()
+    }
+
+}


### PR DESCRIPTION
…ypes_Feature.

I was not aware that the kotlin module already supported sealed classes without "@JsonSubType". I wanted to add this, then I found the method com.fasterxml.jackson.module.kotlin.KotlinAnnotationIntrospector#findSubtypes which does exactly this. 

So instead I added a Test and documentation. 


