### PR TITLE
treeToValue extensions function should not have type erasure

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -13,6 +13,10 @@ Authors:
 
 Contributors:
 
+Fedor Bobin (Fuud@github)
+* #496, #45: Fix treeToValue extension function should not have type erasure
+  (2.13)
+
 Mikhael Sokolov (sokomishalov@github)
 * #489: JsonNode, ArrayNode and ObjectNode extension functions
 
@@ -119,6 +123,3 @@ Konstantin Volivach (kostya05983@github)
 Laimonas Turauskas (Laimiux@github)
 * Contributed fix for #180: handle nullable method parameters correctly (for creator methods)
  (2.10.1)
-
-Fedor Bobin (Fuud@github)
-* Contributed fix for #496 and #45: treeToValue extension function should not have type erasure

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -119,3 +119,6 @@ Konstantin Volivach (kostya05983@github)
 Laimonas Turauskas (Laimiux@github)
 * Contributed fix for #180: handle nullable method parameters correctly (for creator methods)
  (2.10.1)
+
+Fedor Bobin (Fuud@github)
+* Contributed fix for #496 and #45: treeToValue extension function should not have type erasure

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -46,12 +46,12 @@ inline fun <reified T> ObjectMapper.readValue(src: Reader): T = readValue(src, j
 inline fun <reified T> ObjectMapper.readValue(src: InputStream): T = readValue(src, jacksonTypeRef<T>())
 inline fun <reified T> ObjectMapper.readValue(src: ByteArray): T = readValue(src, jacksonTypeRef<T>())
 
-inline fun <reified T> ObjectMapper.treeToValue(n: TreeNode): T? = treeToValue(n, T::class.java)
+inline fun <reified T> ObjectMapper.treeToValue(n: TreeNode): T? = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
 inline fun <reified T> ObjectMapper.convertValue(from: Any): T = convertValue(from, jacksonTypeRef<T>())
 
 inline fun <reified T> ObjectReader.readValueTyped(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
 inline fun <reified T> ObjectReader.readValuesTyped(jp: JsonParser): Iterator<T> = readValues(jp, jacksonTypeRef<T>())
-inline fun <reified T> ObjectReader.treeToValue(n: TreeNode): T? = treeToValue(n, T::class.java)
+inline fun <reified T> ObjectReader.treeToValue(n: TreeNode): T? = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
 
 operator fun ArrayNode.plus(element: Boolean) = Unit.apply { add(element) }
 operator fun ArrayNode.plus(element: Short) = Unit.apply { add(element) }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -46,7 +46,7 @@ inline fun <reified T> ObjectMapper.readValue(src: Reader): T = readValue(src, j
 inline fun <reified T> ObjectMapper.readValue(src: InputStream): T = readValue(src, jacksonTypeRef<T>())
 inline fun <reified T> ObjectMapper.readValue(src: ByteArray): T = readValue(src, jacksonTypeRef<T>())
 
-inline fun <reified T> ObjectMapper.treeToValue(n: TreeNode): T? = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
+inline fun <reified T> ObjectMapper.treeToValue(n: TreeNode): T = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
 inline fun <reified T> ObjectMapper.convertValue(from: Any): T = convertValue(from, jacksonTypeRef<T>())
 
 inline fun <reified T> ObjectReader.readValueTyped(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ExtensionMethodsTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ExtensionMethodsTests.kt
@@ -61,4 +61,19 @@ class TestExtensionMethods {
         (4 downTo 0).forEach { arrayNode -= it }
         assertThat(arrayNode.size(), `is`(0))
     }
+
+    @Test fun noTypeErasure(){
+        data class Person(val name: String)
+        val source = """[ { "name" : "Neo" } ]"""
+        val tree = mapper.readTree(source)
+
+        val readValueResult: List<Person> = mapper.readValue(source)
+        assertThat(readValueResult, `is`(listOf(Person("Neo"))))
+
+        val treeToValueResult: List<Person> = mapper.treeToValue(tree)
+        assertThat(treeToValueResult, `is`(listOf(Person("Neo"))))
+
+        val convertValueResult: List<Person> = mapper.convertValue(tree)
+        assertThat(convertValueResult, `is`(listOf(Person("Neo"))))
+    }
 }


### PR DESCRIPTION
It is fix for #496 and #45 