### PR TITLE
Update Kotlin dependency to latest stable 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
         <javac.target.version>1.8</javac.target.version>
 
         <version.kotlin>1.7.22</version.kotlin>
+        <kotlin.compiler.languageVersion>1.5</kotlin.compiler.languageVersion>
+        <kotlin.compiler.apiVersion>1.5</kotlin.compiler.apiVersion>
 
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/kotlin</packageVersion.dir>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <javac.src.version>1.8</javac.src.version>
         <javac.target.version>1.8</javac.target.version>
 
-        <version.kotlin>1.5.32</version.kotlin>
+        <version.kotlin>1.7.22</version.kotlin>
 
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/kotlin</packageVersion.dir>


### PR DESCRIPTION
1.5.32 -> 1.7.22.
1.8 is available as of Dec 28, 2022, but it was not immediately clear to me if this would be compatible.

This doesn't really count as code, so I don't see a need to fill out the Contributor License Agreement, if this gets merged.