### PR TITLE
Merge creator cache for Constructor and Method

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -20,6 +20,9 @@ Contributors:
 Ilya Ryzhenkov (@orangy)
 * #580: Lazy load UNIT_TYPE
 
+WrongWrong (@k163377)
+* #627: Merge creator cache for Constructor and Method
+
 # 2.14.0
 
 Richard Kwasnicki (Richie94@github)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -22,6 +22,7 @@ Co-maintainers:
  (fix via [jackson-dataformat-xml#547])
 #580: Lazy load UNIT_TYPE
  (contributed by Ilya R)
+#627: Merge creator cache for Constructor and Method
 
 2.14.2 (28-Jan-2023)
 2.14.1 (21-Nov-2022)


### PR DESCRIPTION
#512 added caches for each of `Constructor` and `Method` without any particular consideration.
On the other hand, it is unlikely that `Creator` is equally defined for both `Constructor` and `Method`, and this situation is wasteful.
Therefore, these two caches were merged.

This is minor, but also mitigates the problem of #584.

---

@cowtowncoder 
What should I do about code reviews?
I am concerned about merging complex content without review, let alone simple content like this.