### PR TITLE
Refactor KVI

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ConstructorValueCreator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ConstructorValueCreator.kt
@@ -1,0 +1,12 @@
+package com.fasterxml.jackson.module.kotlin
+
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.isAccessible
+
+internal class ConstructorValueCreator<T>(override val callable: KFunction<T>) : ValueCreator<T>() {
+    override val accessible: Boolean = callable.isAccessible
+
+    init {
+        callable.isAccessible = true
+    }
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -3,24 +3,15 @@ package com.fasterxml.jackson.module.kotlin
 import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.DeserializationConfig
 import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty
 import com.fasterxml.jackson.databind.deser.ValueInstantiator
 import com.fasterxml.jackson.databind.deser.ValueInstantiators
 import com.fasterxml.jackson.databind.deser.impl.NullsAsEmptyProvider
 import com.fasterxml.jackson.databind.deser.impl.PropertyValueBuffer
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
-import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
-import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
-import java.lang.reflect.Constructor
-import java.lang.reflect.Method
 import java.lang.reflect.TypeVariable
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
-import kotlin.reflect.full.extensionReceiverParameter
-import kotlin.reflect.full.instanceParameter
-import kotlin.reflect.full.valueParameters
-import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaType
 
 internal class KotlinValueInstantiator(
@@ -31,62 +22,35 @@ internal class KotlinValueInstantiator(
     private val nullIsSameAsDefault: Boolean,
     private val strictNullChecks: Boolean
 ) : StdValueInstantiator(src) {
-    @Suppress("UNCHECKED_CAST")
     override fun createFromObjectWith(
         ctxt: DeserializationContext,
         props: Array<out SettableBeanProperty>,
         buffer: PropertyValueBuffer
     ): Any? {
-        val callable = when (_withArgsCreator) {
-            is AnnotatedConstructor -> cache.kotlinFromJava(_withArgsCreator.annotated as Constructor<Any>)
-            is AnnotatedMethod -> cache.kotlinFromJava(_withArgsCreator.annotated as Method)
-            else -> throw IllegalStateException("Expected a constructor or method to create a Kotlin object, instead found ${_withArgsCreator.annotated.javaClass.name}")
-        } ?: return super.createFromObjectWith(
-            ctxt,
-            props,
-            buffer
-        ) // we cannot reflect this method so do the default Java-ish behavior
+        // TODO: cache ValueCreator
+        val valueCreator: ValueCreator<*> = ValueCreator.of(_withArgsCreator, cache)
+            ?: return super.createFromObjectWith(ctxt, props, buffer)
 
-        if (callable.extensionReceiverParameter != null) {
-            // we shouldn't have an instance or receiver parameter and if we do, just go with default Java-ish behavior
-            return super.createFromObjectWith(ctxt, props, buffer)
+        val propCount: Int
+        var numCallableParameters: Int
+        val callableParameters: Array<KParameter?>
+        val jsonParamValueList: Array<Any?>
+
+        if (valueCreator is MethodValueCreator) {
+            propCount = props.size + 1
+            numCallableParameters = 1
+            callableParameters = arrayOfNulls<KParameter>(propCount)
+                .apply { this[0] = valueCreator.instanceParameter }
+            jsonParamValueList = arrayOfNulls<Any>(propCount)
+                .apply { this[0] = valueCreator.companionObjectInstance }
+        } else {
+            propCount = props.size
+            numCallableParameters = 0
+            callableParameters = arrayOfNulls(propCount)
+            jsonParamValueList = arrayOfNulls(propCount)
         }
 
-        val propCount = props.size + if (callable.instanceParameter != null) 1 else 0
-
-        var numCallableParameters = 0
-        val callableParameters = arrayOfNulls<KParameter>(propCount)
-        val jsonParamValueList = arrayOfNulls<Any>(propCount)
-
-        if (callable.instanceParameter != null) {
-            val possibleCompanion = callable.instanceParameter!!.type.erasedType().kotlin
-
-            if (!possibleCompanion.isCompanion) {
-                // abort, we have some unknown case here
-                return super.createFromObjectWith(ctxt, props, buffer)
-            }
-
-            // TODO: cache this lookup since the exception throwing/catching can be expensive
-            jsonParamValueList[numCallableParameters] = try {
-                possibleCompanion.objectInstance
-            } catch (ex: IllegalAccessException) {
-                // fallback for when an odd access exception happens through Kotlin reflection
-                val companionField = possibleCompanion.java.enclosingClass.fields.firstOrNull { it.type.kotlin.isCompanion }
-                        ?: throw ex
-                val accessible = companionField.isAccessible
-                if ((!accessible && ctxt.config.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) ||
-                    (accessible && ctxt.config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS))
-                ) {
-                    companionField.isAccessible = true
-                }
-                companionField.get(null) ?: throw ex
-            }
-
-            callableParameters[numCallableParameters] = callable.instanceParameter
-            numCallableParameters++
-        }
-
-        callable.valueParameters.forEachIndexed { idx, paramDef ->
+        valueCreator.valueParameters.forEachIndexed { idx, paramDef ->
             val jsonProp = props[idx]
             val isMissing = !buffer.hasParameter(jsonProp)
 
@@ -157,23 +121,17 @@ internal class KotlinValueInstantiator(
             numCallableParameters++
         }
 
-        return if (numCallableParameters == jsonParamValueList.size && callable.instanceParameter == null) {
+        return if (numCallableParameters == jsonParamValueList.size && valueCreator is ConstructorValueCreator) {
             // we didn't do anything special with default parameters, do a normal call
             super.createFromObjectWith(ctxt, jsonParamValueList)
         } else {
-            val accessible = callable.isAccessible
-            if ((!accessible && ctxt.config.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) ||
-                (accessible && ctxt.config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS))
-            ) {
-                callable.isAccessible = true
-            }
             val callableParametersByName = linkedMapOf<KParameter, Any?>()
             callableParameters.mapIndexed { idx, paramDef ->
                 if (paramDef != null) {
                     callableParametersByName[paramDef] = jsonParamValueList[idx]
                 }
             }
-            callable.callBy(callableParametersByName)
+            valueCreator.callBy(callableParametersByName)
         }
 
     }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -27,8 +27,7 @@ internal class KotlinValueInstantiator(
         props: Array<out SettableBeanProperty>,
         buffer: PropertyValueBuffer
     ): Any? {
-        // TODO: cache ValueCreator
-        val valueCreator: ValueCreator<*> = ValueCreator.of(_withArgsCreator, cache)
+        val valueCreator: ValueCreator<*> = cache.valueCreatorFromJava(_withArgsCreator)
             ?: return super.createFromObjectWith(ctxt, props, buffer)
 
         val propCount: Int

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -124,6 +124,8 @@ internal class KotlinValueInstantiator(
             // we didn't do anything special with default parameters, do a normal call
             super.createFromObjectWith(ctxt, jsonParamValueList)
         } else {
+            valueCreator.checkAccessibility(ctxt)
+
             val callableParametersByName = linkedMapOf<KParameter, Any?>()
             callableParameters.mapIndexed { idx, paramDef ->
                 if (paramDef != null) {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/MethodValueCreator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/MethodValueCreator.kt
@@ -1,0 +1,46 @@
+package com.fasterxml.jackson.module.kotlin
+
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.extensionReceiverParameter
+import kotlin.reflect.full.instanceParameter
+import kotlin.reflect.jvm.isAccessible
+
+internal class MethodValueCreator<T> private constructor(
+    override val callable: KFunction<T>,
+    override val accessible: Boolean,
+    val companionObjectInstance: Any
+) : ValueCreator<T>() {
+    val instanceParameter: KParameter = callable.instanceParameter!!
+
+    companion object {
+        fun <T> of(callable: KFunction<T>): MethodValueCreator<T>? {
+            // we shouldn't have an instance or receiver parameter and if we do, just go with default Java-ish behavior
+            if (callable.extensionReceiverParameter != null) return null
+
+            val possibleCompanion = callable.instanceParameter!!.type.erasedType().kotlin
+
+            // abort, we have some unknown case here
+            if (!possibleCompanion.isCompanion) return null
+
+            val (companionObjectInstance: Any, accessible: Boolean) = try {
+                // throws ex
+                val instance = possibleCompanion.objectInstance!!
+                // If an instance of the companion object can be obtained, accessibility depends on the KFunction
+                instance to callable.isAccessible
+            } catch (ex: IllegalAccessException) {
+                // fallback for when an odd access exception happens through Kotlin reflection
+                possibleCompanion.java.enclosingClass.fields
+                    .firstOrNull { it.type.kotlin.isCompanion }
+                    ?.let {
+                        it.isAccessible = true
+
+                        // If the instance of the companion object cannot be obtained, accessibility will always be false
+                        it.get(null) to false
+                    } ?: throw ex
+            }
+
+            return MethodValueCreator(callable, accessible, companionObjectInstance)
+        }
+    }
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -66,7 +66,6 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
             javaConstructorToValueCreator.get(constructor)
                 ?: kotlinFromJava(constructor)?.let {
                     val value = ConstructorValueCreator(it)
-
                     javaConstructorToValueCreator.putIfAbsent(constructor, value) ?: value
                 }
         }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.module.kotlin
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
+import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams
 import com.fasterxml.jackson.databind.util.LRUMap
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
@@ -35,6 +36,8 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
     private val javaClassToKotlin = LRUMap<Class<Any>, KClass<Any>>(reflectionCacheSize, reflectionCacheSize)
     private val javaConstructorToKotlin = LRUMap<Constructor<Any>, KFunction<Any>>(reflectionCacheSize, reflectionCacheSize)
     private val javaMethodToKotlin = LRUMap<Method, KFunction<*>>(reflectionCacheSize, reflectionCacheSize)
+    private val javaConstructorToValueCreator = LRUMap<Constructor<Any>, ConstructorValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
+    private val javaMethodToValueCreator = LRUMap<Method, MethodValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
     private val javaConstructorIsCreatorAnnotated = LRUMap<AnnotatedConstructor, Boolean>(reflectionCacheSize, reflectionCacheSize)
     private val javaMemberIsRequired = LRUMap<AnnotatedMember, BooleanTriState?>(reflectionCacheSize, reflectionCacheSize)
     private val kotlinGeneratedMethod = LRUMap<AnnotatedMethod, Boolean>(reflectionCacheSize, reflectionCacheSize)
@@ -48,6 +51,37 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
 
     fun kotlinFromJava(key: Method): KFunction<*>? = javaMethodToKotlin.get(key)
             ?: key.kotlinFunction?.let { javaMethodToKotlin.putIfAbsent(key, it) ?: it }
+
+    /**
+     * return null if...
+     * - can't get kotlinFunction
+     * - contains extensionReceiverParameter
+     * - instance parameter is not companion object or can't get
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun valueCreatorFromJava(_withArgsCreator: AnnotatedWithParams): ValueCreator<*>? = when (_withArgsCreator) {
+        is AnnotatedConstructor -> {
+            val constructor = _withArgsCreator.annotated as Constructor<Any>
+
+            javaConstructorToValueCreator.get(constructor)
+                ?: kotlinFromJava(constructor)?.let {
+                    val value = ConstructorValueCreator(it)
+
+                    javaConstructorToValueCreator.putIfAbsent(constructor, value) ?: value
+                }
+        }
+        is AnnotatedMethod -> {
+            val method = _withArgsCreator.annotated as Method
+
+            javaMethodToValueCreator.get(method)
+                ?: kotlinFromJava(method)?.let {
+                    val value = MethodValueCreator.of(it)
+
+                    javaMethodToValueCreator.putIfAbsent(method, value) ?: value
+                }
+        }
+        else -> throw IllegalStateException("Expected a constructor or method to create a Kotlin object, instead found ${_withArgsCreator.annotated.javaClass.name}")
+    } // we cannot reflect this method so do the default Java-ish behavior
 
     fun checkConstructorIsCreatorAnnotated(key: AnnotatedConstructor, calc: (AnnotatedConstructor) -> Boolean): Boolean = javaConstructorIsCreatorAnnotated.get(key)
             ?: calc(key).let { javaConstructorIsCreatorAnnotated.putIfAbsent(key, it) ?: it }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -76,7 +76,6 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
             javaMethodToValueCreator.get(method)
                 ?: kotlinFromJava(method)?.let {
                     val value = MethodValueCreator.of(it)
-
                     javaMethodToValueCreator.putIfAbsent(method, value) ?: value
                 }
         }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ValueCreator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ValueCreator.kt
@@ -1,0 +1,64 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
+import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams
+import java.lang.reflect.Constructor
+import java.lang.reflect.Method
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.valueParameters
+
+/**
+ * A class that abstracts the creation of instances by calling KFunction.
+ * @see KotlinValueInstantiator
+ */
+internal sealed class ValueCreator<T> {
+    /**
+     * Function to be call.
+     */
+    protected abstract val callable: KFunction<T>
+
+    /**
+     * Initial value for accessibility by reflection.
+     */
+    protected abstract val accessible: Boolean
+
+    /**
+     * ValueParameters of the KFunction to be called.
+     */
+    val valueParameters: List<KParameter> by lazy { callable.valueParameters }
+
+    /**
+     * Checking process to see if access from context is possible.
+     * @throws  IllegalAccessException
+     */
+    fun checkAccessibility(ctxt: DeserializationContext) {
+        if ((!accessible && ctxt.config.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) ||
+            (accessible && ctxt.config.isEnabled(MapperFeature.OVERRIDE_PUBLIC_ACCESS_MODIFIERS))) {
+            return
+        }
+
+        throw IllegalAccessException("Cannot access to function or companion object instance, target: $callable")
+    }
+
+    /**
+     * Function call with default values enabled.
+     */
+    fun callBy(args: Map<KParameter, Any?>): T = callable.callBy(args)
+
+    companion object {
+        @Suppress("UNCHECKED_CAST")
+        fun of(
+            _withArgsCreator: AnnotatedWithParams, cache: ReflectionCache
+        ): ValueCreator<*>? = when (_withArgsCreator) {
+            is AnnotatedConstructor -> cache.kotlinFromJava(_withArgsCreator.annotated as Constructor<Any>)
+                ?.let { ConstructorValueCreator(it) }
+            is AnnotatedMethod -> cache.kotlinFromJava(_withArgsCreator.annotated as Method)
+                ?.let { MethodValueCreator.of(it) }
+            else -> throw IllegalStateException("Expected a constructor or method to create a Kotlin object, instead found ${_withArgsCreator.annotated.javaClass.name}")
+        } // we cannot reflect this method so do the default Java-ish behavior
+    }
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ValueCreator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ValueCreator.kt
@@ -2,11 +2,6 @@ package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.MapperFeature
-import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
-import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
-import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams
-import java.lang.reflect.Constructor
-import java.lang.reflect.Method
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.valueParameters
@@ -48,17 +43,4 @@ internal sealed class ValueCreator<T> {
      * Function call with default values enabled.
      */
     fun callBy(args: Map<KParameter, Any?>): T = callable.callBy(args)
-
-    companion object {
-        @Suppress("UNCHECKED_CAST")
-        fun of(
-            _withArgsCreator: AnnotatedWithParams, cache: ReflectionCache
-        ): ValueCreator<*>? = when (_withArgsCreator) {
-            is AnnotatedConstructor -> cache.kotlinFromJava(_withArgsCreator.annotated as Constructor<Any>)
-                ?.let { ConstructorValueCreator(it) }
-            is AnnotatedMethod -> cache.kotlinFromJava(_withArgsCreator.annotated as Method)
-                ?.let { MethodValueCreator.of(it) }
-            else -> throw IllegalStateException("Expected a constructor or method to create a Kotlin object, instead found ${_withArgsCreator.annotated.javaClass.name}")
-        } // we cannot reflect this method so do the default Java-ish behavior
-    }
 }


### PR DESCRIPTION
This PR is a partial realization of the first step of the 3-step change I suggested in my comment #439.

## Changes from existing
Many of the reflection operations performed by the `KotlinValueInstantiator` are now cached.
This is expected to speed up the process since the reflection process is omitted.

The results of the [benchmark](https://github.com/k163377/jackson-kotlin-benchmark-sample/tree/c86be72ed4f5b68d6ff0aef19ed53e67f57db189) comparison are as follows.
From this result, we can see that it is actually faster.

*before*

```
Benchmark                                           Mode  Cnt        Score        Error  Units
c.w.constructor.Benchmarks.useDefaultKotlinMapper  thrpt    9   639074.213 ±  19600.918  ops/s
c.w.constructor.Benchmarks.useJavaMapper           thrpt    9  2883418.695 ± 117219.003  ops/s
c.w.constructor.Benchmarks.useKotlinMapper         thrpt    9  1163349.939 ±  34378.903  ops/s
c.w.factory.Benchmarks.useDefaultKotlinMapper      thrpt    9   556424.552 ±  10447.484  ops/s
c.w.factory.Benchmarks.useJavaMapper               thrpt    9  2848669.598 ±  25770.187  ops/s
c.w.factory.Benchmarks.useKotlinMapper             thrpt    9   571255.239 ±  14027.060  ops/s
```

*after*

```
Benchmark                                           Mode  Cnt        Score        Error  Units
c.w.constructor.Benchmarks.useDefaultKotlinMapper  thrpt    9   775820.306 ±  40891.839  ops/s
c.w.constructor.Benchmarks.useJavaMapper           thrpt    9  2823625.426 ± 107884.530  ops/s
c.w.constructor.Benchmarks.useKotlinMapper         thrpt    9  1312132.093 ±   6461.389  ops/s
c.w.factory.Benchmarks.useDefaultKotlinMapper      thrpt    9   749118.995 ±   2194.277  ops/s
c.w.factory.Benchmarks.useJavaMapper               thrpt    9  2873057.532 ± 142978.335  ops/s
c.w.factory.Benchmarks.useKotlinMapper             thrpt    9   820204.472 ±  32521.224  ops/s
```

## Changes from #439
The class that was originally named `Instantiator` has been changed to `ValueCreator`.
Because the name `Instantiator` seemed to be confusing with the keyword derived from `Jackson`.

Also, the content that was originally defined as just an `interface` has been changed to a `sealed class`.
This makes it easier to standardize the process and improve the handling of conditional expressions.

## Others
I don't think it's necessary to make it `ExperimentalDeserializationBackend`, since many of the changes are based on existing content.
Therefore, I have not incorporated the relevant changes.

Also, to keep the size of the PR small, I have not yet refactored the `KVI.createFromObjectWith` function, such as splitting it.
I plan to do that after this PR is merged.
