### PR TITLE
Improvements to serialization of `value class`.

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -22,6 +22,7 @@ wrongwrong (k163377@github)
 * #456: Refactor KNAI.findImplicitPropertyName()
 * #449: Refactor AnnotatedMethod.hasRequiredMarker()
 * #521: Fixed lookup of instantiators
+* #527: Improvements to serialization of `value class`.
 
 Dmitri Domanine (novtor@github)
 * Contributed fix for #490: Missing value of type JsonNode? is deserialized as NullNode instead of null

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -94,6 +94,9 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
         else -> null
     }
 
+    // Perform proper serialization even if the value wrapped by the value class is null.
+    override fun findNullSerializer(am: Annotated) = findSerializer(am)
+
     /**
      * Subclasses can be detected automatically for sealed classes, since all possible subclasses are known
      * at compile-time to Kotlin. This makes [com.fasterxml.jackson.annotation.JsonSubTypes] redundant.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -62,7 +62,7 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
     }
 
     // Find a serializer to handle the case where the getter returns an unboxed value from the value class.
-    override fun findSerializer(am: Annotated): ValueClassBoxSerializer? = when (am) {
+    override fun findSerializer(am: Annotated): ValueClassBoxSerializer<*>? = when (am) {
         is AnnotatedMethod -> {
             val getter = am.member.apply {
                 // If the return value of the getter is a value class,
@@ -85,9 +85,10 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
 
             (kotlinProperty?.returnType?.classifier as? KClass<*>)
                 ?.takeIf { it.isValue }
+                ?.java
                 ?.let { outerClazz ->
                     @Suppress("UNCHECKED_CAST")
-                    ValueClassBoxSerializer(outerClazz as KClass<Any>, getter.returnType)
+                    ValueClassBoxSerializer(outerClazz, getter.returnType)
                 }
         }
         // Ignore the case of AnnotatedField, because JvmField cannot be set in the field of value class.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -82,7 +82,7 @@ internal class ValueClassBoxSerializer(
 ) : StdSerializer<Any>(outerClazz.java) {
     private val boxMethod = _handledType.getMethod("box-impl", innerClazz)
 
-    override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
+    override fun serialize(value: Any?, gen: JsonGenerator, provider: SerializerProvider) {
         // Values retrieved from getter are considered validated and constructor-impl is not executed.
         val boxed = boxMethod.invoke(null, value)
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.ser.Serializers
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import java.math.BigInteger
+import kotlin.reflect.KClass
 
 object SequenceSerializer : StdSerializer<Sequence<*>>(Sequence::class.java) {
     override fun serialize(value: Sequence<*>, gen: JsonGenerator, provider: SerializerProvider) {
@@ -69,5 +70,22 @@ internal class KotlinSerializers : Serializers.Base() {
         // The priority of Unboxing needs to be lowered so as not to break the serialization of Unsigned Integers.
         type.rawClass.isUnboxableValueClass() -> ValueClassUnboxSerializer
         else -> null
+    }
+}
+
+// This serializer is used to properly serialize the value class.
+// The getter generated for the value class is special,
+// so this class will not work properly when added to the Serializers
+// (it is configured from KotlinAnnotationIntrospector.findSerializer).
+internal class ValueClassBoxSerializer(
+    outerClazz: KClass<Any>, innerClazz: Class<*>
+) : StdSerializer<Any>(outerClazz.java) {
+    private val boxMethod = _handledType.getMethod("box-impl", innerClazz)
+
+    override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
+        // Values retrieved from getter are considered validated and constructor-impl is not executed.
+        val boxed = boxMethod.invoke(null, value)
+
+        provider.findValueSerializer(_handledType).serialize(boxed, gen, provider)
     }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -77,15 +77,15 @@ internal class KotlinSerializers : Serializers.Base() {
 // The getter generated for the value class is special,
 // so this class will not work properly when added to the Serializers
 // (it is configured from KotlinAnnotationIntrospector.findSerializer).
-internal class ValueClassBoxSerializer(
-    outerClazz: KClass<Any>, innerClazz: Class<*>
-) : StdSerializer<Any>(outerClazz.java) {
-    private val boxMethod = _handledType.getMethod("box-impl", innerClazz)
+internal class ValueClassBoxSerializer<T : Any>(
+    private val outerClazz: Class<out Any>, innerClazz: Class<T>
+) : StdSerializer<T>(innerClazz) {
+    private val boxMethod = outerClazz.getMethod("box-impl", innerClazz)
 
-    override fun serialize(value: Any?, gen: JsonGenerator, provider: SerializerProvider) {
+    override fun serialize(value: T?, gen: JsonGenerator, provider: SerializerProvider) {
         // Values retrieved from getter are considered validated and constructor-impl is not executed.
         val boxed = boxMethod.invoke(null, value)
 
-        provider.findValueSerializer(_handledType).serialize(boxed, gen, provider)
+        provider.findValueSerializer(outerClazz).serialize(boxed, gen, provider)
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub524.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub524.kt
@@ -1,0 +1,55 @@
+package com.fasterxml.jackson.module.kotlin.test.github
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
+import org.junit.Test
+import kotlin.test.assertEquals
+
+// Most of the current behavior has been tested on GitHub464, so only serializer-related behavior is tested here.
+class GitHub524 {
+    @JvmInline
+    value class HasSerializer(val value: Int?)
+    object Serializer : StdSerializer<HasSerializer>(HasSerializer::class.java) {
+        override fun serialize(value: HasSerializer, gen: JsonGenerator, provider: SerializerProvider) {
+            gen.writeString(value.toString())
+        }
+    }
+
+    @JvmInline
+    value class NoSerializer(val value: Int?)
+
+    data class Poko(
+        // ULong has a custom serializer defined in Serializers.
+        val foo: ULong = ULong.MAX_VALUE,
+        // If a custom serializer is set, the ValueClassUnboxSerializer will be overridden.
+        val bar: HasSerializer = HasSerializer(1),
+        val baz: HasSerializer = HasSerializer(null),
+        val qux: HasSerializer? = null,
+        // If there is no serializer, it will be unboxed as the existing.
+        val quux: NoSerializer = NoSerializer(2)
+    )
+
+    @Test
+    fun test() {
+        val sm = SimpleModule()
+            .addSerializer(Serializer)
+        val writer = jacksonMapperBuilder().addModule(sm).build().writerWithDefaultPrettyPrinter()
+
+        // 18446744073709551615 is ULong.MAX_VALUE.
+        assertEquals(
+            """
+                {
+                  "foo" : 18446744073709551615,
+                  "bar" : "HasSerializer(value=1)",
+                  "baz" : "HasSerializer(value=null)",
+                  "qux" : null,
+                  "quux" : 2
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(Poko())
+        )
+    }
+}


### PR DESCRIPTION
Fixed a problem where the `Serializer` set for the `value class` was not working if it was `unboxed` by the `getter`.
This also fixes #524.

# Additional contexts.
## 1
This fix is a destructive change.
If a `Serializer` is already set for a `value class`, it may change the response.

## 2
This fix adds reflection to all `getters`, which will reduce serialization performance.

## 3
Support for the `JsonSerialize` annotation could not be added.
The reasons as follows.

- I did not know the proper way to find the `JsonSerialize` annotation.
  - `jackson-module-kotlin` seems to handle not only `getter`, but also annotations set to `constructor parameter` and so on.
- I did not know the correspondence between the fields that can be set in the `JsonSerialize` annotation and the contents returned by `findSerializer`.