### PR TITLE
Changed to use default argument on `null` if `JsonSetter(nulls = Nulls.SKIP)` is specified.

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -21,6 +21,7 @@ kkurczewski
 * #689: Add KotlinDuration support
 
 WrongWrong (@k163377)
+* #707: Changed to use default argument on null if JsonSetter(nulls = Nulls.SKIP) is specified.
 * #700: Reduce the load on the search process for serializers
 * #687: Optimize and Refactor KotlinValueInstantiator.createFromObjectWith
 * #686: Add KotlinPropertyNameAsImplicitName option

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,7 @@ Co-maintainers:
 
 2.16.0 (not yet released)
 
+#707: If JsonSetter(nulls = Nulls.SKIP) is specified, the default argument is now used when null.
 #700: Reduce the load on the search process for serializers.
 #689: Added UseJavaDurationConversion feature.
  By enabling this feature and adding the Java Time module, Kotlin Duration can be handled in the same way as Java Duration.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -35,7 +35,7 @@ internal class KotlinValueInstantiator(
     private fun List<KTypeProjection>.markedNonNullAt(index: Int) = getOrNull(index)?.type?.isMarkedNullable == false
 
     private fun SettableBeanProperty.skipNulls(): Boolean =
-        nullIsSameAsDefault || (getAnnotation(JsonSetter::class.java).nulls == Nulls.SKIP)
+        nullIsSameAsDefault || (getAnnotation(JsonSetter::class.java)?.nulls == Nulls.SKIP)
 
     override fun createFromObjectWith(
         ctxt: DeserializationContext,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.module.kotlin
 
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
 import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.DeserializationConfig
 import com.fasterxml.jackson.databind.DeserializationContext
@@ -31,6 +33,9 @@ internal class KotlinValueInstantiator(
     private fun KType.isGenericTypeVar() = javaType is TypeVariable<*>
 
     private fun List<KTypeProjection>.markedNonNullAt(index: Int) = getOrNull(index)?.type?.isMarkedNullable == false
+
+    private fun SettableBeanProperty.skipNulls(): Boolean =
+        nullIsSameAsDefault || (getAnnotation(JsonSetter::class.java).nulls == Nulls.SKIP)
 
     override fun createFromObjectWith(
         ctxt: DeserializationContext,
@@ -70,7 +75,7 @@ internal class KotlinValueInstantiator(
             val paramType = paramDef.type
             var paramVal = if (!isMissing || paramDef.isPrimitive() || jsonProp.hasInjectableValueId()) {
                 val tempParamVal = buffer.getParameter(jsonProp)
-                if (nullIsSameAsDefault && tempParamVal == null && paramDef.isOptional) {
+                if (tempParamVal == null && jsonProp.skipNulls() && paramDef.isOptional) {
                     return@forEachIndexed
                 }
                 tempParamVal

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.module.kotlin
 
-import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.annotation.Nulls
 import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.DeserializationConfig
@@ -35,7 +34,7 @@ internal class KotlinValueInstantiator(
     private fun List<KTypeProjection>.markedNonNullAt(index: Int) = getOrNull(index)?.type?.isMarkedNullable == false
 
     private fun SettableBeanProperty.skipNulls(): Boolean =
-        nullIsSameAsDefault || (getAnnotation(JsonSetter::class.java)?.nulls == Nulls.SKIP)
+        nullIsSameAsDefault || (metadata.valueNulls == Nulls.SKIP)
 
     override fun createFromObjectWith(
         ctxt: DeserializationContext,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github526.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github526.kt
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.module.kotlin.test.github
+
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class Github526 {
+    data class D(@JsonSetter(nulls = Nulls.SKIP) val v: Int = -1)
+
+    @Test
+    fun test() {
+        val mapper = jacksonObjectMapper()
+        val d = mapper.readValue<D>("""{"v":null}""")
+
+        assertEquals(-1, d.v)
+    }
+}


### PR DESCRIPTION
At least `Nulls.FAIL` worked, so it seems natural behavior for `Nulls.SKIP` to use default values.

Fixes #526