### PR TITLE
Update Kotlin Version to 1.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: ['8', '11', '17']
-        # Jackson 2.15 drops support for Kotlin 1.4
-        kotlin_version: ['1.5.32', '1.6.21', '1.7.20', '1.8.10', '1.8.20-RC']
+        kotlin_version: ['1.6.21', '1.7.20', '1.8.22', '1.9.0']
         os: ['ubuntu-20.04']
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ println(arrayNode.toString()) // ["foo",true,1,1.0,"YmFy"]
 Different `kotlin-core` versions are supported by different Jackson Kotlin module minor versions.
 Here is an incomplete list of supported versions:
 
+* Jackson 2.16.x: Kotlin-core 1.6 - 1.9
 * Jackson 2.15.x: Kotlin-core 1.5 - 1.8
 * Jackson 2.14.x: Kotlin-core 1.4 - 1.8
 * Jackson 2.13.x: Kotlin-core 1.4 - 1.7

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <javac.src.version>1.8</javac.src.version>
         <javac.target.version>1.8</javac.target.version>
 
-        <version.kotlin>1.5.32</version.kotlin>
+        <version.kotlin>1.6.21</version.kotlin>
 	
         <!-- Generate PackageVersion.java into this directory. -->
         <packageVersion.dir>com/fasterxml/jackson/module/kotlin</packageVersion.dir>

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.16.0 (not yet released)
 
 WrongWrong (@k163377)
+* #684: Update Kotlin Version to 1.6
 * #682: Remove MissingKotlinParameterException and replace with MismatchedInputException
 
 # 2.15.2

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,7 @@ Co-maintainers:
 
 2.16.0 (not yet released)
 
+#684: Kotlin 1.5 has been deprecated and the minimum supported Kotlin version will be updated to 1.6.
 #682: Remove MissingKotlinParameterException and replace with MismatchedInputException
  This change removes MissingKotlinParameterException and resolves #617.
  This change is a prerequisite for future work to improve performance.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github356.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github356.kt
@@ -42,8 +42,8 @@ class TestGithub356 {
     }
 }
 
-// Deprecated usage kept at 1.5.0 upgrade; delete in the future
-inline class InlineClass(val value: String)
+@JvmInline
+value class InlineClass(val value: String)
 
 @JsonDeserialize(builder = ClassWithInlineMember.JacksonBuilder::class)
 data class ClassWithInlineMember(val inlineClassProperty: InlineClass) {


### PR DESCRIPTION
Kotlin 1.5 has been deprecated and the minimum supported Kotlin version will be updated to 1.6 for Jackson 2.16 and later.
https://kotlinlang.org/docs/kotlin-evolution.html#compatibility-flags