### PR TITLE
fixes #585 there is no way to support this kind of feature right now

### DIFF
--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefaultTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefaultTests.kt
@@ -10,74 +10,156 @@ import org.junit.Test
 
 class TestNullToDefault {
 
-	private fun createMapper(allowDefaultingByNull: Boolean) = ObjectMapper()
-		.registerModule(kotlinModule { configure(NullIsSameAsDefault, allowDefaultingByNull) })
+    private fun createMapper(allowDefaultingByNull: Boolean) = ObjectMapper()
+        .registerModule(kotlinModule { configure(NullIsSameAsDefault, allowDefaultingByNull) })
 
-	private data class TestClass(val sku: Int = -1,
-								 val text: String,
-								 val name: String = "",
-								 val images: String?,
-								 val language: String = "uk",
-								 val attribute: Int = 0,
-								 val order: Int = -1)
+    private data class TestClass(
+        val sku: Int? = -1,
+        val text: String,
+        val images: String? = "some image",
+        val language: String = "uk",
+        val temperature: Double? = 24.7,
+        val canBeProcessed: Boolean? = true,
+    )
+
+    data class TestClassWithNotNullPrimitives(
+        val sku: Int = -1,
+        val text: String,
+        val temperature: Double = 24.7,
+        val canBeProcessed: Boolean = true,
+    )
+
+    @Test
+    fun shouldUseNullAsDefault() {
+        val item = createMapper(true).readValue<TestClass>(
+            """{
+					"sku": null,
+					"text": "plain",
+					"images": null,
+					"language": null,
+					"temperature": null,
+					"canBeProcessed": null
+				}"""
+        )
+
+        Assert.assertEquals(-1, item.sku)
+        Assert.assertEquals("plain", item.text)
+        Assert.assertEquals("some image", item.images)
+        Assert.assertEquals("uk", item.language)
+		Assert.assertTrue(item.temperature == 24.7)
+		Assert.assertEquals(true, item.canBeProcessed)
+    }
+
+    @Test
+    fun shouldUseRealValuesInsteadOfDefaultsWhenProvided() {
+        val item = createMapper(true).readValue<TestClass>(
+            """{
+					"sku": "0",
+					"text": "plain",
+					"images": "image1",
+					"language": "pl",
+					"temperature": "0.0",
+					"canBeProcessed": "false"
+				}"""
+        )
+
+        Assert.assertEquals(0, item.sku)
+        Assert.assertEquals("plain", item.text)
+        Assert.assertEquals("image1", item.images)
+        Assert.assertEquals("pl", item.language)
+        Assert.assertTrue(item.temperature == 0.0)
+        Assert.assertEquals(false, item.canBeProcessed)
+    }
+
+    @Test
+    fun shouldNotUseNullAsDefault() {
+        val item = createMapper(false).readValue<TestClass>(
+            """{
+					"sku": "974",
+					"text": "plain",
+					"images": null,
+					"language": "pl",
+					"temperature": "36.6",
+					"canBeProcessed": "false"
+				}"""
+        )
+
+        Assert.assertEquals(974, item.sku)
+        Assert.assertEquals("plain", item.text)
+        Assert.assertEquals(null, item.images)
+        Assert.assertEquals("pl", item.language)
+		Assert.assertTrue(item.temperature == 36.6)
+        Assert.assertEquals(false, item.canBeProcessed)
+    }
 
 	@Test
-	fun shouldUseNullAsDefault() {
-		val item = createMapper(true).readValue<TestClass>(
-				"""{
-					"sku": "974",
+	fun shouldUseDefaultPrimitiveValuesInsteadOfDefaultsWhenProvidingNullForNotNullPrimitives() {
+		val item = createMapper(false).readValue<TestClassWithNotNullPrimitives>(
+			"""{
+					"sku": null,
 					"text": "plain",
-					"name": null,
-					"images": null,
-					"attribute": "19"     
-				}""")
+					"temperature": null,
+					"canBeProcessed": null
+				}"""
+		)
 
-		Assert.assertTrue(item.sku == 974)
-		Assert.assertTrue(item.text == "plain")
-		@Suppress("SENSELESS_COMPARISON")
-		Assert.assertTrue(item.name != null)
-		Assert.assertTrue(item.images == null)
-		Assert.assertTrue(item.language == "uk")
-		Assert.assertTrue(item.attribute == 19)
-		Assert.assertTrue(item.order == -1)
+		Assert.assertEquals(0, item.sku)
+		Assert.assertEquals("plain", item.text)
+		Assert.assertTrue(item.temperature == 0.0)
+		Assert.assertEquals(false, item.canBeProcessed)
 	}
 
-	@Test(expected = MissingKotlinParameterException::class)
-	fun shouldNotUseNullAsDefault() {
-		val item = createMapper(false).readValue<TestClass>(
-				"""{
-					"sku": "974",
-					"text": "plain",
-					"name": null,
-					"images": null,
-					"attribute": "19"     
-				}""")
+    @Test
+    fun shouldUseDefaultsWhenNotProvidingAnyValueForNotNullPrimitives() {
+        val item = createMapper(false).readValue<TestClassWithNotNullPrimitives>(
+            """{
+					"text": "plain"
+				}"""
+        )
 
-		Assert.assertTrue(item.sku == 974)
-		Assert.assertTrue(item.text == "plain")
-		@Suppress("SENSELESS_COMPARISON")
-		Assert.assertTrue(item.name != null)
-		Assert.assertTrue(item.images == null)
-		Assert.assertTrue(item.language == "uk")
-		Assert.assertTrue(item.attribute == 19)
-		Assert.assertTrue(item.order == -1)
-	}
+        Assert.assertEquals(-1, item.sku)
+        Assert.assertEquals("plain", item.text)
+        Assert.assertTrue(item.temperature == 24.7)
+        Assert.assertEquals(true, item.canBeProcessed)
+    }
 
-	@Test(expected = MissingKotlinParameterException::class)
-	fun errorIfNotDefault() {
-		val item = createMapper(true).readValue<TestClass>(
-				"""{
-						"sku": "974",
-						"text": null,
-						"attribute": "19",
-						"name": null     
- 				}""")
+    @Test
+    fun shouldUseDefaultValueWhenItsNotPresentEvenWhenDefaultingByNullIsDisabled() {
+        val item = createMapper(false).readValue<TestClass>(
+            """{
+					"text": "plain"
+				}"""
+        )
 
-		Assert.assertTrue(item.sku == 974)
-		Assert.assertTrue(item.language == "uk")
-		Assert.assertTrue(item.attribute == 19)
-		@Suppress("SENSELESS_COMPARISON")
-		Assert.assertTrue(item.name != null)
-		Assert.assertTrue(item.order == -1)
-	}
+        Assert.assertEquals(-1, item.sku)
+        Assert.assertEquals("plain", item.text)
+        Assert.assertEquals("some image", item.images)
+        Assert.assertEquals("uk", item.language)
+		Assert.assertTrue(item.temperature == 24.7)
+        Assert.assertEquals(true, item.canBeProcessed)
+    }
+
+    @Test(expected = MissingKotlinParameterException::class)
+    fun shouldThrowExceptionWhenProvidedNullForNotNullFieldWithoutDefault() {
+        createMapper(true).readValue<TestClass>(
+            """{
+						"text": null
+ 				}"""
+        )
+    }
+
+    @Test
+    fun shouldUseDefaultValueForNullNestedDataClasses() {
+        data class InnerDataClass(val someString: String = "someString")
+        data class OuterDataClass(val innerClass: InnerDataClass = InnerDataClass())
+
+        val outerDataClassInstance = createMapper(true).readValue<OuterDataClass>(
+            """{
+					"innerClass": null
+				}"""
+        )
+
+        val expectedResult = OuterDataClass(InnerDataClass("someString"))
+        Assert.assertEquals(expectedResult, outerDataClassInstance)
+    }
 }


### PR DESCRIPTION
Cleaned up tests for null to default feature as they can now clearly show what is supported and what is not. There is no way to provide default value for primitive fields which are not set as nullable, because the primitives are initialized to their defaults (0, 0.0, false etc.) and there is no possibility to distinguish if the value was initialized as a default primitive value or it was provided by user in content (in the first case we can use default parameter value but in the latter no)
