### PR TITLE
Fix NoSuchMethodException in runtime for Kotlin 1.4

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -65,34 +65,40 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
     // Find a serializer to handle the case where the getter returns an unboxed value from the value class.
     override fun findSerializer(am: Annotated): StdSerializer<*>? = when (am) {
         is AnnotatedMethod -> {
-            val getter = am.member.apply {
-                // If the return value of the getter is a value class,
-                // it will be serialized properly without doing anything.
-                if (this.returnType.isUnboxableValueClass()) return null
-            }
-
-            val kotlinProperty = getter
-                .declaringClass
-                .kotlin
-                .let {
-                    // KotlinReflectionInternalError is raised in GitHub167 test,
-                    // but it looks like an edge case, so it is ignored.
-                    try {
-                        it.memberProperties
-                    } catch (e: Error) {
-                        null
+            when (KotlinVersion.CURRENT.isAtLeast(1, 5)) {
+                true -> {
+                    val getter = am.member.apply {
+                        // If the return value of the getter is a value class,
+                        // it will be serialized properly without doing anything.
+                        if (this.returnType.isUnboxableValueClass()) return null
                     }
-                }?.find { it.javaGetter == getter }
 
-            (kotlinProperty?.returnType?.classifier as? KClass<*>)
-                ?.takeIf { it.isValue }
-                ?.java
-                ?.let { outerClazz ->
-                    val innerClazz = getter.returnType
+                    val kotlinProperty = getter
+                        .declaringClass
+                        .kotlin
+                        .let {
+                            // KotlinReflectionInternalError is raised in GitHub167 test,
+                            // but it looks like an edge case, so it is ignored.
+                            try {
+                                it.memberProperties
+                            } catch (e: Error) {
+                                null
+                            }
+                        }?.find { it.javaGetter == getter }
 
-                    ValueClassStaticJsonValueSerializer.createdOrNull(outerClazz, innerClazz)
-                        ?: @Suppress("UNCHECKED_CAST") ValueClassBoxSerializer(outerClazz, innerClazz)
+                    (kotlinProperty?.returnType?.classifier as? KClass<*>)
+                        ?.takeIf { it.isValue }
+                        ?.java
+                        ?.let { outerClazz ->
+                            val innerClazz = getter.returnType
+
+                            ValueClassStaticJsonValueSerializer.createdOrNull(outerClazz, innerClazz)
+                                ?: @Suppress("UNCHECKED_CAST") ValueClassBoxSerializer(outerClazz, innerClazz)
+                        }
                 }
+                // Kotlin 1.4 and lower doesn't have value classes and we avoid the NoSuchMethodException on it.isValue
+                else -> null
+            }
         }
         // Ignore the case of AnnotatedField, because JvmField cannot be set in the field of value class.
         else -> null


### PR DESCRIPTION
Add an explicit language check before code checking for value classes

Closes #556