### PR TITLE
Add test case for KNAI.hasCreatorAnnotation

### DIFF
--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
@@ -209,6 +209,16 @@ class TestJacksonWithKotlin {
         assertThat(test1out, equalTo(pascalCasedJson))
     }
 
+    private class HasSameParamNameConstructor(val value: Int) {
+        constructor(value: Short) : this(value.toInt() + 100)
+    }
+
+    @Test fun findingPrimaryConstructor() {
+        val json = "{\"value\":1}"
+
+        // If there is more than one constructor, the primary constructor will be used.
+        assertEquals(1, normalCasedMapper.readValue<HasSameParamNameConstructor>(json).value)
+    }
 
     // ==================
 


### PR DESCRIPTION
While checking, I found that deleting [this line](https://github.com/FasterXML/jackson-module-kotlin/blob/2.13/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt#L79) did not change the test results.
On the other hand, I found a case where the deserialization would fail if this line did not exist.

So I added a test case for such a case.
