### PR TITLE
Refactor KNAI.hasCreatorAnnotation

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -55,15 +55,6 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
         return null
     }
 
-    // if has parameters, is a Kotlin class, and the parameters all have parameter annotations, then pretend we have a JsonCreator
-    private fun AnnotatedConstructor.isKotlinConstructorWithParameters(): Boolean =
-        parameterCount > 0 && declaringClass.isKotlinClass() && !declaringClass.isEnum
-
-    private fun KFunction<*>.isPossibleSingleString(propertyNames: Set<String>): Boolean = parameters.size == 1 &&
-            parameters[0].name !in propertyNames &&
-            parameters[0].type.javaType == String::class.java &&
-            !parameters[0].hasAnnotation<JsonProperty>()
-
     @Suppress("UNCHECKED_CAST")
     override fun hasCreatorAnnotation(member: Annotated): Boolean {
         // don't add a JsonCreator to any constructor if one is declared already
@@ -159,3 +150,12 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
     ReplaceWith("with(receiver) { declaringClass.declaredMethods.any { it.name.contains('-') } }")
 )
 private fun AnnotatedMethod.isInlineClass() = declaringClass.declaredMethods.any { it.name.contains('-') }
+
+// if has parameters, is a Kotlin class, and the parameters all have parameter annotations, then pretend we have a JsonCreator
+private fun AnnotatedConstructor.isKotlinConstructorWithParameters(): Boolean =
+    parameterCount > 0 && declaringClass.isKotlinClass() && !declaringClass.isEnum
+
+private fun KFunction<*>.isPossibleSingleString(propertyNames: Set<String>): Boolean = parameters.size == 1 &&
+        parameters[0].name !in propertyNames &&
+        parameters[0].type.javaType == String::class.java &&
+        !parameters[0].hasAnnotation<JsonProperty>()

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -59,9 +59,8 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
     private fun hasCreatorAnnotation(member: AnnotatedConstructor): Boolean {
         // don't add a JsonCreator to any constructor if one is declared already
 
-        val kClass = cache.kotlinFromJava(member.declaringClass as Class<Any>).apply {
-            if (this in ignoredClassesForImplyingJsonCreator) return false
-        }
+        val kClass = cache.kotlinFromJava(member.declaringClass as Class<Any>)
+            .apply { if (this in ignoredClassesForImplyingJsonCreator) return false }
         val kConstructor = cache.kotlinFromJava(member.annotated as Constructor<Any>)
 
         return if (kConstructor != null) {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -14,11 +14,15 @@ import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
 import com.fasterxml.jackson.databind.util.BeanUtil
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
-import java.util.*
+import java.util.Locale
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
-import kotlin.reflect.full.*
+import kotlin.reflect.full.companionObject
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.kotlinFunction

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -59,7 +59,9 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
     private fun hasCreatorAnnotation(member: AnnotatedConstructor): Boolean {
         // don't add a JsonCreator to any constructor if one is declared already
 
-        val kClass = cache.kotlinFromJava(member.declaringClass as Class<Any>)
+        val kClass = cache.kotlinFromJava(member.declaringClass as Class<Any>).apply {
+            if (this in ignoredClassesForImplyingJsonCreator) return false
+        }
         val kConstructor = cache.kotlinFromJava(member.annotated as Constructor<Any>)
 
         return if (kConstructor != null) {
@@ -89,7 +91,6 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
                     && !(anyConstructorHasJsonCreator || anyCompanionMethodIsJsonCreator)
                     && areAllParametersValid
                     && !isSingleStringConstructor
-                    && kClass !in ignoredClassesForImplyingJsonCreator
         } else {
             false
         }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -66,8 +66,8 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
     override fun hasCreatorAnnotation(member: Annotated): Boolean {
         // don't add a JsonCreator to any constructor if one is declared already
 
-        if (member is AnnotatedConstructor && member.isKotlinConstructorWithParameters()) {
-            return cache.checkConstructorIsCreatorAnnotated(member) {
+        return if (member is AnnotatedConstructor && member.isKotlinConstructorWithParameters()) {
+            cache.checkConstructorIsCreatorAnnotated(member) {
                 val kClass = cache.kotlinFromJava(member.declaringClass as Class<Any>)
                 val kConstructor = cache.kotlinFromJava(member.annotated as Constructor<Any>)
 
@@ -118,8 +118,7 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
                     false
                 }
             }
-        }
-        return false
+        } else false
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -83,7 +83,7 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
             // val requiredProperties = kClass.declaredMemberProperties.filter {!it.returnType.isMarkedNullable }.map { it.name }.toSet()
             // val areAllRequiredParametersInConstructor = kConstructor.parameters.all { requiredProperties.contains(it.name) }
 
-            val areAllParametersValid = kConstructor.parameters.size == kConstructor.parameters.count { it.name != null }
+            val areAllParametersValid = kConstructor.parameters.all { it.name != null }
 
             val isSingleStringConstructor = kConstructor.isPossibleSingleString(propertyNames)
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -63,31 +63,29 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
             .apply { if (this in ignoredClassesForImplyingJsonCreator) return false }
         val kConstructor = cache.kotlinFromJava(member.annotated as Constructor<Any>) ?: return false
 
-        val isPrimaryConstructor = kClass.isPrimaryConstructor(kConstructor)
-
-        val propertyNames = kClass.memberProperties.map { it.name }.toSet()
-
-        val anyConstructorHasJsonCreator = kClass.constructors
-            .filterOutSingleStringCallables(propertyNames)
-            .any { it.hasAnnotation<JsonCreator>() }
-
-        val anyCompanionMethodIsJsonCreator = member.type.rawClass.kotlin.companionObject?.declaredFunctions
-            ?.filterOutSingleStringCallables(propertyNames)
-            ?.any { it.hasAnnotation<JsonCreator>() && it.hasAnnotation<JvmStatic>() }
-            ?: false
-
         // TODO:  should we do this check or not?  It could cause failures if we miss another way a property could be set
         // val requiredProperties = kClass.declaredMemberProperties.filter {!it.returnType.isMarkedNullable }.map { it.name }.toSet()
         // val areAllRequiredParametersInConstructor = kConstructor.parameters.all { requiredProperties.contains(it.name) }
 
-        val areAllParametersValid = kConstructor.parameters.all { it.name != null }
+        val propertyNames = kClass.memberProperties.map { it.name }.toSet()
 
-        val isSingleStringConstructor = kConstructor.isPossibleSingleString(propertyNames)
+        return when {
+            kConstructor.isPossibleSingleString(propertyNames) -> false
+            kConstructor.parameters.any { it.name == null } -> false
+            !kClass.isPrimaryConstructor(kConstructor) -> false
+            else -> {
+                val anyConstructorHasJsonCreator = kClass.constructors
+                    .filterOutSingleStringCallables(propertyNames)
+                    .any { it.hasAnnotation<JsonCreator>() }
 
-        return isPrimaryConstructor
-                && !(anyConstructorHasJsonCreator || anyCompanionMethodIsJsonCreator)
-                && areAllParametersValid
-                && !isSingleStringConstructor
+                val anyCompanionMethodIsJsonCreator = member.type.rawClass.kotlin.companionObject?.declaredFunctions
+                    ?.filterOutSingleStringCallables(propertyNames)
+                    ?.any { it.hasAnnotation<JsonCreator>() && it.hasAnnotation<JvmStatic>() }
+                    ?: false
+
+                !(anyConstructorHasJsonCreator || anyCompanionMethodIsJsonCreator)
+            }
+        }
     }
 
     override fun hasCreatorAnnotation(member: Annotated): Boolean =

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -18,10 +18,7 @@ import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
-import kotlin.reflect.full.companionObject
-import kotlin.reflect.full.declaredFunctions
-import kotlin.reflect.full.memberProperties
-import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.full.*
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.kotlinFunction
@@ -65,7 +62,7 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
     private fun KFunction<*>.isPossibleSingleString(propertyNames: Set<String>): Boolean = parameters.size == 1 &&
             parameters[0].name !in propertyNames &&
             parameters[0].type.javaType == String::class.java &&
-            parameters[0].annotations.none { it.annotationClass.java == JsonProperty::class.java }
+            !parameters[0].hasAnnotation<JsonProperty>()
 
     @Suppress("UNCHECKED_CAST")
     override fun hasCreatorAnnotation(member: Annotated): Boolean {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -87,13 +87,11 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
 
                     val isSingleStringConstructor = kConstructor.isPossibleSingleString(propertyNames)
 
-                    val implyCreatorAnnotation = isPrimaryConstructor
+                    isPrimaryConstructor
                             && !(anyConstructorHasJsonCreator || anyCompanionMethodIsJsonCreator)
                             && areAllParametersValid
                             && !isSingleStringConstructor
                             && kClass !in ignoredClassesForImplyingJsonCreator
-
-                    implyCreatorAnnotation
                 } else {
                     false
                 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -151,5 +151,6 @@ private fun KFunction<*>.isPossibleSingleString(propertyNames: Set<String>): Boo
 private fun Collection<KFunction<*>>.filterOutSingleStringCallables(propertyNames: Set<String>): Collection<KFunction<*>> =
     this.filter { !it.isPossibleSingleString(propertyNames) }
 
-private fun KClass<*>.isPrimaryConstructor(kConstructor: KFunction<*>) = this.primaryConstructor == kConstructor ||
-        (this.primaryConstructor == null && this.constructors.size == 1)
+private fun KClass<*>.isPrimaryConstructor(kConstructor: KFunction<*>) = this.primaryConstructor.let {
+    it == kConstructor || (it == null && this.constructors.size == 1)
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -63,8 +63,7 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
             .apply { if (this in ignoredClassesForImplyingJsonCreator) return false }
         val kConstructor = cache.kotlinFromJava(member.annotated as Constructor<Any>) ?: return false
 
-        val isPrimaryConstructor = kClass.primaryConstructor == kConstructor ||
-                (kClass.primaryConstructor == null && kClass.constructors.size == 1)
+        val isPrimaryConstructor = kClass.isPrimaryConstructor(kConstructor)
 
         val propertyNames = kClass.memberProperties.map { it.name }.toSet()
 
@@ -153,3 +152,6 @@ private fun KFunction<*>.isPossibleSingleString(propertyNames: Set<String>): Boo
 
 private fun Collection<KFunction<*>>.filterOutSingleStringCallables(propertyNames: Set<String>): Collection<KFunction<*>> =
     this.filter { !it.isPossibleSingleString(propertyNames) }
+
+private fun KClass<*>.isPrimaryConstructor(kConstructor: KFunction<*>) = this.primaryConstructor == kConstructor ||
+        (this.primaryConstructor == null && this.constructors.size == 1)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -70,15 +70,14 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
 
                     val propertyNames = kClass.memberProperties.map { it.name }.toSet()
 
-                    val anyConstructorHasJsonCreator = kClass.constructors.filterOutSingleStringCallables(propertyNames)
-                            .any { it.annotations.any { it.annotationClass.java == JsonCreator::class.java }
-                            }
+                    val anyConstructorHasJsonCreator = kClass.constructors
+                        .filterOutSingleStringCallables(propertyNames)
+                        .any { it.hasAnnotation<JsonCreator>() }
 
                     val anyCompanionMethodIsJsonCreator = member.type.rawClass.kotlin.companionObject?.declaredFunctions
-                            ?.filterOutSingleStringCallables(propertyNames)?.any {
-                                it.annotations.any { it.annotationClass.java == JvmStatic::class.java } &&
-                                        it.annotations.any { it.annotationClass.java == JsonCreator::class.java }
-                            } ?: false
+                        ?.filterOutSingleStringCallables(propertyNames)
+                        ?.any { it.hasAnnotation<JsonCreator>() && it.hasAnnotation<JvmStatic>() }
+                        ?: false
 
                     // TODO:  should we do this check or not?  It could cause failures if we miss another way a property could be set
                     // val requiredProperties = kClass.declaredMemberProperties.filter {!it.returnType.isMarkedNullable }.map { it.name }.toSet()


### PR DESCRIPTION
Since `KNAI.hasCreatorAnnotation` is a huge and complex process, and at the same time, some grammatical warnings were given, I divided the process and suppressed the warnings.
In addition, we changed it to the form that the judgment with low cost is done first and returns early, so the processing efficiency is expected to be improved by omitting the reflection process.

There are a lot of changes in the whole PR, but if you follow each commit, it will be easier to read the changes.