### PR TITLE
Ignore open-ended ranges in KotlinMixins.kt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,7 @@
                             <exclude>com.fasterxml.jackson.databind.jsonschema.SchemaAware[com.fasterxml.jackson.databind.jsonschema.SchemaAware]</exclude>
                             <exclude>com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable[com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable]:INTERFACE_REMOVED, java.io.Serializable[java.io.Serializable]</exclude>
                             <exclude>com.fasterxml.jackson.module.kotlin.ValueClassUnboxSerializer</exclude>
+                            <exclude>com.fasterxml.jackson.module.kotlin.ClosedRangeMixin</exclude>
                         </excludes>
                     </parameter>
                 </configuration>

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinMixins.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinMixins.kt
@@ -11,4 +11,5 @@ internal abstract class ClosedRangeMixin<T> @JsonCreator constructor(public val 
     @JsonIgnore abstract public fun getIncrement(): T
     @JsonIgnore abstract public fun isEmpty(): Boolean
     @JsonIgnore abstract public fun getStep(): T
+    @JsonIgnore abstract public fun getEndExclusive(): T
 }


### PR DESCRIPTION
Fix for https://github.com/FasterXML/jackson-module-kotlin/issues/582 using his suggested fix on ignore the `getEndExclusive`