### PR TITLE
Correction of forgotten changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,9 +216,9 @@
 			    <!-- 16-Mar-2022, tatu: Sometimes may need to change baseline and
 				  if so, need to add temporary exclusions to avoid build breakage
 			    -->
-			    <!-- 19-Feb-2023, tatu: For 2.15, compare to 2.14 baseline
-			      -->
-                            <version>2.14.0</version>
+			    <!-- 30-Sep-2023, wrongwrong: For 2.16, compare to 2.15.2 baseline
+			    -->
+                            <version>2.15.2</version>
                             <type>jar</type>
                         </dependency>
                     </oldVersion>
@@ -231,14 +231,15 @@
                         <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                         <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
                         <excludes>
-			  <!-- Cache removal from ReflectionCache; internal change
-			    -->
-                          <exclude>com.fasterxml.jackson.module.kotlin.ReflectionCache</exclude>
-                          <exclude>com.fasterxml.jackson.module.kotlin.TypesKt</exclude>
+                <!-- public -->
+                          <!-- options added -->
+                          <exclude>com.fasterxml.jackson.module.kotlin.KotlinModule</exclude>
+                          <!-- class removed -->
                           <exclude>com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException</exclude>
+                <!-- internal -->
+                          <exclude>com.fasterxml.jackson.module.kotlin.KotlinNamesAnnotationIntrospector</exclude>
                           <exclude>com.fasterxml.jackson.module.kotlin.KotlinAnnotationIntrospector</exclude>
-                          <exclude>com.fasterxml.jackson.module.kotlin.ValueClassBoxSerializer</exclude>
-                          <exclude>com.fasterxml.jackson.module.kotlin.ValueClassStaticJsonValueSerializer</exclude>
+                          <exclude>com.fasterxml.jackson.module.kotlin.KotlinDeserializers</exclude>
                         </excludes>
                     </parameter>
                 </configuration>

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -61,6 +61,11 @@ class KotlinModule @Deprecated(
     val useKotlinPropertyNameForGetter: Boolean = false,
     val useJavaDurationConversion: Boolean = false,
 ) : SimpleModule(KotlinModule::class.java.name, PackageVersion.VERSION) {
+    companion object {
+        // Increment when option is added
+        const val serialVersionUID = 2L
+    }
+
     init {
         if (!KotlinVersion.CURRENT.isAtLeast(1, 5)) {
             // Kotlin 1.4 was deprecated when this process was introduced(jackson-module-kotlin 2.15).
@@ -112,10 +117,6 @@ class KotlinModule @Deprecated(
         builder.isEnabled(KotlinPropertyNameAsImplicitName),
         builder.isEnabled(UseJavaDurationConversion),
     )
-
-    companion object {
-        const val serialVersionUID = 1L
-    }
 
     private val ignoredClassesForImplyingJsonCreator = emptySet<KClass<*>>()
 


### PR DESCRIPTION
- Change japicmp baseline to 2.15.2 for 2.16 dev ed3ac13280e38137da102d778d91c5ecc0b158b5
- Correction of forgotten `serialVersionUID` increment 57b72d7be10c3f880f4ee0460800fa6aee65a737