### PR TITLE
Correction of package and class names in Github396

### DIFF
--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github396.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github396.kt
@@ -1,13 +1,11 @@
-package com.fasterxml.jackson.module.kotlin.test.github.failing
+package com.fasterxml.jackson.module.kotlin.test.github
 
-import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class TestGithub396 {
+class Github396 {
     /**
      * Succeeds in Jackson 2.11.x, but fails in Jackson 2.12.0.
      * But succeeds again in 2.15.0.


### PR DESCRIPTION
It appears that the package was left out of the fix when moving from the failing test.
Also, , class name and file name were discrepant, so they were corrected to match the file name.