### PR TITLE
Fix #340

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -29,34 +29,34 @@ import kotlin.reflect.jvm.kotlinFunction
 
 internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val cache: ReflectionCache, val ignoredClassesForImplyingJsonCreator: Set<KClass<*>>) : NopAnnotationIntrospector() {
     // since 2.4
-    override fun findImplicitPropertyName(member: AnnotatedMember): String? = when (member) {
-        is AnnotatedMethod -> if (member.name.contains('-') && member.parameterCount == 0) {
-            when {
-                member.name.startsWith("get") -> member.name.substringAfter("get")
-                member.name.startsWith("is") -> member.name.substringAfter("is")
-                else -> null
-            }?.replaceFirstChar { it.lowercase(Locale.getDefault()) }?.substringBefore('-')
-        } else null
-        is AnnotatedParameter -> findKotlinParameterName(member)
-        else -> null
-    }
+    override fun findImplicitPropertyName(member: AnnotatedMember): String? {
+        if (!member.declaringClass.isKotlinClass()) return null
 
-    // since 2.11: support Kotlin's way of handling "isXxx" backed properties where
-    // logical property name needs to remain "isXxx" and not become "xxx" as with Java Beans
-    // (see https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html and
-    //  https://github.com/FasterXML/jackson-databind/issues/2527
-    //  for details)
-    override fun findRenameByField(config: MapperConfig<*>,
-                                   field: AnnotatedField,
-                                   implName: PropertyName): PropertyName? {
-        val origSimple = implName.simpleName
-        if (field.declaringClass.isKotlinClass() && origSimple.startsWith("is")) {
-            val mangledName: String? = BeanUtil.stdManglePropertyName(origSimple, 2)
-            if ((mangledName != null) && !mangledName.equals(origSimple)) {
-                return PropertyName.construct(mangledName)
-            }
+        val name = member.name
+
+        return when (member) {
+            is AnnotatedMethod -> if (member.parameterCount == 0) {
+                // The reason for truncating after `-` is to truncate the random suffix
+                // given after the value class accessor name.
+                when {
+                    name.startsWith("get") -> name.takeIf { it.contains("-") }?.let { _ ->
+                        name.substringAfter("get")
+                            .replaceFirstChar { it.lowercase(Locale.getDefault()) }
+                            .substringBefore('-')
+                    }
+                    // since 2.15: support Kotlin's way of handling "isXxx" backed properties where
+                    // logical property name needs to remain "isXxx" and not become "xxx" as with Java Beans
+                    // (see https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html and
+                    //  https://github.com/FasterXML/jackson-databind/issues/2527 and
+                    //  https://github.com/FasterXML/jackson-module-kotlin/issues/340
+                    //  for details)
+                    name.startsWith("is") -> if (name.contains("-")) name.substringAfter("-") else name
+                    else -> null
+                }
+            } else null
+            is AnnotatedParameter -> findKotlinParameterName(member)
+            else -> null
         }
-        return null
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
@@ -25,24 +25,27 @@ class TestJacksonWithKotlin {
         val primaryAddress: String
         val wrongName: Boolean
         val createdDt: Date
+        val isName: Boolean
 
         fun validate(
             nameField: String = name,
             ageField: Int = age,
             addressField: String = primaryAddress,
             wrongNameField: Boolean = wrongName,
-            createDtField: Date = createdDt
+            createDtField: Date = createdDt,
+            isNameField: Boolean = isName,
         ) {
             assertThat(nameField, equalTo("Frank"))
             assertThat(ageField, equalTo(30))
             assertThat(addressField, equalTo("something here"))
             assertThat(wrongNameField, equalTo(true))
             assertThat(createDtField, equalTo(Date(1477419948000)))
+            assertThat(isNameField, equalTo(false))
         }
     }
 
-    private val normalCasedJson = """{"name":"Frank","age":30,"primaryAddress":"something here","renamed":true,"createdDt":"2016-10-25T18:25:48.000+00:00"}"""
-    private val pascalCasedJson = """{"Name":"Frank","Age":30,"PrimaryAddress":"something here","Renamed":true,"CreatedDt":"2016-10-25T18:25:48.000+00:00"}"""
+    private val normalCasedJson = """{"name":"Frank","age":30,"primaryAddress":"something here","renamed":true,"createdDt":"2016-10-25T18:25:48.000+00:00","isName":false}"""
+    private val pascalCasedJson = """{"Name":"Frank","Age":30,"PrimaryAddress":"something here","Renamed":true,"CreatedDt":"2016-10-25T18:25:48.000+00:00","IsName":false}"""
 
     private val normalCasedMapper = jacksonObjectMapper()
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
@@ -65,6 +68,7 @@ class TestJacksonWithKotlin {
 
         override var primaryAddress: String = ""
         override var createdDt: Date = Date()
+        override val isName: Boolean = false
     }
 
     @Test fun NoFailWithDefaultAndSpecificConstructor() {
@@ -79,7 +83,8 @@ class TestJacksonWithKotlin {
         override val age: Int,
         override val primaryAddress: String,
         val renamed: Boolean,
-        override val createdDt: Date
+        override val createdDt: Date,
+        override val isName: Boolean
     ) : TestFields {
         @JsonIgnore
         override val wrongName = renamed // here for the test validation only
@@ -97,7 +102,8 @@ class TestJacksonWithKotlin {
         override val age: Int,
         override val primaryAddress: String,
         val renamed: Boolean,
-        override val createdDt: Date
+        override val createdDt: Date,
+        override val isName: Boolean
     ) : TestFields {
         @JsonIgnore
         override val wrongName = renamed // here for the test validation only
@@ -121,7 +127,8 @@ class TestJacksonWithKotlin {
         override val age: Int,
         override val primaryAddress: String,
         @JsonProperty("renamed") override val wrongName: Boolean,
-        override val createdDt: Date
+        override val createdDt: Date,
+        override val isName: Boolean
     ) : TestFields
 
     @Test fun testDataClassWithExplicitJsonCreatorAndJsonProperty() {
@@ -141,7 +148,8 @@ class TestJacksonWithKotlin {
         override val age: Int,
         override val primaryAddress: String,
         @JsonProperty("renamed") override val wrongName: Boolean,
-        override val createdDt: Date
+        override val createdDt: Date,
+        override val isName: Boolean
     ) : TestFields
 
     @Test fun testNormalClassWithJsonCreator() {
@@ -155,7 +163,8 @@ class TestJacksonWithKotlin {
     private class StateObjectWithPartialFieldsInConstructor(
         override val name: String,
         override val age: Int,
-        override val primaryAddress: String
+        override val primaryAddress: String,
+        override val isName: Boolean
     ) : TestFields {
         @JsonProperty("renamed") override var wrongName: Boolean = false
         override var createdDt: Date by Delegates.notNull()
@@ -176,7 +185,8 @@ class TestJacksonWithKotlin {
         override val age: Int,
         override val primaryAddress: String,
         @JsonProperty("renamed") override val wrongName: Boolean,
-        override val createdDt: Date
+        override val createdDt: Date,
+        override val isName: Boolean
     ) : TestFields
 
     @Test fun testDataClassWithNonFieldParametersInConstructor() {
@@ -207,7 +217,8 @@ class TestJacksonWithKotlin {
         override val age: Int,
         override val primaryAddress: String,
         override val wrongName: Boolean,
-        override val createdDt: Date
+        override val createdDt: Date,
+        override val isName: Boolean
     ) : TestFields {
         var factoryUsed: Boolean = false
         companion object {
@@ -216,9 +227,10 @@ class TestJacksonWithKotlin {
                 @JsonProperty("age") age: Int,
                 @JsonProperty("primaryAddress") primaryAddress: String,
                 @JsonProperty("renamed") wrongName: Boolean,
-                @JsonProperty("createdDt") createdDt: Date
+                @JsonProperty("createdDt") createdDt: Date,
+                @JsonProperty("isName") isName: Boolean
             ): StateObjectWithFactory {
-                val obj = StateObjectWithFactory(nameThing, age, primaryAddress, wrongName, createdDt)
+                val obj = StateObjectWithFactory(nameThing, age, primaryAddress, wrongName, createdDt, isName)
                 obj.factoryUsed = true
                 return obj
             }
@@ -236,7 +248,8 @@ class TestJacksonWithKotlin {
         val age: Int,
         val primaryAddress: String,
         val renamed: Boolean,
-        val createdDt: Date
+        val createdDt: Date,
+        val isName: Boolean
     ) {
         companion object {
             @JvmStatic @JsonCreator fun create(
@@ -244,9 +257,10 @@ class TestJacksonWithKotlin {
                 age: Int,
                 primaryAddress: String,
                 renamed: Boolean,
-                createdDt: Date
+                createdDt: Date,
+                isName: Boolean
             ): StateObjectWithFactoryNoParamAnnotations {
-                return StateObjectWithFactoryNoParamAnnotations(name, age, primaryAddress, renamed, createdDt)
+                return StateObjectWithFactoryNoParamAnnotations(name, age, primaryAddress, renamed, createdDt, isName)
             }
         }
     }
@@ -266,7 +280,8 @@ class TestJacksonWithKotlin {
         override val age: Int,
         override val primaryAddress: String,
         override val wrongName: Boolean,
-        override val createdDt: Date
+        override val createdDt: Date,
+        override val isName: Boolean
     ) : TestFields {
         var factoryUsed: Boolean = false
         private companion object Named {
@@ -275,9 +290,10 @@ class TestJacksonWithKotlin {
                 @JsonProperty("age") age: Int,
                 @JsonProperty("primaryAddress") primaryAddress: String,
                 @JsonProperty("renamed") wrongName: Boolean,
-                @JsonProperty("createdDt") createdDt: Date
+                @JsonProperty("createdDt") createdDt: Date,
+                @JsonProperty("isName") isName: Boolean
             ): StateObjectWithFactoryOnNamedCompanion {
-                val obj = StateObjectWithFactoryOnNamedCompanion(nameThing, age, primaryAddress, wrongName, createdDt)
+                val obj = StateObjectWithFactoryOnNamedCompanion(nameThing, age, primaryAddress, wrongName, createdDt, isName)
                 obj.factoryUsed = true
                 return obj
             }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github340.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github340.kt
@@ -1,10 +1,8 @@
-package com.fasterxml.jackson.module.kotlin.test.github.failing
+package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -21,10 +19,9 @@ class OwnerRequestTest {
 
     @Test
     fun testDeserHit340() {
-        expectFailure<UnrecognizedPropertyException>("GitHub #340 has been fixed!") {
-            val value: IsField = jackson.readValue(json)
-            assertEquals("Got a foo", value.foo)
-        }
+        val value: IsField = jackson.readValue(json)
+        // Fixed
+        assertEquals("Got a foo", value.foo)
     }
 
     @Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github340.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github340.kt
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Test
@@ -28,5 +29,18 @@ class OwnerRequestTest {
     fun testDeserWithoutIssue() {
         val value: NoIsField = jackson.readValue(json)
         assertEquals("Got a foo", value.foo)
+    }
+
+    // A test case for isSetter to work, added with the fix for this issue.
+    class IsSetter {
+        lateinit var isFoo: String
+    }
+
+    @Test
+    fun isSetterTest() {
+        val json = """{"isFoo":"bar"}"""
+        val isSetter: IsSetter = jackson.readValue(json)
+
+        assertEquals("bar", isSetter.isFoo)
     }
 }


### PR DESCRIPTION
`Kotlin` generates an getter named `isXxx` for a property named `isXxx`.
https://kotlinlang.org/docs/java-to-kotlin-interop.html#package-level-functions

On the other hand, `Jackson` treats a getter named `isXxx` as a property named `xxx`.
This has caused several problems in the past.

Currently `jackson-module-kotlin` avoids this problem by implementing `findRenameByField`(#287).
On the other hand, this approach causes unintended behavior when properties named `xxx` and `isXxx` are set (#340).

So I changed the name rewriting to do `findImplicitPropertyName` to fix this problem.

## Concerns
@cowtowncoder 
My main concern is that I am not fully aware of the scope of the impact of this change.

#287 changed from using `findImplicitPropertyName` to using `findRenameByField`, why is this?
All the tests that existed in `jackson-module-kotlin` were successful except for the failing test, and I could not read any intent in the implementation as far as I could find.
Any input on the impact of this change in terms of `databind` would be appreciated.

Also, even though this is a fix for a bug, it changes some of the behavior, do I need to be concerned about this?
I will add a note to the release notes in due course.