### PR TITLE
Reduce the load on the search process for serializers

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -21,6 +21,7 @@ kkurczewski
 * #689: Add KotlinDuration support
 
 WrongWrong (@k163377)
+* #700: Reduce the load on the search process for serializers
 * #687: Optimize and Refactor KotlinValueInstantiator.createFromObjectWith
 * #686: Add KotlinPropertyNameAsImplicitName option
 * #685: Streamline default value management for KotlinFeatures

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,7 @@ Co-maintainers:
 
 2.16.0 (not yet released)
 
+#700: Reduce the load on the search process for serializers.
 #689: Added UseJavaDurationConversion feature.
  By enabling this feature and adding the Java Time module, Kotlin Duration can be handled in the same way as Java Duration.
 #687: Optimize and Refactor KotlinValueInstantiator.createFromObjectWith.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -102,10 +102,10 @@ internal class KotlinSerializers : Serializers.Base() {
         val rawClass = type.rawClass
 
         return when {
-            UByte::class.java.isAssignableFrom(rawClass) -> UByteSerializer
-            UShort::class.java.isAssignableFrom(rawClass) -> UShortSerializer
-            UInt::class.java.isAssignableFrom(rawClass) -> UIntSerializer
-            ULong::class.java.isAssignableFrom(rawClass) -> ULongSerializer
+            UByte::class.java == rawClass -> UByteSerializer
+            UShort::class.java == rawClass -> UShortSerializer
+            UInt::class.java == rawClass -> UIntSerializer
+            ULong::class.java == rawClass -> ULongSerializer
             // The priority of Unboxing needs to be lowered so as not to break the serialization of Unsigned Integers.
             rawClass.isUnboxableValueClass() -> ValueClassSerializer.from(rawClass)
             else -> null


### PR DESCRIPTION
Because unsigned integers are a final class and there is no need to compare them with isAssignableFrom.
This change slightly speeds up the initial execution of serialization.