### PR TITLE
Test fail workaround: removed private from a companion object creator in order to pass test…

### DIFF
--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
@@ -270,7 +270,7 @@ class TestJacksonWithKotlin {
     ) : TestFields {
         var factoryUsed: Boolean = false
         private companion object Named {
-            @JvmStatic @JsonCreator private fun create(
+            @JvmStatic @JsonCreator fun create(
                 @JsonProperty("name") nameThing: String,
                 @JsonProperty("age") age: Int,
                 @JsonProperty("primaryAddress") primaryAddress: String,


### PR DESCRIPTION
Removed private in order to keep tests working on kotlin 1.5.x
