### PR TITLE
Add `KeyDeserializers` for `unsigned integers`

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.core.JsonParser

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
@@ -1,0 +1,72 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.core.exc.InputCoercionException
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer
+import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializers
+
+// The reason why key is treated as nullable is to match the tentative behavior of StdKeyDeserializer.
+// If StdKeyDeserializer is modified, need to modify this too.
+
+internal object UByteKeyDeserializer : StdKeyDeserializer(TYPE_SHORT, UByte::class.java) {
+    override fun deserializeKey(key: String?, ctxt: DeserializationContext): UByte? = super.deserializeKey(key, ctxt)
+        ?.let {
+            (it as Short).asUByte() ?: throw InputCoercionException(
+                null,
+                "Numeric value (${key}) out of range of UByte (0 - ${UByte.MAX_VALUE}).",
+                JsonToken.VALUE_NUMBER_INT,
+                UByte::class.java
+            )
+        }
+}
+
+internal object UShortKeyDeserializer : StdKeyDeserializer(TYPE_INT, UShort::class.java) {
+    override fun deserializeKey(key: String?, ctxt: DeserializationContext): UShort? = super.deserializeKey(key, ctxt)
+        ?.let {
+            (it as Int).asUShort() ?: throw InputCoercionException(
+                null,
+                "Numeric value (${key}) out of range of UShort (0 - ${UShort.MAX_VALUE}).",
+                JsonToken.VALUE_NUMBER_INT,
+                UShort::class.java
+            )
+        }
+}
+
+internal object UIntKeyDeserializer : StdKeyDeserializer(TYPE_LONG, UInt::class.java) {
+    override fun deserializeKey(key: String?, ctxt: DeserializationContext): UInt? = super.deserializeKey(key, ctxt)
+        ?.let {
+            (it as Long).asUInt() ?: throw InputCoercionException(
+                null,
+                "Numeric value (${key}) out of range of UInt (0 - ${UInt.MAX_VALUE}).",
+                JsonToken.VALUE_NUMBER_INT,
+                UInt::class.java
+            )
+        }
+}
+
+// kind parameter is dummy.
+internal object ULongKeyDeserializer : StdKeyDeserializer(TYPE_LONG, ULong::class.java) {
+    override fun deserializeKey(key: String?, ctxt: DeserializationContext): ULong? = key?.let {
+        it.toBigInteger().asULong() ?: throw InputCoercionException(
+            null,
+            "Numeric value (${key}) out of range of ULong (0 - ${ULong.MAX_VALUE}).",
+            JsonToken.VALUE_NUMBER_INT,
+            ULong::class.java
+        )
+    }
+}
+
+internal object KotlinKeyDeserializers : StdKeyDeserializers() {
+    override fun findKeyDeserializer(
+        type: JavaType,
+        config: DeserializationConfig?,
+        beanDesc: BeanDescription?
+    ): KeyDeserializer? = when (type.rawClass) {
+        UByte::class.java -> UByteKeyDeserializer
+        UShort::class.java -> UShortKeyDeserializer
+        UInt::class.java -> UIntKeyDeserializer
+        ULong::class.java -> ULongKeyDeserializer
+        else -> null
+    }
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -122,6 +122,7 @@ class KotlinModule @Deprecated(
         context.appendAnnotationIntrospector(KotlinNamesAnnotationIntrospector(this, cache, ignoredClassesForImplyingJsonCreator))
 
         context.addDeserializers(KotlinDeserializers())
+        context.addKeyDeserializers(KotlinKeyDeserializers)
         context.addSerializers(KotlinSerializers())
         context.addKeySerializers(KotlinKeySerializers())
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.core.JsonGenerator
@@ -57,7 +55,6 @@ object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
     }
 }
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 internal class KotlinSerializers : Serializers.Base() {
     override fun findSerializer(
         config: SerializationConfig?,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/UnsignedNumbers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/UnsignedNumbers.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package com.fasterxml.jackson.module.kotlin
 
 import java.math.BigInteger

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersOnKeyTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersOnKeyTest.kt
@@ -1,0 +1,111 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.core.exc.InputCoercionException
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.math.BigInteger
+import kotlin.test.assertEquals
+
+internal class UnsignedNumbersOnKeyTest {
+    companion object {
+        val MAPPER = jacksonObjectMapper()
+    }
+
+    class ForUByte {
+        private fun makeSrc(v: Int): String = MAPPER.writeValueAsString(mapOf(v to 0))
+
+        @Test
+        fun test() {
+            val actual = MAPPER.readValue<Map<UByte, UByte>>(makeSrc(UByte.MAX_VALUE.toInt()))
+            assertEquals(mapOf(UByte.MAX_VALUE to 0.toUByte()), actual)
+        }
+
+        @Test
+        fun overflow() {
+            assertThrows(InputCoercionException::class.java) {
+                MAPPER.readValue<Map<UByte, UByte>>(makeSrc(UByte.MAX_VALUE.toInt() + 1))
+            }
+        }
+
+        @Test
+        fun underflow() {
+            assertThrows(InputCoercionException::class.java) {
+                MAPPER.readValue<Map<UByte, UByte>>(makeSrc(-1))
+            }
+        }
+    }
+
+    class ForUShort {
+        private fun makeSrc(v: Int): String = MAPPER.writeValueAsString(mapOf(v to 0))
+
+        @Test
+        fun test() {
+            val actual = MAPPER.readValue<Map<UShort, UShort>>(makeSrc(UShort.MAX_VALUE.toInt()))
+            assertEquals(mapOf(UShort.MAX_VALUE to 0.toUShort()), actual)
+        }
+
+        @Test
+        fun overflow() {
+            assertThrows(InputCoercionException::class.java) {
+                MAPPER.readValue<Map<UShort, UShort>>(makeSrc(UShort.MAX_VALUE.toInt() + 1))
+            }
+        }
+
+        @Test
+        fun underflow() {
+            assertThrows(InputCoercionException::class.java) {
+                MAPPER.readValue<Map<UShort, UShort>>(makeSrc(-1))
+            }
+        }
+    }
+
+    class ForUInt {
+        private fun makeSrc(v: Long): String = MAPPER.writeValueAsString(mapOf(v to 0))
+
+        @Test
+        fun test() {
+            val actual = MAPPER.readValue<Map<UInt, UInt>>(makeSrc(UInt.MAX_VALUE.toLong()))
+            assertEquals(mapOf(UInt.MAX_VALUE to 0.toUInt()), actual)
+        }
+
+        @Test
+        fun overflow() {
+            assertThrows(InputCoercionException::class.java) {
+                MAPPER.readValue<Map<UInt, UInt>>(makeSrc(UInt.MAX_VALUE.toLong() + 1L))
+            }
+        }
+
+        @Test
+        fun underflow() {
+            assertThrows(InputCoercionException::class.java) {
+                MAPPER.readValue<Map<UInt, UInt>>(makeSrc(-1L))
+            }
+        }
+    }
+
+    class ForULong {
+        private fun makeSrc(v: BigInteger): String = MAPPER.writeValueAsString(mapOf(v to 0))
+
+        @Test
+        fun test() {
+            val actual = MAPPER.readValue<Map<ULong, ULong>>(makeSrc(BigInteger(ULong.MAX_VALUE.toString())))
+            assertEquals(mapOf(ULong.MAX_VALUE to 0.toULong()), actual)
+        }
+
+        @Test
+        fun overflow() {
+            assertThrows(InputCoercionException::class.java) {
+                MAPPER.readValue<Map<ULong, ULong>>(makeSrc(BigInteger(ULong.MAX_VALUE.toString()) + BigInteger.ONE))
+            }
+        }
+
+        @Test
+        fun underflow() {
+            assertThrows(InputCoercionException::class.java) {
+                MAPPER.readValue<Map<ULong, ULong>>(makeSrc(BigInteger.valueOf(-1L)))
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersTests.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE", "EXPERIMENTAL_UNSIGNED_LITERALS")
-
 package com.fasterxml.jackson.module.kotlin.test
 
 import com.fasterxml.jackson.core.exc.InputCoercionException

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github356.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github356.kt
@@ -52,7 +52,6 @@ data class ClassWithInlineMember(val inlineClassProperty: InlineClass) {
     }
 }
 
-@Suppress("EXPERIMENTAL_FEATURE_WARNING") // Enabled in test-compile
 @JvmInline
 value class ValueClass(val value: String)
 


### PR DESCRIPTION
Normal deserialization of `unsigned integers` was already supported, but `KeyDeserializer` was not, so it was added.Normal deserialization of `unsigned integers` was already supported, but `KeyDeserializer` was not, so it was added.
However, I did not add the `KeyDeserializer` for `Sequence` and `Regex` because I did not see the need for it (I will add it in another PR if necessary).

At the same time, I removed `Suppress` for `unsigned integers` because it is no longer needed since `Kotlin 1.5`.