### PR TITLE
Add KotlinPropertyNameAsImplicitName option

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinFeature.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinFeature.kt
@@ -42,7 +42,23 @@ enum class KotlinFeature(private val enabledByDefault: Boolean) {
      * may contain null values after deserialization.
      * Enabling it protects against this but has significant performance impact.
      */
-    StrictNullChecks(enabledByDefault = false);
+    StrictNullChecks(enabledByDefault = false),
+
+    /**
+     * By enabling this feature, the property name on Kotlin will be used as the getter name.
+     *
+     * By default, the name based on the getter name on the JVM is used as the accessor name.
+     * This name may be different from the parameter/field name, in which case serialization results
+     * may be incorrect or annotations may malfunction.
+     * See [jackson-module-kotlin#630] for details.
+     *
+     * By enabling this feature, such malfunctions will not occur.
+     *
+     * On the other hand, enabling this option increases the amount of reflection processing,
+     * which may result in performance degradation for both serialization and deserialization.
+     * In addition, the adjustment of behavior using get:JvmName is disabled.
+     */
+    UseKotlinPropertyNameForGetter(enabledByDefault = false);
 
     internal val bitSet: BitSet = (1 shl ordinal).toBitSet()
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinFeature.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinFeature.kt
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
 import java.util.BitSet
-import kotlin.math.pow
 
 /**
  * @see KotlinModule.Builder
@@ -45,9 +44,9 @@ enum class KotlinFeature(private val enabledByDefault: Boolean) {
     StrictNullChecks(enabledByDefault = false),
 
     /**
-     * By enabling this feature, the property name on Kotlin will be used as the getter name.
+     * By enabling this feature, the property name on Kotlin is used as the implicit name for the getter.
      *
-     * By default, the name based on the getter name on the JVM is used as the accessor name.
+     * By default, the getter name is used during serialization.
      * This name may be different from the parameter/field name, in which case serialization results
      * may be incorrect or annotations may malfunction.
      * See [jackson-module-kotlin#630] for details.
@@ -57,8 +56,9 @@ enum class KotlinFeature(private val enabledByDefault: Boolean) {
      * On the other hand, enabling this option increases the amount of reflection processing,
      * which may result in performance degradation for both serialization and deserialization.
      * In addition, the adjustment of behavior using get:JvmName is disabled.
+     * Note also that this feature does not apply to setters.
      */
-    UseKotlinPropertyNameForGetter(enabledByDefault = false);
+    KotlinPropertyNameAsImplicitName(enabledByDefault = false);
 
     internal val bitSet: BitSet = (1 shl ordinal).toBitSet()
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyCollection
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
-import com.fasterxml.jackson.module.kotlin.KotlinFeature.UseKotlinPropertyNameForGetter
+import com.fasterxml.jackson.module.kotlin.KotlinFeature.KotlinPropertyNameAsImplicitName
 import com.fasterxml.jackson.module.kotlin.SingletonSupport.CANONICALIZE
 import com.fasterxml.jackson.module.kotlin.SingletonSupport.DISABLED
 import java.util.*
@@ -105,7 +105,7 @@ class KotlinModule @Deprecated(
             else -> DISABLED
         },
         builder.isEnabled(StrictNullChecks),
-        builder.isEnabled(UseKotlinPropertyNameForGetter)
+        builder.isEnabled(KotlinPropertyNameAsImplicitName)
     )
 
     companion object {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyCollection
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
+import com.fasterxml.jackson.module.kotlin.KotlinFeature.UseKotlinPropertyNameForGetter
 import com.fasterxml.jackson.module.kotlin.SingletonSupport.CANONICALIZE
 import com.fasterxml.jackson.module.kotlin.SingletonSupport.DISABLED
 import java.util.*
@@ -53,7 +54,8 @@ class KotlinModule @Deprecated(
     val nullToEmptyMap: Boolean = false,
     val nullIsSameAsDefault: Boolean = false,
     val singletonSupport: SingletonSupport = DISABLED,
-    val strictNullChecks: Boolean = false
+    val strictNullChecks: Boolean = false,
+    val useKotlinPropertyNameForGetter: Boolean = false
 ) : SimpleModule(KotlinModule::class.java.name, PackageVersion.VERSION) {
     init {
         if (!KotlinVersion.CURRENT.isAtLeast(1, 5)) {
@@ -102,7 +104,8 @@ class KotlinModule @Deprecated(
             builder.isEnabled(KotlinFeature.SingletonSupport) -> CANONICALIZE
             else -> DISABLED
         },
-        builder.isEnabled(StrictNullChecks)
+        builder.isEnabled(StrictNullChecks),
+        builder.isEnabled(UseKotlinPropertyNameForGetter)
     )
 
     companion object {
@@ -130,7 +133,13 @@ class KotlinModule @Deprecated(
         }
 
         context.insertAnnotationIntrospector(KotlinAnnotationIntrospector(context, cache, nullToEmptyCollection, nullToEmptyMap, nullIsSameAsDefault))
-        context.appendAnnotationIntrospector(KotlinNamesAnnotationIntrospector(this, cache, ignoredClassesForImplyingJsonCreator))
+        context.appendAnnotationIntrospector(
+            KotlinNamesAnnotationIntrospector(
+                this,
+                cache,
+                ignoredClassesForImplyingJsonCreator,
+                useKotlinPropertyNameForGetter)
+        )
 
         context.addDeserializers(KotlinDeserializers())
         context.addKeyDeserializers(KotlinKeyDeserializers)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -27,7 +27,12 @@ import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.kotlinFunction
 
-internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val cache: ReflectionCache, val ignoredClassesForImplyingJsonCreator: Set<KClass<*>>) : NopAnnotationIntrospector() {
+internal class KotlinNamesAnnotationIntrospector(
+    val module: KotlinModule,
+    val cache: ReflectionCache,
+    val ignoredClassesForImplyingJsonCreator: Set<KClass<*>>,
+    val useKotlinPropertyNameForGetter: Boolean
+) : NopAnnotationIntrospector() {
     // since 2.4
     override fun findImplicitPropertyName(member: AnnotatedMember): String? {
         if (!member.declaringClass.isKotlinClass()) return null

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github630.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github630.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertEquals
 
 class Github630 {
     private val mapper = ObjectMapper()
-        .registerModule(KotlinModule.Builder().enable(KotlinFeature.UseKotlinPropertyNameForGetter).build())!!
+        .registerModule(KotlinModule.Builder().enable(KotlinFeature.KotlinPropertyNameAsImplicitName).build())!!
 
     data class Dto(
         // from #570, #603

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github630.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github630.kt
@@ -1,0 +1,40 @@
+package com.fasterxml.jackson.module.kotlin.test.github
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class Github630 {
+    private val mapper = ObjectMapper()
+        .registerModule(KotlinModule.Builder().enable(KotlinFeature.UseKotlinPropertyNameForGetter).build())!!
+
+    data class Dto(
+        // from #570, #603
+        val FOO: Int = 0,
+        val bAr: Int = 0,
+        @JsonProperty("b")
+        val BAZ: Int = 0,
+        @JsonProperty("q")
+        val qUx: Int = 0,
+        // from #71
+        internal val quux: Int = 0,
+        // from #434
+        val `corge-corge`: Int = 0,
+        // additional
+        @get:JvmName("aaa")
+        val grault: Int = 0
+    )
+
+    @Test
+    fun test() {
+        val dto = Dto()
+
+        assertEquals(
+            """{"FOO":0,"bAr":0,"b":0,"q":0,"quux":0,"corge-corge":0,"grault":0}""",
+            mapper.writeValueAsString(dto)
+        )
+    }
+}


### PR DESCRIPTION
Added option to use property names in Kotlin as getter names.
This resolves #630.