### PR TITLE
Fixed mapping failure when `private` `companion object` is nammed.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -71,7 +71,7 @@ internal class KotlinValueInstantiator(
                 possibleCompanion.objectInstance
             } catch (ex: IllegalAccessException) {
                 // fallback for when an odd access exception happens through Kotlin reflection
-                val companionField = possibleCompanion.java.enclosingClass.fields.firstOrNull { it.name == "Companion" }
+                val companionField = possibleCompanion.java.enclosingClass.fields.firstOrNull { it.type.kotlin.isCompanion }
                         ?: throw ex
                 val accessible = companionField.isAccessible
                 if ((!accessible && ctxt.config.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) ||

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
@@ -197,6 +197,23 @@ class TestJacksonWithKotlin {
         }
     }
 
+    private class StateObjectWithFactoryOnNamedCompanion private constructor (override val name: String, override val age: Int, override val primaryAddress: String, override val wrongName: Boolean, override val createdDt: Date) : TestFields {
+        var factoryUsed: Boolean = false
+        companion object Named {
+            @JvmStatic @JsonCreator fun create(@JsonProperty("name") nameThing: String, @JsonProperty("age") age: Int, @JsonProperty("primaryAddress") primaryAddress: String, @JsonProperty("renamed") wrongName: Boolean, @JsonProperty("createdDt") createdDt: Date): StateObjectWithFactoryOnNamedCompanion {
+                val obj = StateObjectWithFactoryOnNamedCompanion(nameThing, age, primaryAddress, wrongName, createdDt)
+                obj.factoryUsed = true
+                return obj
+            }
+        }
+    }
+
+    @Test fun findingFactoryMethod3() {
+        val stateObj = normalCasedMapper.readValue(normalCasedJson, StateObjectWithFactoryOnNamedCompanion::class.java)
+        stateObj.validate()
+        assertThat(stateObj.factoryUsed, equalTo(true))
+    }
+
     // GH #14 failing due to this enum type
     data class Gh14FailureWithEnum(var something: String = "hi", var someEnum: LaunchType = LaunchType.ACTIVITY)
 


### PR DESCRIPTION
Currently, when retrieving a `companion object` from a `field`, the name is used for comparison.
https://github.com/FasterXML/jackson-module-kotlin/blob/244b27f2c543f8541e06fd40935ba74659860614/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt#L74

On the other hand, you can name the `companion object` as follows.
In this case, the field name in the compilation result will not be `Companion`.

```kotlin
companion object Named {

}
```

This causes the mapping to fail.

We fixed this in PR.

## Question
I would like to submit a `CLA`, but is it enough to fill in `Your name` and `Email`?
Also, where should I submit it?

I'm not familiar with English or submitting the `CLA`, so I don't know what to do.
If you could tell me how to do it, I would be very grateful.

Thank you.
