### PR TITLE
Remove meaningless checks and properties in KNAI.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,9 @@
                             <exclude>com.fasterxml.jackson.module.kotlin.KotlinModule$Builder#reflectionCacheSize(int)
                             </exclude>
                             <!-- internal -->
+                            <exclude>
+                                com.fasterxml.jackson.module.kotlin.KotlinNamesAnnotationIntrospector#KotlinNamesAnnotationIntrospector(com.fasterxml.jackson.module.kotlin.ReflectionCache,java.util.Set,boolean)
+                            </exclude>
 
                         </excludes>
                     </parameter>

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -17,6 +17,7 @@ Contributors:
 
 # 2.18.0 (not yet released)
 * #782: Organize deprecated contents
+* #542: Remove meaningless checks and properties in KNAI
 
 # 2.17.2 (not yet released)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -23,6 +23,7 @@ Co-maintainers:
 #782: Content marked as deprecated has been reorganized.
   Several constructors and accessors to properties of KotlinModule.Builder that were marked as DeprecationLevel.ERROR have been removed.
   Also, the content marked as DeprecationLevel.WARNING is now DeprecationLevel.ERROR.
+#542: Remove meaningless checks and properties in KNAI.
 
 2.17.2 (not yet released)
 #799: Fixed problem with code compiled with 2.17.x losing backward compatibility.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -89,8 +89,6 @@ class KotlinModule private constructor(
         builder.isEnabled(UseJavaDurationConversion),
     )
 
-    private val ignoredClassesForImplyingJsonCreator = emptySet<KClass<*>>()
-
     override fun setupModule(context: SetupContext) {
         super.setupModule(context)
 
@@ -114,12 +112,7 @@ class KotlinModule private constructor(
             nullIsSameAsDefault,
             useJavaDurationConversion
         ))
-        context.appendAnnotationIntrospector(
-            KotlinNamesAnnotationIntrospector(
-                cache,
-                ignoredClassesForImplyingJsonCreator,
-                kotlinPropertyNameAsImplicitName)
-        )
+        context.appendAnnotationIntrospector(KotlinNamesAnnotationIntrospector(cache, kotlinPropertyNameAsImplicitName))
 
         context.addDeserializers(KotlinDeserializers(cache, useJavaDurationConversion))
         context.addKeyDeserializers(KotlinKeyDeserializers)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -23,7 +23,6 @@ import kotlin.reflect.jvm.javaType
 
 internal class KotlinNamesAnnotationIntrospector(
     private val cache: ReflectionCache,
-    private val ignoredClassesForImplyingJsonCreator: Set<KClass<*>>,
     private val useKotlinPropertyNameForGetter: Boolean
 ) : NopAnnotationIntrospector() {
     private fun getterNameFromJava(member: AnnotatedMethod): String? {
@@ -89,7 +88,6 @@ internal class KotlinNamesAnnotationIntrospector(
         // don't add a JsonCreator to any constructor if one is declared already
 
         val kClass = member.declaringClass.kotlin
-            .apply { if (this in ignoredClassesForImplyingJsonCreator) return false }
         val kConstructor = cache.kotlinFromJava(member.annotated) ?: return false
 
         // TODO:  should we do this check or not?  It could cause failures if we miss another way a property could be set


### PR DESCRIPTION
The `hasCreatorAnnotation` was checking if the `declaringClass` was included in the `ignoredClassesForImplyingJsonCreator`.
On the other hand, since `ignoredClassesForImplyingJsonCreator` was always the `emptySet`, this check would always return `false`.
(Since `KotlinNameAnnotationIntrospector` is an `internal` class, it is not initialized with any external arguments.)

This PR removes meaningless checks and removes `ignoredClassesForImplyingJsonCreator`.

However, it seems to me that this property should be set via `KotlinFeature`.
Do you have any background on this?