### PR TITLE
`unbox` `value class` in `Map key` when serializing

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -80,3 +80,9 @@ internal fun Int.toBitSet(): BitSet {
     }
     return bits
 }
+
+// In the future, value class without JvmInline will be available, and unbox may not be able to handle it.
+// https://github.com/FasterXML/jackson-module-kotlin/issues/464
+// The JvmInline annotation can be given to Java class,
+// so the isKotlinClass decision is necessary (the order is preferable in terms of possible frequency).
+internal fun Class<*>.isUnboxableValueClass() = annotations.any { it is JvmInline } && this.isKotlinClass()

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -115,8 +115,8 @@ internal fun Int.toBitSet(): BitSet {
     return bits
 }
 
-// In the future, value class without JvmInline will be available, and unbox may not be able to handle it.
+// In the future, value classes without @JvmInline will be available, and unboxing may not be able to handle it.
 // https://github.com/FasterXML/jackson-module-kotlin/issues/464
-// The JvmInline annotation can be given to Java class,
+// The JvmInline annotation can be added to Java classes,
 // so the isKotlinClass decision is necessary (the order is preferable in terms of possible frequency).
 internal fun Class<*>.isUnboxableValueClass() = annotations.any { it is JvmInline } && this.isKotlinClass()

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
@@ -1,0 +1,33 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.databind.ser.Serializers
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.fasterxml.jackson.databind.type.TypeFactory
+
+internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.java) {
+    override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
+        val method = value::class.java.getMethod("unbox-impl")
+        val unboxed = method.invoke(value)
+
+        if (unboxed == null) {
+            val javaType = provider.typeFactory.constructType(method.genericReturnType)
+            provider.findNullKeySerializer(javaType, null).serialize(null, gen, provider)
+            return
+        }
+
+        provider.findKeySerializer(unboxed::class.java, null).serialize(unboxed, gen, provider)
+    }
+}
+
+class KotlinKeySerializers : Serializers.Base() {
+    override fun findSerializer(
+        config: SerializationConfig,
+        type: JavaType,
+        beanDesc: BeanDescription
+    ): JsonSerializer<*>? = when {
+        type.rawClass.isUnboxableValueClass() -> ValueClassUnboxKeySerializer
+        else -> null
+    }
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.ser.Serializers
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
-import com.fasterxml.jackson.databind.type.TypeFactory
 
 internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.java) {
     override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
@@ -21,7 +20,7 @@ internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.jav
     }
 }
 
-class KotlinKeySerializers : Serializers.Base() {
+internal class KotlinKeySerializers : Serializers.Base() {
     override fun findSerializer(
         config: SerializationConfig,
         type: JavaType,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -123,6 +123,7 @@ class KotlinModule @Deprecated(
 
         context.addDeserializers(KotlinDeserializers())
         context.addSerializers(KotlinSerializers())
+        context.addKeySerializers(KotlinKeySerializers())
 
         fun addMixIn(clazz: Class<*>, mixin: Class<*>) {
             context.setMixInAnnotations(clazz, mixin)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -45,7 +45,7 @@ object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
         val unboxed = value::class.java.getMethod("unbox-impl").invoke(value)
 
         if (unboxed == null) {
-            gen.writeNull()
+            provider.findNullValueSerializer(null).serialize(unboxed, gen, provider)
             return
         }
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.ser.Serializers
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
-import com.fasterxml.jackson.module.kotlin.ValueClassUnboxSerializer.isUnboxableValueClass
 import java.math.BigInteger
 
 object SequenceSerializer : StdSerializer<Sequence<*>>(Sequence::class.java) {
@@ -52,12 +51,6 @@ object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
 
         provider.findValueSerializer(unboxed::class.java).serialize(unboxed, gen, provider)
     }
-
-    // In the future, value class without JvmInline will be available, and unbox may not be able to handle it.
-    // https://github.com/FasterXML/jackson-module-kotlin/issues/464
-    // The JvmInline annotation can be given to Java class,
-    // so the isKotlinClass decision is necessary (the order is preferable in terms of possible frequency).
-    fun Class<*>.isUnboxableValueClass() = annotations.any { it is JvmInline } && this.isKotlinClass()
 }
 
 @Suppress("EXPERIMENTAL_API_USAGE")


### PR DESCRIPTION
This PR is a continuation of #468, and a fix for #469.
This change will also cause `unboxing` when `value class` is set as `key`.
The tests now reflect this as well.

## Repletion
### About the behavior when `WrapperClass` is set to `key`
#468 described a pattern that would `unbox` the `value class` field when the `WrapperClass` was set to `key`.
On the other hand, this appeared to be a behavior that improperly overrides the `toString` method of the `WrapperClass`, so it has been removed.

### Fixed `NullValueSerializer` being ignored when `unbox` result is `null`
In the previous PR, there was a problem that `null` was written ignoring the `NullValueSerializer` when the result of `unbox` was `null`.
Test cases have been added as well.

## Question
The `JSON string` output by `writerWithDefaultPrettyPrinter` respects the newline code of the platform, but the `Kotlin raw string` always seems to use `\n`.
This is why the `Github464` test is failing on my `Windows` environment.

How should I fix this problem?
I believe that replacing `\r\n` with `\n` for both output results would superficially solve the problem, but I'm wondering if there is a better fix.