### PR TITLE
Fix ReflectionCache to be serializable

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -14,6 +14,7 @@ import kotlin.reflect.jvm.kotlinFunction
 
 internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     companion object {
+        // Increment is required when properties that use LRUMap are changed.
         private const val serialVersionUID = 1L
     }
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -5,13 +5,18 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMember
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams
 import com.fasterxml.jackson.databind.util.LRUMap
+import java.io.Serializable
 import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
 import java.lang.reflect.Method
 import kotlin.reflect.KFunction
 import kotlin.reflect.jvm.kotlinFunction
 
-internal class ReflectionCache(reflectionCacheSize: Int) {
+internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+
     sealed class BooleanTriState(val value: Boolean?) {
         class True : BooleanTriState(true)
         class False : BooleanTriState(false)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/JDKSerializabilityTestHelper.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/JDKSerializabilityTestHelper.kt
@@ -1,0 +1,28 @@
+package com.fasterxml.jackson.module.kotlin
+
+import junit.framework.TestCase
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+fun jdkSerialize(o: Any): ByteArray {
+    val bytes = ByteArrayOutputStream(1000)
+    val obOut = ObjectOutputStream(bytes)
+    obOut.writeObject(o)
+    obOut.close()
+    return bytes.toByteArray()
+}
+
+fun <T> jdkDeserialize(raw: ByteArray): T? {
+    val objIn = ObjectInputStream(ByteArrayInputStream(raw))
+    return try {
+        @Suppress("UNCHECKED_CAST")
+        objIn.readObject() as T
+    } catch (e: ClassNotFoundException) {
+        TestCase.fail("Missing class: " + e.message)
+        null
+    } finally {
+        objIn.close()
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertNotNull
 
 class KotlinModuleTest {
     /**
@@ -102,5 +103,28 @@ class KotlinModuleTest {
         }.build()
 
         assertTrue(module.strictNullChecks)
+    }
+
+    @Test
+    fun jdkSerializabilityTest() {
+        val module = KotlinModule.Builder().apply {
+            withReflectionCacheSize(123)
+            enable(NullToEmptyCollection)
+            enable(NullToEmptyMap)
+            enable(NullIsSameAsDefault)
+            enable(SingletonSupport)
+            enable(StrictNullChecks)
+        }.build()
+
+        val serialized = jdkSerialize(module)
+        val deserialized = jdkDeserialize<KotlinModule>(serialized)
+
+        assertNotNull(deserialized)
+        assertEquals(123, deserialized.reflectionCacheSize)
+        assertTrue(deserialized.nullToEmptyCollection)
+        assertTrue(deserialized.nullToEmptyMap)
+        assertTrue(deserialized.nullIsSameAsDefault)
+        assertEquals(CANONICALIZE, deserialized.singletonSupport)
+        assertTrue(deserialized.strictNullChecks)
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCacheTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCacheTest.kt
@@ -1,0 +1,30 @@
+package com.fasterxml.jackson.module.kotlin
+
+import org.junit.Test
+import kotlin.test.assertNotNull
+
+class ReflectionCacheTest {
+    @Test
+    fun serializeEmptyCache() {
+        val cache = ReflectionCache(100)
+        val serialized = jdkSerialize(cache)
+        val deserialized = jdkDeserialize<ReflectionCache>(serialized)
+
+        assertNotNull(deserialized)
+        // Deserialized instance also do not raise exceptions
+        deserialized.kotlinFromJava(ReflectionCacheTest::class.java.getDeclaredMethod("serializeEmptyCache"))
+    }
+
+    @Test
+    fun serializeNotEmptyCache() {
+        val method = ReflectionCacheTest::class.java.getDeclaredMethod("serializeNotEmptyCache")
+
+        val cache = ReflectionCache(100).apply { kotlinFromJava(method) }
+        val serialized = jdkSerialize(cache)
+        val deserialized = jdkDeserialize<ReflectionCache>(serialized)
+
+        assertNotNull(deserialized)
+        // Deserialized instance also do not raise exceptions
+        deserialized.kotlinFromJava(method)
+    }
+}


### PR DESCRIPTION
Maybe fixes #295 

I honestly don't understand the required specifications, but is this correct?
The following test confirms that the `LRUMap` set to `reflectionCacheSize` is retained, but not its contents.

```kotlin
import com.fasterxml.jackson.module.kotlin.ReflectionCache
import org.junit.Test
import java.io.FileInputStream
import java.io.FileNotFoundException
import java.io.FileOutputStream
import java.io.IOException
import java.io.ObjectInputStream
import java.io.ObjectOutputStream

class ReflectionCacheTest {
    private val serialFile = "./serial.ser"

    private fun mkSerialFile(obj: Any) {
        try {
            FileOutputStream(serialFile).use { fileOutStream ->
                ObjectOutputStream(fileOutStream).use { outStream ->
                    outStream.writeObject(obj)
                    outStream.flush()
                    outStream.reset()
                }
            }
        } catch (e: FileNotFoundException) {
            e.printStackTrace()
        } catch (e: IOException) {
            e.printStackTrace()
        }
    }

    private fun readSerialFile(): ReflectionCache {
        var reflectionCache: ReflectionCache? = null
        try {
            FileInputStream(serialFile).use { fileInStream ->
                ObjectInputStream(fileInStream).use { inStream ->
                    reflectionCache = inStream.readObject() as ReflectionCache
                }
            }
        } catch (e: ClassNotFoundException) {
            e.printStackTrace()
        } catch (e: IOException) {
            e.printStackTrace()
        } catch (e: Exception) {
            e.printStackTrace()
        }
        return reflectionCache ?: throw RuntimeException()
    }

    @Test
    fun test() {
        val cache = ReflectionCache(100)
        cache.kotlinFromJava(this::class.java.methods.first())
        mkSerialFile(cache)
        val tmp = readSerialFile()

        println()
    }
}
```