### PR TITLE
Fix #632: drop Kotlin 1.4 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         java_version: ['8', '11', '17']
-        kotlin_version: ['1.4.32', '1.5.32', '1.6.21', '1.7.20']
+	# Jackson 2.15 drops support for Kotlin 1.4, adds 1.8
+        kotlin_version: ['1.5.32', '1.6.21', '1.7.20', '1.8.10']
         os: ['ubuntu-20.04']
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: ['8', '11', '17']
-	# Jackson 2.15 drops support for Kotlin 1.4, adds 1.8
+        # Jackson 2.15 drops support for Kotlin 1.4, adds 1.8
         kotlin_version: ['1.5.32', '1.6.21', '1.7.20', '1.8.10']
         os: ['ubuntu-20.04']
     env:

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ println(arrayNode.toString()) // ["foo",true,1,1.0,"YmFy"]
 Different `kotlin-core` versions are supported by different Jackson Kotlin module minor versions.
 Here is an incomplete list of supported versions:
 
+* Jackson 2.15.x: Kotlin-core 1.5 - 1.8
 * Jackson 2.14.x: Kotlin-core 1.4 - 1.7
 * Jackson 2.13.x: Kotlin-core 1.4 - 1.7
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,7 @@
         <javac.src.version>1.8</javac.src.version>
         <javac.target.version>1.8</javac.target.version>
 
-	<!-- 11-Mar-2023, tatu: [kotlin#632] drops Kotlin 1.4 so target 1.5, but
-	       build with 1.6.x for now
-	  -->
-        <version.kotlin>1.6.21</version.kotlin>
-        <kotlin.compiler.languageVersion>1.5</kotlin.compiler.languageVersion>
-        <kotlin.compiler.apiVersion>1.5</kotlin.compiler.apiVersion>
+        <version.kotlin>1.5.32</version.kotlin>
 	
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/kotlin</packageVersion.dir>

--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,16 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- 16-Oct-2019, tatu: No point trying to target Java 7, Java 8 needed for build anyway -->
         <javac.src.version>1.8</javac.src.version>
         <javac.target.version>1.8</javac.target.version>
 
-        <version.kotlin>1.5.32</version.kotlin>
-
+	<!-- 11-Mar-2023, tatu: [kotlin#632] drops Kotlin 1.4 so target 1.5, but
+	       build with 1.6.x for now
+	  -->
+        <version.kotlin>1.6.21</version.kotlin>
+        <kotlin.compiler.languageVersion>1.5</kotlin.compiler.languageVersion>
+        <kotlin.compiler.apiVersion>1.5</kotlin.compiler.apiVersion>
+	
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/kotlin</packageVersion.dir>
         <packageVersion.package>${project.groupId}.kotlin</packageVersion.package>


### PR DESCRIPTION
As per title, changes build, CI, to target Kotlin versions 1.5 - 1.8, no longer 1.4.

Build will use Kotlin 1.6.