### PR TITLE
Fix #565: add matrix build to CI to build module against Kotlin 1.4/1.5/1.6/1.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: ['8', '11', '17']
-	kotlin_version: ['1.4.32', '1.5.32', '1.6.21', '1.7.20']
+        kotlin_version: ['1.4.32', '1.5.32', '1.6.21', '1.7.20']
         os: ['ubuntu-20.04']
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: ['8', '11', '17']
+	kotlin_version: ['1.4.32', '1.5.32', '1.6.21', '1.7.20']
         os: ['ubuntu-20.04']
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
@@ -43,7 +44,7 @@ jobs:
         # gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
         # gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
     - name: Build
-      run: ./mvnw -B -q -ff -ntp verify
+      run: ./mvnw -B -q -ff -ntp -Dversion.kotlin=${{ matrix.kotlin_version }} verify
     - name: Extract project Maven version
       id: projectVersion
       run: echo ::set-output name=version::$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -DforceStdout -Dexpression=project.version -q)

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <connection>scm:git:git@github.com:FasterXML/jackson-module-kotlin.git</connection>
         <developerConnection>scm:git:git@github.com:FasterXML/jackson-module-kotlin.git</developerConnection>
         <url>https://github.com/FasterXML/jackson-module-kotlin</url>
-        <tag>jackson-module-kotlin-2.13.2-take2</tag>
+        <tag>HEAD2</tag>
     </scm>
 
     <properties>
@@ -52,7 +52,7 @@
         <javac.src.version>1.8</javac.src.version>
         <javac.target.version>1.8</javac.target.version>
 
-        <version.kotlin>1.5.30</version.kotlin>
+        <version.kotlin>1.5.32</version.kotlin>
 
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/kotlin</packageVersion.dir>


### PR DESCRIPTION
As per title adds Matrix-build to CI so that tests are executed against multiple Kotlin core versions; from 1.4(.32) to 1.7(.20)
