### PR TITLE
Move internals to …internal package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
                         <dependency>
                             <groupId>com.fasterxml.jackson.module</groupId>
                             <artifactId>jackson-module-kotlin</artifactId>
-                            <version>2.12.2</version>
+                            <version>2.12.3-SNAPSHOT</version>
                             <type>jar</type>
                         </dependency>
                     </oldVersion>
@@ -203,6 +203,10 @@
                     <parameter>
                         <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                         <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+                        <excludes>
+                            <exclude>com.fasterxml.jackson.module.kotlin.internal</exclude>
+                        </excludes>
+                        <excludeExclusively>true</excludeExclusively>
                     </parameter>
                 </configuration>
                 <executions>

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -4,6 +4,13 @@ import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.SingletonSupport.CANONICALIZE
 import com.fasterxml.jackson.module.kotlin.SingletonSupport.DISABLED
+import com.fasterxml.jackson.module.kotlin.internal.KotlinAnnotationIntrospector
+import com.fasterxml.jackson.module.kotlin.internal.KotlinBeanDeserializerModifier
+import com.fasterxml.jackson.module.kotlin.internal.KotlinDeserializers
+import com.fasterxml.jackson.module.kotlin.internal.KotlinInstantiators
+import com.fasterxml.jackson.module.kotlin.internal.KotlinNamesAnnotationIntrospector
+import com.fasterxml.jackson.module.kotlin.internal.KotlinSerializers
+import com.fasterxml.jackson.module.kotlin.internal.ReflectionCache
 import kotlin.reflect.KClass
 
 private val metadataFqName = "kotlin.Metadata"

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinAnnotationIntrospector.kt
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.kotlin
+package com.fasterxml.jackson.module.kotlin.internal
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.Module
 import com.fasterxml.jackson.databind.cfg.MapperConfig
 import com.fasterxml.jackson.databind.introspect.*
 import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.fasterxml.jackson.module.kotlin.isKotlinClass
 import java.lang.reflect.AccessibleObject
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinBeanDeserializerModifier.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinBeanDeserializerModifier.kt
@@ -1,9 +1,10 @@
-package com.fasterxml.jackson.module.kotlin
+package com.fasterxml.jackson.module.kotlin.internal
 
 import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.DeserializationConfig
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
+import com.fasterxml.jackson.module.kotlin.isKotlinClass
 
 // [module-kotlin#225]: keep Kotlin singletons as singletons
 object KotlinBeanDeserializerModifier : BeanDeserializerModifier() {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinDeserializers.kt
@@ -1,6 +1,6 @@
 @file:Suppress("EXPERIMENTAL_API_USAGE")
 
-package com.fasterxml.jackson.module.kotlin
+package com.fasterxml.jackson.module.kotlin.internal
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonToken.VALUE_NUMBER_INT
@@ -8,6 +8,10 @@ import com.fasterxml.jackson.core.exc.InputCoercionException
 import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.module.kotlin.asUByte
+import com.fasterxml.jackson.module.kotlin.asUInt
+import com.fasterxml.jackson.module.kotlin.asULong
+import com.fasterxml.jackson.module.kotlin.asUShort
 
 object SequenceDeserializer : StdDeserializer<Sequence<*>>(Sequence::class.java) {
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Sequence<*> {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinNamesAnnotationIntrospector.kt
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.kotlin
+package com.fasterxml.jackson.module.kotlin.internal
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.PropertyName
 import com.fasterxml.jackson.databind.cfg.MapperConfig
 import com.fasterxml.jackson.databind.introspect.*
 import com.fasterxml.jackson.databind.util.BeanUtil
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.isKotlinClass
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import kotlin.reflect.KClass

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinObjectSingletonDeserializer.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinObjectSingletonDeserializer.kt
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.kotlin
+package com.fasterxml.jackson.module.kotlin.internal
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.BeanProperty

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinSerializers.kt
@@ -1,6 +1,6 @@
 @file:Suppress("EXPERIMENTAL_API_USAGE")
 
-package com.fasterxml.jackson.module.kotlin
+package com.fasterxml.jackson.module.kotlin.internal
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.*

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/KotlinValueInstantiator.kt
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.kotlin
+package com.fasterxml.jackson.module.kotlin.internal
 
 import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.DeserializationConfig
@@ -12,6 +12,9 @@ import com.fasterxml.jackson.databind.deser.impl.PropertyValueBuffer
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.fasterxml.jackson.module.kotlin.isKotlinClass
+import com.fasterxml.jackson.module.kotlin.wrapWithPath
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.lang.reflect.TypeVariable
@@ -24,12 +27,12 @@ import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaType
 
 internal class KotlinValueInstantiator(
-    src: StdValueInstantiator,
-    private val cache: ReflectionCache,
-    private val nullToEmptyCollection: Boolean,
-    private val nullToEmptyMap: Boolean,
-    private val nullIsSameAsDefault: Boolean,
-    private val strictNullChecks: Boolean
+        src: StdValueInstantiator,
+        private val cache: ReflectionCache,
+        private val nullToEmptyCollection: Boolean,
+        private val nullToEmptyMap: Boolean,
+        private val nullIsSameAsDefault: Boolean,
+        private val strictNullChecks: Boolean
 ) : StdValueInstantiator(src) {
     @Suppress("UNCHECKED_CAST")
     override fun createFromObjectWith(
@@ -184,11 +187,11 @@ internal class KotlinValueInstantiator(
 }
 
 internal class KotlinInstantiators(
-    private val cache: ReflectionCache,
-    private val nullToEmptyCollection: Boolean,
-    private val nullToEmptyMap: Boolean,
-    private val nullIsSameAsDefault: Boolean,
-    private val strictNullChecks: Boolean
+        private val cache: ReflectionCache,
+        private val nullToEmptyCollection: Boolean,
+        private val nullToEmptyMap: Boolean,
+        private val nullIsSameAsDefault: Boolean,
+        private val strictNullChecks: Boolean
 ) : ValueInstantiators {
     override fun findValueInstantiator(
         deserConfig: DeserializationConfig,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/ReflectionCache.kt
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.kotlin
+package com.fasterxml.jackson.module.kotlin.internal
 
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/Types.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/internal/Types.kt
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.kotlin
+package com.fasterxml.jackson.module.kotlin.internal
 
 import java.lang.reflect.*
 import kotlin.reflect.KType


### PR DESCRIPTION
Move internals to a new `…internal` package and tell japicmp to ignore it.  This will allow us to do internal refactoring without tripping the version compatibility checks.