### PR TITLE
Fixed KotlinPropertyNameAsImplicitName not working in edge case

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -21,6 +21,7 @@ kkurczewski
 * #689: Add KotlinDuration support
 
 WrongWrong (@k163377)
+* #710: Fixed KotlinPropertyNameAsImplicitName not working in edge case
 * #709: Add failing test for #242
 * #707: Changed to use default argument on null if JsonSetter(nulls = Nulls.SKIP) is specified.
 * #700: Reduce the load on the search process for serializers

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -28,6 +28,7 @@ Co-maintainers:
 #686: Added KotlinPropertyNameAsImplicitName feature to use Kotlin property names as implicit names for getters.
  Enabling this feature eliminates some of the problems summarized in #630,
  but also causes some behavioral changes and performance degradation.
+ A minor correction has been made to this option in #710.
 #685: Streamline default value management for KotlinFeatures.
  This improves the initialization cost of kotlin-module a little.
 #684: Kotlin 1.5 has been deprecated and the minimum supported Kotlin version will be updated to 1.6.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -2,16 +2,12 @@ package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.PropertyName
-import com.fasterxml.jackson.databind.cfg.MapperConfig
 import com.fasterxml.jackson.databind.introspect.Annotated
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
-import com.fasterxml.jackson.databind.introspect.AnnotatedField
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
-import com.fasterxml.jackson.databind.util.BeanUtil
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.util.Locale
@@ -57,10 +53,11 @@ internal class KotlinNamesAnnotationIntrospector(
     }
 
     private fun getterNameFromKotlin(member: AnnotatedMethod): String? {
-        val getter = member.member
+        val getterName = member.member.name
 
         return member.member.declaringClass.takeIf { it.isKotlinClass() }?.let { clazz ->
-            clazz.kotlin.memberProperties.find { it.javaGetter == getter }
+            // For edge case, methods must be compared by name, not directly.
+            clazz.kotlin.memberProperties.find { it.javaGetter?.name == getterName }
                 ?.let { it.name }
         }
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github710.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github710.kt
@@ -1,0 +1,25 @@
+package com.fasterxml.jackson.module.kotlin.test.github
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class Github710 {
+    interface I<T> {
+        val foo: T
+        val bAr: T get() = foo
+    }
+
+    class C(override val foo: Int) : I<Int>
+
+    @Test
+    fun test() {
+        val mapper = KotlinModule.Builder().enable(KotlinFeature.KotlinPropertyNameAsImplicitName)
+            .let { ObjectMapper().registerModule(it.build()) }
+        val result = mapper.writeValueAsString(C(1))
+
+        assertEquals("""{"foo":1,"bAr":1}""", result)
+    }
+}


### PR DESCRIPTION
The case to be fixed is as described in the test.

The `Kotlin` property `javaGetter`, in its default implementation, returns a bridge method, but since `Jackson` processes real methods, method-to-method comparisons will fail.
Comparing by name fixes this problem.

```java
      // decompiled
      // jackson's processing target
      @NotNull
      public Integer getBAr() {
         return (Integer)GithubXXX.I.DefaultImpls.getBAr(this);
      }

      // javaGetter returns
      // $FF: synthetic method
      // $FF: bridge method
      public Object getBAr() {
         return this.getBAr();
      }
```