### PR TITLE
Optimize and Refactor KotlinValueInstantiator.createFromObjectWith

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.16.0 (not yet released)
 
 WrongWrong (@k163377)
+* #687: Optimize and Refactor KotlinValueInstantiator.createFromObjectWith
 * #685: Streamline default value management for KotlinFeatures
 * #684: Update Kotlin Version to 1.6
 * #682: Remove MissingKotlinParameterException and replace with MismatchedInputException

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,7 @@ Co-maintainers:
 
 2.16.0 (not yet released)
 
+#687: Optimize and Refactor KotlinValueInstantiator.createFromObjectWith.
 #685: Streamline default value management for KotlinFeatures.
  This improves the initialization cost of kotlin-module a little.
 #684: Kotlin 1.5 has been deprecated and the minimum supported Kotlin version will be updated to 1.6.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import java.lang.reflect.TypeVariable
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
 import kotlin.reflect.jvm.javaType
 
 internal class KotlinValueInstantiator(
@@ -28,6 +29,8 @@ internal class KotlinValueInstantiator(
         (nullToEmptyCollection && this.isCollectionLikeType) || (nullToEmptyMap && this.isMapLikeType)
 
     private fun KType.isGenericTypeVar() = javaType is TypeVariable<*>
+
+    private fun List<KTypeProjection>.markedNonNullAt(index: Int) = getOrNull(index)?.type?.isMarkedNullable == false
 
     override fun createFromObjectWith(
         ctxt: DeserializationContext,
@@ -64,6 +67,7 @@ internal class KotlinValueInstantiator(
                 return@forEachIndexed
             }
 
+            val paramType = paramDef.type
             var paramVal = if (!isMissing || paramDef.isPrimitive() || jsonProp.hasInjectableValueId()) {
                 val tempParamVal = buffer.getParameter(jsonProp)
                 if (nullIsSameAsDefault && tempParamVal == null && paramDef.isOptional) {
@@ -71,7 +75,7 @@ internal class KotlinValueInstantiator(
                 }
                 tempParamVal
             } else {
-                if(paramDef.type.isMarkedNullable) {
+                if(paramType.isMarkedNullable) {
                     // do not try to create any object if it is nullable and the value is missing
                     null
                 } else {
@@ -80,17 +84,19 @@ internal class KotlinValueInstantiator(
                 }
             }
 
+            val propType = jsonProp.type
+
             if (paramVal == null) {
-                if (jsonProp.type.requireEmptyValue()) {
+                if (propType.requireEmptyValue()) {
                     paramVal = NullsAsEmptyProvider(jsonProp.valueDeserializer).getNullValue(ctxt)
                 } else {
                     val isMissingAndRequired = isMissing && jsonProp.isRequired
 
                     // Since #310 reported that the calculation cost is high, isGenericTypeVar is determined last.
-                    if (isMissingAndRequired || (!paramDef.type.isMarkedNullable && !paramDef.type.isGenericTypeVar())) {
+                    if (isMissingAndRequired || (!paramType.isMarkedNullable && !paramType.isGenericTypeVar())) {
                         throw MismatchedInputException.from(
                             ctxt.parser,
-                            jsonProp.type,
+                            propType,
                             "Instantiation of $valueTypeDesc value failed for JSON property ${jsonProp.name} " +
                                     "due to missing (therefore NULL) value for creator parameter ${paramDef.name} " +
                                     "which is a non-nullable type"
@@ -98,28 +104,31 @@ internal class KotlinValueInstantiator(
                     }
                 }
             } else if (strictNullChecks) {
-                var paramType: String? = null
+                val arguments = paramType.arguments
+
+                var paramTypeStr: String? = null
                 var itemType: KType? = null
-                if (jsonProp.type.isCollectionLikeType && paramDef.type.arguments.getOrNull(0)?.type?.isMarkedNullable == false && (paramVal as Collection<*>).any { it == null }) {
-                    paramType = "collection"
-                    itemType = paramDef.type.arguments[0].type
+
+                if (propType.isCollectionLikeType && arguments.markedNonNullAt(0) && (paramVal as Collection<*>).any { it == null }) {
+                    paramTypeStr = "collection"
+                    itemType = arguments[0].type
                 }
 
-                if (jsonProp.type.isMapLikeType && paramDef.type.arguments.getOrNull(1)?.type?.isMarkedNullable == false && (paramVal as Map<*, *>).any { it.value == null }) {
-                    paramType = "map"
-                    itemType = paramDef.type.arguments[1].type
+                if (propType.isMapLikeType && arguments.markedNonNullAt(1) && (paramVal as Map<*, *>).any { it.value == null }) {
+                    paramTypeStr = "map"
+                    itemType = arguments[1].type
                 }
 
-                if (jsonProp.type.isArrayType && paramDef.type.arguments.getOrNull(0)?.type?.isMarkedNullable == false && (paramVal as Array<*>).any { it == null }) {
-                    paramType = "array"
-                    itemType = paramDef.type.arguments[0].type
+                if (propType.isArrayType && arguments.markedNonNullAt(0) && (paramVal as Array<*>).any { it == null }) {
+                    paramTypeStr = "array"
+                    itemType = arguments[0].type
                 }
 
-                if (paramType != null && itemType != null) {
+                if (paramTypeStr != null && itemType != null) {
                     throw MismatchedInputException.from(
                         ctxt.parser,
-                        jsonProp.type,
-                        "Instantiation of $itemType $paramType failed for JSON property ${jsonProp.name} due to null value in a $paramType that does not allow null values"
+                        propType,
+                        "Instantiation of $itemType $paramTypeStr failed for JSON property ${jsonProp.name} due to null value in a $paramTypeStr that does not allow null values"
                     ).wrapWithPath(this.valueClass, jsonProp.name)
                 }
             }


### PR DESCRIPTION
Optimized various checks on `paramVal`.

- Null check of paramVal is done only once
- Skip MismatchedInput check when paramVal is non-null
- Skip strictNullCheck for empty collections completed by requireEmptyValue
- Modified isGenericTypeVar to be determined at the last(relates to #310)

These changes are expected to improve deserialization performance.

In addition, several refactors were made to improve readability.