### PR TITLE
Fix `KotlinAnnotationIntrospector.findSubtypes` returning wrong value in super edge case.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -63,21 +63,14 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
      * Subclasses can be detected automatically for sealed classes, since all possible subclasses are known
      * at compile-time to Kotlin. This makes [com.fasterxml.jackson.annotation.JsonSubTypes] redundant.
      */
-    override fun findSubtypes(a: Annotated): MutableList<NamedType>? {
-
-        val rawType = a.rawType
-        if (rawType.isKotlinClass()) {
-            val kClass = rawType.kotlin
-            if (kClass.isSealed) {
-                return kClass.sealedSubclasses
-                    .map { NamedType(it.java) }
-                    .toMutableList()
-            }
+    override fun findSubtypes(a: Annotated): MutableList<NamedType>? = a.rawType
+        .takeIf { it.isKotlinClass() }
+        ?.let { rawType ->
+            rawType.kotlin.sealedSubclasses
+                .map { NamedType(it.java) }
+                .toMutableList()
+                .ifEmpty { null }
         }
-
-        return null
-
-    }
 
     private fun AnnotatedField.hasRequiredMarker(): Boolean? {
         val byAnnotation = (member as Field).isRequiredByAnnotation()


### PR DESCRIPTION
`findSubtypes` is defined to return `null` if nothing can be retrieved.

https://github.com/FasterXML/jackson-databind/blob/2644cba99ec5e23ffdbe85dfe00fb471e5aa0d9c/src/main/java/com/fasterxml/jackson/databind/AnnotationIntrospector.java#L483

On the other hand, a `sealed class` may not have any classes to inherit from.
In this case, the conventional implementation of `findSubtypes` will return an empty List.

So I modified it to return `null` in case of an empty list.

Also, it is simpler to look at `sealedSubclasses` directly than to determine `isSealed`, so I fixed it while I was at it.