### PR TITLE
Decrease Kotlin version to 1.5.32 to restore binary compatibility with 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <javac.src.version>1.8</javac.src.version>
         <javac.target.version>1.8</javac.target.version>
 
-        <version.kotlin>1.6.21</version.kotlin>
+        <version.kotlin>1.5.32</version.kotlin>
 
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/kotlin</packageVersion.dir>


### PR DESCRIPTION
Decrease Kotlin version to 1.5.32 to restore binary compatibility with Kotlin 1.4

Closes #586