### PR TITLE
In 2.15, fixed to not be able to use Kotlin 1.4 or lower.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -65,40 +65,34 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
     // Find a serializer to handle the case where the getter returns an unboxed value from the value class.
     override fun findSerializer(am: Annotated): StdSerializer<*>? = when (am) {
         is AnnotatedMethod -> {
-            when (KotlinVersion.CURRENT.isAtLeast(1, 5)) {
-                true -> {
-                    val getter = am.member.apply {
-                        // If the return value of the getter is a value class,
-                        // it will be serialized properly without doing anything.
-                        if (this.returnType.isUnboxableValueClass()) return null
-                    }
-
-                    val kotlinProperty = getter
-                        .declaringClass
-                        .kotlin
-                        .let {
-                            // KotlinReflectionInternalError is raised in GitHub167 test,
-                            // but it looks like an edge case, so it is ignored.
-                            try {
-                                it.memberProperties
-                            } catch (e: Error) {
-                                null
-                            }
-                        }?.find { it.javaGetter == getter }
-
-                    (kotlinProperty?.returnType?.classifier as? KClass<*>)
-                        ?.takeIf { it.isValue }
-                        ?.java
-                        ?.let { outerClazz ->
-                            val innerClazz = getter.returnType
-
-                            ValueClassStaticJsonValueSerializer.createdOrNull(outerClazz, innerClazz)
-                                ?: @Suppress("UNCHECKED_CAST") ValueClassBoxSerializer(outerClazz, innerClazz)
-                        }
-                }
-                // Kotlin 1.4 and lower doesn't have value classes and we avoid the NoSuchMethodException on it.isValue
-                else -> null
+            val getter = am.member.apply {
+                // If the return value of the getter is a value class,
+                // it will be serialized properly without doing anything.
+                if (this.returnType.isUnboxableValueClass()) return null
             }
+
+            val kotlinProperty = getter
+                .declaringClass
+                .kotlin
+                .let {
+                    // KotlinReflectionInternalError is raised in GitHub167 test,
+                    // but it looks like an edge case, so it is ignored.
+                    try {
+                        it.memberProperties
+                    } catch (e: Error) {
+                        null
+                    }
+                }?.find { it.javaGetter == getter }
+
+            (kotlinProperty?.returnType?.classifier as? KClass<*>)
+                ?.takeIf { it.isValue }
+                ?.java
+                ?.let { outerClazz ->
+                    val innerClazz = getter.returnType
+
+                    ValueClassStaticJsonValueSerializer.createdOrNull(outerClazz, innerClazz)
+                        ?: @Suppress("UNCHECKED_CAST") ValueClassBoxSerializer(outerClazz, innerClazz)
+                }
         }
         // Ignore the case of AnnotatedField, because JvmField cannot be set in the field of value class.
         else -> null

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
@@ -57,7 +58,10 @@ class KotlinModule @Deprecated(
     init {
         if (!KotlinVersion.CURRENT.isAtLeast(1, 5)) {
             // Kotlin 1.4 was deprecated when this process was introduced(jackson-module-kotlin 2.15).
-            throw IllegalStateException("jackson-module-kotlin requires Kotlin 1.5 or higher.")
+            throw JsonMappingException(
+                null,
+                "KotlinModule requires Kotlin version >= 1.5 - Found ${KotlinVersion.CURRENT}"
+            )
         }
     }
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -54,6 +54,13 @@ class KotlinModule @Deprecated(
     val singletonSupport: SingletonSupport = DISABLED,
     val strictNullChecks: Boolean = false
 ) : SimpleModule(KotlinModule::class.java.name, PackageVersion.VERSION) {
+    init {
+        if (!KotlinVersion.CURRENT.isAtLeast(1, 5)) {
+            // Kotlin 1.4 was deprecated when this process was introduced(jackson-module-kotlin 2.15).
+            throw IllegalStateException("jackson-module-kotlin requires Kotlin 1.5 or higher.")
+        }
+    }
+
     @Deprecated(level = DeprecationLevel.HIDDEN, message = "For ABI compatibility")
     constructor(
         reflectionCacheSize: Int,


### PR DESCRIPTION
SSIA

see https://github.com/FasterXML/jackson-module-kotlin/pull/643#discussion_r1133335284