### PR TITLE
Fix problem with Serializable objects not implementing readResolve

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -17,6 +17,11 @@ Contributors:
 
 # 2.17.0 (not yet released)
 
+# 2.16.1 (not yet released)
+
+WrongWrong (@k163377)
+* #733: Fix problem with Serializable objects not implementing readResolve
+
 # 2.16.0
 
 kkurczewski

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,10 @@ Co-maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.16.1 (not yet released)
+
+#733: Fix problem with Serializable objects not implementing readResolve.
+
 2.16.0 (15-Nov-2023)
 
 #707: If JsonSetter(nulls = Nulls.SKIP) is specified, the default argument is now used when null.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
@@ -13,12 +13,16 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import kotlin.time.Duration as KotlinDuration
 
 object SequenceDeserializer : StdDeserializer<Sequence<*>>(Sequence::class.java) {
+    private fun readResolve(): Any = SequenceDeserializer
+
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Sequence<*> {
         return ctxt.readValue(p, List::class.java).asSequence()
     }
 }
 
 object RegexDeserializer : StdDeserializer<Regex>(Regex::class.java) {
+    private fun readResolve(): Any = RegexDeserializer
+
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Regex {
         val node = ctxt.readTree(p)
 
@@ -43,6 +47,8 @@ object RegexDeserializer : StdDeserializer<Regex>(Regex::class.java) {
 }
 
 object UByteDeserializer : StdDeserializer<UByte>(UByte::class.java) {
+    private fun readResolve(): Any = UByteDeserializer
+
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext) =
         p.shortValue.asUByte() ?: throw InputCoercionException(
             p,
@@ -53,6 +59,8 @@ object UByteDeserializer : StdDeserializer<UByte>(UByte::class.java) {
 }
 
 object UShortDeserializer : StdDeserializer<UShort>(UShort::class.java) {
+    private fun readResolve(): Any = UShortDeserializer
+
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext) =
         p.intValue.asUShort() ?: throw InputCoercionException(
             p,
@@ -63,6 +71,8 @@ object UShortDeserializer : StdDeserializer<UShort>(UShort::class.java) {
 }
 
 object UIntDeserializer : StdDeserializer<UInt>(UInt::class.java) {
+    private fun readResolve(): Any = UIntDeserializer
+
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext) =
         p.longValue.asUInt() ?: throw InputCoercionException(
             p,
@@ -73,6 +83,8 @@ object UIntDeserializer : StdDeserializer<UInt>(UInt::class.java) {
 }
 
 object ULongDeserializer : StdDeserializer<ULong>(ULong::class.java) {
+    private fun readResolve(): Any = ULongDeserializer
+
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext) =
         p.bigIntegerValue.asULong() ?: throw InputCoercionException(
             p,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializers
 // If StdKeyDeserializer is modified, need to modify this too.
 
 internal object UByteKeyDeserializer : StdKeyDeserializer(TYPE_SHORT, UByte::class.java) {
+    private fun readResolve(): Any = UByteKeyDeserializer
+
     override fun deserializeKey(key: String?, ctxt: DeserializationContext): UByte? = super.deserializeKey(key, ctxt)
         ?.let {
             (it as Short).asUByte() ?: throw InputCoercionException(
@@ -22,6 +24,8 @@ internal object UByteKeyDeserializer : StdKeyDeserializer(TYPE_SHORT, UByte::cla
 }
 
 internal object UShortKeyDeserializer : StdKeyDeserializer(TYPE_INT, UShort::class.java) {
+    private fun readResolve(): Any = UShortKeyDeserializer
+
     override fun deserializeKey(key: String?, ctxt: DeserializationContext): UShort? = super.deserializeKey(key, ctxt)
         ?.let {
             (it as Int).asUShort() ?: throw InputCoercionException(
@@ -34,6 +38,8 @@ internal object UShortKeyDeserializer : StdKeyDeserializer(TYPE_INT, UShort::cla
 }
 
 internal object UIntKeyDeserializer : StdKeyDeserializer(TYPE_LONG, UInt::class.java) {
+    private fun readResolve(): Any = UIntKeyDeserializer
+
     override fun deserializeKey(key: String?, ctxt: DeserializationContext): UInt? = super.deserializeKey(key, ctxt)
         ?.let {
             (it as Long).asUInt() ?: throw InputCoercionException(
@@ -47,6 +53,8 @@ internal object UIntKeyDeserializer : StdKeyDeserializer(TYPE_LONG, UInt::class.
 
 // kind parameter is dummy.
 internal object ULongKeyDeserializer : StdKeyDeserializer(TYPE_LONG, ULong::class.java) {
+    private fun readResolve(): Any = ULongKeyDeserializer
+
     override fun deserializeKey(key: String?, ctxt: DeserializationContext): ULong? = key?.let {
         it.toBigInteger().asULong() ?: throw InputCoercionException(
             null,
@@ -58,6 +66,8 @@ internal object ULongKeyDeserializer : StdKeyDeserializer(TYPE_LONG, ULong::clas
 }
 
 internal object KotlinKeyDeserializers : StdKeyDeserializers() {
+    private fun readResolve(): Any = KotlinKeyDeserializers
+
     override fun findKeyDeserializer(
         type: JavaType,
         config: DeserializationConfig?,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
@@ -13,6 +13,8 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
 internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.java) {
+    private fun readResolve(): Any = ValueClassUnboxKeySerializer
+
     override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
         val method = value::class.java.getMethod("unbox-impl")
         val unboxed = method.invoke(value)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -24,21 +24,29 @@ object SequenceSerializer : StdSerializer<Sequence<*>>(Sequence::class.java) {
 }
 
 object UByteSerializer : StdSerializer<UByte>(UByte::class.java) {
+    private fun readResolve(): Any = UByteSerializer
+
     override fun serialize(value: UByte, gen: JsonGenerator, provider: SerializerProvider) =
         gen.writeNumber(value.toShort())
 }
 
 object UShortSerializer : StdSerializer<UShort>(UShort::class.java) {
+    private fun readResolve(): Any = UShortSerializer
+
     override fun serialize(value: UShort, gen: JsonGenerator, provider: SerializerProvider) =
         gen.writeNumber(value.toInt())
 }
 
 object UIntSerializer : StdSerializer<UInt>(UInt::class.java) {
+    private fun readResolve(): Any = UIntSerializer
+
     override fun serialize(value: UInt, gen: JsonGenerator, provider: SerializerProvider) =
         gen.writeNumber(value.toLong())
 }
 
 object ULongSerializer : StdSerializer<ULong>(ULong::class.java) {
+    private fun readResolve(): Any = ULongSerializer
+
     override fun serialize(value: ULong, gen: JsonGenerator, provider: SerializerProvider) {
         val longValue = value.toLong()
         when {
@@ -54,6 +62,8 @@ private fun Class<*>.getStaticJsonValueGetter(): Method? = this.declaredMethods.
 }
 
 object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
+    private fun readResolve(): Any = ValueClassUnboxSerializer
+
     override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
         val unboxed = value::class.java.getMethod("unbox-impl").invoke(value)
 


### PR DESCRIPTION
SSIA

This change is a minor fix and will be made to branch 2.16.