### PR TITLE
Minor performance improvements to NullToEmptyCollection/Map

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.17.0 (not yet released)
 
 WrongWrong (@k163377)
+* #742: Minor performance improvements to NullToEmptyCollection/Map.
 * #741: Changed to allow KotlinFeature to be set in the function that registers a KotlinModule.
 * #740: Reduce conversion cache from Executable to KFunction.
 * #738: Fix JacksonInject priority.

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,7 @@ Co-maintainers:
 
 2.17.0 (not yet released)
 
+#742: Minor performance improvements to NullToEmptyCollection/Map.
 #741: Changed to allow KotlinFeature to be set in the function that registers a KotlinModule.
  The `jacksonObjectMapper {}` and `registerKotlinModule {}` lambdas allow configuration for KotlinModule.
 #740: Reduce conversion cache from Executable to KFunction.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty
 import com.fasterxml.jackson.databind.deser.ValueInstantiator
 import com.fasterxml.jackson.databind.deser.ValueInstantiators
-import com.fasterxml.jackson.databind.deser.impl.NullsAsEmptyProvider
 import com.fasterxml.jackson.databind.deser.impl.PropertyValueBuffer
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import java.lang.reflect.TypeVariable
@@ -89,7 +88,7 @@ internal class KotlinValueInstantiator(
 
             if (paramVal == null) {
                 if (propType.requireEmptyValue()) {
-                    paramVal = NullsAsEmptyProvider(jsonProp.valueDeserializer).getNullValue(ctxt)
+                    paramVal = jsonProp.valueDeserializer!!.getEmptyValue(ctxt)
                 } else {
                     val isMissingAndRequired = isMissing && jsonProp.isRequired
 


### PR DESCRIPTION
I checked the implementation and found that `NullsAsEmptyProvider` simply calls `valueDeserializer.getEmptyValue`, so there was no need to specifically wrap it.
https://github.com/FasterXML/jackson-databind/blob/15fa6ec14608790664f214ab53688b68aad23dbd/src/main/java/com/fasterxml/jackson/databind/deser/impl/NullsAsEmptyProvider.java#L30

Skipping this process will improve performance, albeit slightly.

From https://github.com/ProjectMapK/jackson-module-kogera/pull/195/commits/997a5369c245045d98d5cd0444d0a3581c669cb1