### PR TITLE
Reduce conversion cache from Executable to KFunction

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.17.0 (not yet released)
 
 WrongWrong (@k163377)
+* #740: Reduce conversion cache from Executable to KFunction.
 * #738: Fix JacksonInject priority.
 * #732: SequenceSerializer removed.
 * #727: Fixed overriding findCreatorAnnotation instead of hasCreatorAnnotation

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,8 @@ Co-maintainers:
 
 2.17.0 (not yet released)
 
+#740: Reduce conversion cache from Executable to KFunction.
+ This will reduce memory usage efficiency and total memory consumption, but may result in a minor performance degradation in use cases where a large number of factory functions are used as JsonCreator.
 #738: JacksonInject is now preferred over the default argument(fixes #722).
 #732: SequenceSerializer removed.
 #727: Fixed overriding findCreatorAnnotation instead of hasCreatorAnnotation.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -95,9 +95,8 @@ internal class KotlinAnnotationIntrospector(
         if (!useJavaDurationConversion) return null
 
         return (a as? AnnotatedParameter)?.let { param ->
-            @Suppress("UNCHECKED_CAST")
             val function: KFunction<*> = when (val owner = param.owner.member) {
-                is Constructor<*> -> cache.kotlinFromJava(owner as Constructor<Any>)
+                is Constructor<*> -> cache.kotlinFromJava(owner)
                 is Method -> cache.kotlinFromJava(owner)
                 else -> null
             } ?: return@let null

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -79,13 +79,12 @@ internal class KotlinNamesAnnotationIntrospector(
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun hasCreatorAnnotation(member: AnnotatedConstructor): Boolean {
         // don't add a JsonCreator to any constructor if one is declared already
 
         val kClass = member.declaringClass.kotlin
             .apply { if (this in ignoredClassesForImplyingJsonCreator) return false }
-        val kConstructor = cache.kotlinFromJava(member.annotated as Constructor<Any>) ?: return false
+        val kConstructor = cache.kotlinFromJava(member.annotated) ?: return false
 
         // TODO:  should we do this check or not?  It could cause failures if we miss another way a property could be set
         // val requiredProperties = kClass.declaredMemberProperties.filter {!it.returnType.isMarkedNullable }.map { it.name }.toSet()

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -42,7 +42,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
         }
     }
 
-    private val javaConstructorToKotlin = LRUMap<Constructor<Any>, KFunction<Any>>(reflectionCacheSize, reflectionCacheSize)
+    private val javaConstructorToKotlin = LRUMap<Constructor<*>, KFunction<*>>(reflectionCacheSize, reflectionCacheSize)
     private val javaMethodToKotlin = LRUMap<Method, KFunction<*>>(reflectionCacheSize, reflectionCacheSize)
     private val javaExecutableToValueCreator = LRUMap<Executable, ValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
     private val javaConstructorIsCreatorAnnotated = LRUMap<AnnotatedConstructor, Boolean>(reflectionCacheSize, reflectionCacheSize)
@@ -57,7 +57,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     private val valueClassBoxConverterCache: LRUMap<KClass<*>, ValueClassBoxConverter<*, *>> =
         LRUMap(0, reflectionCacheSize)
 
-    fun kotlinFromJava(key: Constructor<Any>): KFunction<Any>? = javaConstructorToKotlin.get(key)
+    fun kotlinFromJava(key: Constructor<*>): KFunction<*>? = javaConstructorToKotlin.get(key)
             ?: key.kotlinFunction?.let { javaConstructorToKotlin.putIfAbsent(key, it) ?: it }
 
     fun kotlinFromJava(key: Method): KFunction<*>? = javaMethodToKotlin.get(key)


### PR DESCRIPTION
Since cache target functions are almost exclusively limited to creators, the same measures as in #627 were taken to improve the efficiency of cache utilization.