### PR TITLE
Add extension function for addMixin

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -59,6 +59,9 @@ inline fun <reified T> ObjectReader.readValueTyped(jp: JsonParser): T = readValu
 inline fun <reified T> ObjectReader.readValuesTyped(jp: JsonParser): Iterator<T> = readValues(jp, jacksonTypeRef<T>())
 inline fun <reified T> ObjectReader.treeToValue(n: TreeNode): T? = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
 
+inline fun <reified T, reified U> ObjectMapper.addMixIn(): ObjectMapper = this.addMixIn(T::class.java, U::class.java)
+inline fun <reified T, reified U> JsonMapper.Builder.addMixIn(): JsonMapper.Builder = this.addMixIn(T::class.java, U::class.java)
+
 operator fun ArrayNode.plus(element: Boolean) = Unit.apply { add(element) }
 operator fun ArrayNode.plus(element: Short) = Unit.apply { add(element) }
 operator fun ArrayNode.plus(element: Int) = Unit.apply { add(element) }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ExtensionMethodsTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ExtensionMethodsTests.kt
@@ -1,11 +1,15 @@
 package com.fasterxml.jackson.module.kotlin.test
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.module.kotlin.addMixIn
 import com.fasterxml.jackson.module.kotlin.contains
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.jsonMapper
 import com.fasterxml.jackson.module.kotlin.minusAssign
 import com.fasterxml.jackson.module.kotlin.plusAssign
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -81,5 +85,16 @@ class TestExtensionMethods {
 
         val convertValueResult: List<Person> = mapper.convertValue(tree)
         assertThat(convertValueResult, `is`(listOf(Person("Neo"))))
+    }
+
+    @Test fun mixInExtensionTest() {
+
+        data class Person(val name: String)
+        abstract class PersonMixIn { @JsonIgnore var name: String = "" }
+
+        val mapper: JsonMapper = jsonMapper { addMixIn<Person, PersonMixIn>() }
+        val serializedPerson: String = mapper.writeValueAsString(Person("test"))
+
+        assertThat(serializedPerson, `is`("{}"))
     }
 }


### PR DESCRIPTION
Hello, this pull request is related to https://github.com/FasterXML/jackson-module-kotlin/issues/553

It aims to add the extension functions for addMixIn on ObjectMapper and JsonMapper.Builder.