### PR TITLE
Fixed an issue that could cause unexpected behavior when an instance that inherits from `StdValueInstantiator` is passed to `defaultInstantiator`.

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -21,6 +21,7 @@ Stefan Schmid (schmist@github)
 wrongwrong (k163377@github)
 * #456: Refactor KNAI.findImplicitPropertyName()
 * #449: Refactor AnnotatedMethod.hasRequiredMarker()
+* #521: Fixed lookup of instantiators
 
 Dmitri Domanine (novtor@github)
 * Contributed fix for #490: Missing value of type JsonNode? is deserialized as NullNode instead of null

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -201,8 +201,15 @@ internal class KotlinInstantiators(
         defaultInstantiator: ValueInstantiator
     ): ValueInstantiator {
         return if (beanDescriptor.beanClass.isKotlinClass()) {
-            if (defaultInstantiator is StdValueInstantiator) {
-                KotlinValueInstantiator(defaultInstantiator, cache, nullToEmptyCollection, nullToEmptyMap, nullIsSameAsDefault, strictNullChecks)
+            if (defaultInstantiator::class == StdValueInstantiator::class) {
+                KotlinValueInstantiator(
+                    defaultInstantiator as StdValueInstantiator,
+                    cache,
+                    nullToEmptyCollection,
+                    nullToEmptyMap,
+                    nullIsSameAsDefault,
+                    strictNullChecks
+                )
             } else {
                 // TODO: return defaultInstantiator and let default method parameters and nullability go unused?  or die with exception:
                 throw IllegalStateException("KotlinValueInstantiator requires that the default ValueInstantiator is StdValueInstantiator")


### PR DESCRIPTION
Reading the comments and the initialization process of the `KotlinValueInstantiator`, it looks like the `defaultInstantiator` of `KotlinInstantiators.findValueInstantiator` requires `StdValueInstantiator`.
On the other hand, this comparison is done with the `is` operator, which means that even if an instance that inherits　`StdValueInstantiator` is passed, it will be treated as normal.

In this `PR`, this problem is fixed by comparing the `Class`.