### PR TITLE
Optimize `KotlinAnnotationIntrospector#AnnotatedMethod.hasRequiredMarker` method.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -131,8 +131,7 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
     }
 
     private fun KFunction<*>.isGetterLike(): Boolean = parameters.size == 1
-    private fun KFunction<*>.isSetterLike(): Boolean =
-        parameters.size == 2 && returnType == Unit::class.createType()
+    private fun KFunction<*>.isSetterLike(): Boolean = parameters.size == 2 && returnType == UNIT_TYPE
 
     private fun AnnotatedParameter.hasRequiredMarker(): Boolean? {
         val member = this.member
@@ -170,4 +169,7 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
 
     private fun KType.isRequired(): Boolean = !isMarkedNullable
 
+    companion object {
+        val UNIT_TYPE: KType = Unit::class.createType()
+    }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -98,7 +98,7 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
 
     // This could be a setter or a getter of a class property or
     // a setter-like/getter-like method.
-    private fun AnnotatedMethod.hasRequiredMarker(): Boolean? = this.getFromCorrespondingAccessor()
+    private fun AnnotatedMethod.hasRequiredMarker(): Boolean? = this.getRequiredMarkerFromCorrespondingAccessor()
         ?: this.member.kotlinFunction?.let { method -> // Is the member method a regular method of the data class or
             val byAnnotation = method.javaMethod?.isRequiredByAnnotation()
             when {
@@ -110,7 +110,7 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
             }
         }
 
-    private fun AnnotatedMethod.getFromCorrespondingAccessor(): Boolean? {
+    private fun AnnotatedMethod.getRequiredMarkerFromCorrespondingAccessor(): Boolean? {
         member.declaringClass.kotlin.declaredMemberProperties.forEach { kProperty1 ->
             kProperty1.javaGetter
                 ?.takeIf { it == this.member }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -99,7 +99,7 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
     // This could be a setter or a getter of a class property or
     // a setter-like/getter-like method.
     private fun AnnotatedMethod.hasRequiredMarker(): Boolean? = this.getRequiredMarkerFromCorrespondingAccessor()
-        ?: this.member.kotlinFunction?.getRequiredMarkerFromAccessorLikeMethod()
+        ?: this.member.getRequiredMarkerFromAccessorLikeMethod()
 
     private fun AnnotatedMethod.getRequiredMarkerFromCorrespondingAccessor(): Boolean? {
         member.declaringClass.kotlin.declaredMemberProperties.forEach { kProperty1 ->
@@ -121,11 +121,11 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
     }
 
     // Is the member method a regular method of the data class or
-    private fun KFunction<*>.getRequiredMarkerFromAccessorLikeMethod(): Boolean? {
-        val byAnnotation = this.javaMethod?.isRequiredByAnnotation()
+    private fun Method.getRequiredMarkerFromAccessorLikeMethod(): Boolean? = this.kotlinFunction?.let { method ->
+        val byAnnotation = this.isRequiredByAnnotation()
         return when {
-            this.isGetterLike() -> requiredAnnotationOrNullability(byAnnotation, this.returnType.isRequired())
-            this.isSetterLike() -> requiredAnnotationOrNullability(byAnnotation, this.isMethodParameterRequired(0))
+            method.isGetterLike() -> requiredAnnotationOrNullability(byAnnotation, method.returnType.isRequired())
+            method.isSetterLike() -> requiredAnnotationOrNullability(byAnnotation, method.isMethodParameterRequired(0))
             else -> null
         }
     }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -13,7 +13,6 @@ import java.lang.reflect.Field
 import java.lang.reflect.Method
 import kotlin.reflect.KFunction
 import kotlin.reflect.KMutableProperty1
-import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredMemberProperties
@@ -100,17 +99,7 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
     private fun AnnotatedMethod.hasRequiredMarker(): Boolean? {
         // This could be a setter or a getter of a class property or
         // a setter-like/getter-like method.
-        val paramGetter = this.getCorrespondingGetter()
-        if (paramGetter != null) {
-            val byAnnotation = paramGetter.javaGetter?.isRequiredByAnnotation()
-            return requiredAnnotationOrNullability(byAnnotation, paramGetter.returnType.isRequired())
-        }
-
-        val paramSetter = this.getCorrespondingSetter()
-        if (paramSetter != null) {
-            val byAnnotation = paramSetter.javaMethod?.isRequiredByAnnotation()
-            return requiredAnnotationOrNullability(byAnnotation, paramSetter.isMethodParameterRequired(0))
-        }
+        this.getFromCorrespondingAccessor()?.let { return it }
 
         // Is the member method a regular method of the data class or
         val method = this.member.kotlinFunction
@@ -132,21 +121,23 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
     private fun KFunction<*>.isSetterLike(): Boolean =
             parameters.size == 2 && returnType == Unit::class.createType()
 
+    private fun AnnotatedMethod.getFromCorrespondingAccessor(): Boolean? {
+        member.declaringClass.kotlin.declaredMemberProperties.forEach { kProperty1 ->
+            kProperty1.javaGetter
+                ?.takeIf { it == this.member }
+                ?.let {
+                    val byAnnotation = it.isRequiredByAnnotation()
+                    return requiredAnnotationOrNullability(byAnnotation, kProperty1.returnType.isRequired())
+                }
 
-    private fun AnnotatedMethod.getCorrespondingGetter(): KProperty1<out Any, Any?>? =
-            member.declaringClass.kotlin.declaredMemberProperties.find {
-                it.getter.javaMethod == this.member
-            }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun AnnotatedMethod.getCorrespondingSetter(): KMutableProperty1.Setter<out Any, Any?>? {
-        val mutableProperty = member.declaringClass.kotlin.declaredMemberProperties.find {
-            when (it) {
-                is KMutableProperty1 -> it.javaSetter == this.member
-                else                 -> false
-            }
+            (kProperty1 as? KMutableProperty1)?.javaSetter
+                ?.takeIf { it == this.member }
+                ?.let {
+                    val byAnnotation = it.isRequiredByAnnotation()
+                    return requiredAnnotationOrNullability(byAnnotation, kProperty1.setter.isMethodParameterRequired(0))
+                }
         }
-        return (mutableProperty as? KMutableProperty1<out Any, Any?>)?.setter
+        return null
     }
 
     private fun AnnotatedParameter.hasRequiredMarker(): Boolean? {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -110,10 +110,6 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
             }
         }
 
-    private fun KFunction<*>.isGetterLike(): Boolean = parameters.size == 1
-    private fun KFunction<*>.isSetterLike(): Boolean =
-            parameters.size == 2 && returnType == Unit::class.createType()
-
     private fun AnnotatedMethod.getFromCorrespondingAccessor(): Boolean? {
         member.declaringClass.kotlin.declaredMemberProperties.forEach { kProperty1 ->
             kProperty1.javaGetter
@@ -132,6 +128,10 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
         }
         return null
     }
+
+    private fun KFunction<*>.isGetterLike(): Boolean = parameters.size == 1
+    private fun KFunction<*>.isSetterLike(): Boolean =
+        parameters.size == 2 && returnType == Unit::class.createType()
 
     private fun AnnotatedParameter.hasRequiredMarker(): Boolean? {
         val member = this.member


### PR DESCRIPTION

## Purpose of the PR
The main purpose of this PR is to speed up the `AnnotatedMethod.hasRequiredMarker` method.

### On getting a `RequiredMarker` from a `KProperty`
The process of getting `RequiredMarker` from `KProperty` has been modified to be done in a single loop.

In the current implementation, the process of getting the `RequiredMarker` from `KProperty` is performed separately by `AnnotatedMethod.getCorrespondingGetter` and `AnnotatedMethod.getCorrespondingSetter`.
`member.declaringClass.kotlin.declaredMemberProperties`, which is called in each of these two methods, is considered to be expensive to execute (I didn't run a benchmark to confirm this, but it seems so from the implementation).
Therefore, reducing the number of calls to it will speed up the process.

### Regarding `KFunction<*>.isSetterLike()`
Since the result of `Unit::class.createType()` executed by `KFunction<*>.isSetterLike()` is immutable, it has been modified to be used as a constant.
This process also seems to have been expensive to execute.

## Others
I also did some refactoring at the same time.

## Questions
Should `declaringClass.kotlin.declaredMemberProperties` also be cached as `Class` -> `List<KProperty1>`?
When serializing/deserializing a class with a large number of fields, it seems to be more efficient to cache this process as well.