### PR TITLE
Bug fix: Don't serialize value class if their outer class has JsonInclude.NonNull annotation(#625)

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -71,6 +71,10 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
                         // If the return value of the getter is a value class,
                         // it will be serialized properly without doing anything.
                         if (this.returnType.isUnboxableValueClass()) return null
+                        // If outer class has JsonInclude.Include.NON_NULL value, then ignore value class
+                        // But we have to find how to get serialization configure of object mapper
+                        // because we don't have to serialize if object mapper has been configured by JsonInclude.Include.NON_NULL feature
+                        if (am.declaringClass.hasNonNullAnnotations()) return null
                     }
 
                     val kotlinProperty = getter

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.module.kotlin
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.core.json.PackageVersion
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
@@ -12,9 +14,19 @@ import java.util.*
 import kotlin.reflect.KClass
 
 private const val metadataFqName = "kotlin.Metadata"
+private const val jsonIncludeAnnotation = "com.fasterxml.jackson.annotation.JsonInclude"
 
 fun Class<*>.isKotlinClass(): Boolean {
     return declaredAnnotations.any { it.annotationClass.java.name == metadataFqName }
+}
+
+fun Class<*>.hasNonNullAnnotations(): Boolean {
+    return declaredAnnotations
+        .filter { it.annotationClass.java.name == jsonIncludeAnnotation }
+        .any {
+            it as JsonInclude
+            it.value == JsonInclude.Include.NON_NULL
+        }
 }
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullFeatureTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NonNullFeatureTest.kt
@@ -1,0 +1,47 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NonNullFeatureTest {
+    val objectMapper = jacksonObjectMapper()
+        .registerModule(SimpleModule())
+//        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+
+    @JvmInline
+    value class Wrapped(val rawValue: String)
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class NonNullDto (
+        val text: String? = null,
+        val wrapped: Wrapped? = null,
+    )
+
+    data class NullDto (
+        val text: String? = null,
+        val wrapped: Wrapped? = null,
+    )
+
+    @Test
+    fun `should not serialize null values with NonNull`() {
+        val nonNullDto = NonNullDto()
+        val expected = "{}"
+
+        val result = objectMapper.writeValueAsString(nonNullDto)
+
+        assertEquals(result, expected)
+    }
+
+    @Test
+    fun `should serialize null values with Null`() {
+        val nonNullDto = NullDto()
+        val expected = "{\"text\":null,\"wrapped\":null}"
+
+        val result = objectMapper.writeValueAsString(nonNullDto)
+
+        assertEquals(result, expected)
+    }
+}


### PR DESCRIPTION
The problem of #625 will resolved by this P.R.

-------
There's one more problem with that. 
if the objectmapper was configured as JsonInclude.NonNull, then objectmapper don't serialize property. But, objectMapper serialize property. I think it can be easily resolve if i know how to get serializationInclusion values of objectMapper in kotlinModuleClass.