### PR TITLE
Modified to use `Converter` in `Sequence` serialization

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Converters.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Converters.kt
@@ -1,8 +1,20 @@
 package com.fasterxml.jackson.module.kotlin
 
+import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
+import com.fasterxml.jackson.databind.type.TypeFactory
 import com.fasterxml.jackson.databind.util.StdConverter
 import kotlin.reflect.KClass
+
+internal class SequenceToIteratorConverter(private val input: JavaType) : StdConverter<Sequence<*>, Iterator<*>>() {
+    override fun convert(value: Sequence<*>): Iterator<*> = value.iterator()
+
+    override fun getInputType(typeFactory: TypeFactory): JavaType = input
+    // element-type may not be obtained, so a null check is required
+    override fun getOutputType(typeFactory: TypeFactory): JavaType = input.containedType(0)
+        ?.let { typeFactory.constructCollectionLikeType(Iterator::class.java, it) }
+        ?: typeFactory.constructType(Iterator::class.java)
+}
 
 // S is nullable because value corresponds to a nullable value class
 // @see KotlinNamesAnnotationIntrospector.findNullSerializer

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -68,9 +68,6 @@ internal class KotlinAnnotationIntrospector(private val context: Module.SetupCon
         // Find a converter to handle the case where the getter returns an unboxed value from the value class.
         is AnnotatedMethod -> cache.findValueClassReturnType(a)
             ?.let { cache.getValueClassBoxConverter(a.rawReturnType, it) }
-            ?: a.takeIf { Sequence::class.java.isAssignableFrom(it.rawType) }
-                ?.let { SequenceToIteratorConverter(it.type) }
-
         is AnnotatedClass -> a
             .takeIf { Sequence::class.java.isAssignableFrom(it.rawType) }
             ?.let { SequenceToIteratorConverter(it.type) }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -13,12 +13,6 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.math.BigInteger
 
-object SequenceSerializer : StdSerializer<Sequence<*>>(Sequence::class.java) {
-    override fun serialize(value: Sequence<*>, gen: JsonGenerator, provider: SerializerProvider) {
-        provider.defaultSerializeValue(value.iterator(), gen)
-    }
-}
-
 object UByteSerializer : StdSerializer<UByte>(UByte::class.java) {
     override fun serialize(value: UByte, gen: JsonGenerator, provider: SerializerProvider) =
         gen.writeNumber(value.toShort())
@@ -98,7 +92,6 @@ internal class KotlinSerializers : Serializers.Base() {
         val rawClass = type.rawClass
 
         return when {
-            Sequence::class.java.isAssignableFrom(rawClass) -> SequenceSerializer
             UByte::class.java.isAssignableFrom(rawClass) -> UByteSerializer
             UShort::class.java.isAssignableFrom(rawClass) -> UShortSerializer
             UInt::class.java.isAssignableFrom(rawClass) -> UIntSerializer

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -13,6 +13,16 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.math.BigInteger
 
+@Deprecated(
+    message = "This class will be removed in 2.16 or later as it has been replaced by SequenceToIteratorConverter.",
+    replaceWith = ReplaceWith("com.fasterxml.jackson.module.kotlin.SequenceToIteratorConverter")
+)
+object SequenceSerializer : StdSerializer<Sequence<*>>(Sequence::class.java) {
+    override fun serialize(value: Sequence<*>, gen: JsonGenerator, provider: SerializerProvider) {
+        provider.defaultSerializeValue(value.iterator(), gen)
+    }
+}
+
 object UByteSerializer : StdSerializer<UByte>(UByte::class.java) {
     override fun serialize(value: UByte, gen: JsonGenerator, provider: SerializerProvider) =
         gen.writeNumber(value.toShort())

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SequenceSerdesTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SequenceSerdesTests.kt
@@ -1,5 +1,9 @@
 package com.fasterxml.jackson.module.kotlin.test
 
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Test
@@ -41,5 +45,40 @@ class TestSequenceDeserializer {
         val objectMapper =  jacksonObjectMapper()
         val result = objectMapper.writeValueAsString(data)
         assertEquals("{\"value\":[]}", result)
+    }
+
+    class ContentSer : StdSerializer<String>(String::class.java) {
+        override fun serialize(value: String, gen: JsonGenerator, provider: SerializerProvider) {
+            provider.defaultSerializeValue("$value-ser", gen)
+        }
+    }
+
+    data class ListWrapper(
+        @JsonSerialize(contentUsing = ContentSer::class) val value: List<String>
+    )
+
+    data class SequenceWrapper(
+        @JsonSerialize(contentUsing = ContentSer::class)
+        val value: Sequence<String>
+    )
+
+    @Test
+    fun contentUsingTest() {
+        val mapper = jacksonObjectMapper()
+
+        val listResult = mapper.writeValueAsString(ListWrapper(listOf("foo")))
+        val sequenceResult = mapper.writeValueAsString(SequenceWrapper(sequenceOf("foo")))
+
+        assertEquals("""{"value":["foo-ser"]}""", sequenceResult)
+        assertEquals(listResult, sequenceResult)
+    }
+
+    // @see #674
+    @Test
+    fun sequenceOfTest() {
+        val mapper = jacksonObjectMapper()
+        val result = mapper.writeValueAsString(sequenceOf("foo"))
+
+        assertEquals("""["foo"]""", result)
     }
 }


### PR DESCRIPTION
Serialization of `Sequence` has been modified to use `Converter` instead of `Serializer`.
With this change, `JsonSerialize(contentUsing = ...) `, etc., will work for `Collection` as well as for `Sequence`.

This issue is related to #671.
Also, for #674, fixes a problem with serialization of `Sequence` created by the `sequenceOf` function.