### PR TITLE
API deprecation update for KotlinModule

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.17.0 (not yet released)
 
 WrongWrong (@k163377)
+* #744: API deprecation update for KotlinModule.
 * #743: Fix handling of vararg deserialization.
 * #742: Minor performance improvements to NullToEmptyCollection/Map.
 * #741: Changed to allow KotlinFeature to be set in the function that registers a KotlinModule.

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,7 +18,7 @@ Co-maintainers:
 
 2.17.0 (not yet released)
 
-* #743: The handling of deserialization using vararg arguments has been improved to allow deserialization even when the input to the vararg argument is undefined.
+#743: The handling of deserialization using vararg arguments has been improved to allow deserialization even when the input to the vararg argument is undefined.
  In addition, vararg arguments are now reported as non-required.
 #742: Minor performance improvements to NullToEmptyCollection/Map.
 #741: Changed to allow KotlinFeature to be set in the function that registers a KotlinModule.

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,12 @@ Co-maintainers:
 
 2.17.0 (not yet released)
 
+#744: Functions that were already marked as deprecated,
+ such as the primary constructor in KotlinModule and some functions in Builder,
+  are scheduled for removal in 2.18 and their DeprecationLevel has been raised to Error.
+  Hidden constructors that were left in for compatibility are also marked for removal.
+  This PR also adds a hidden no-argument constructor to facilitate initialization from reflection.
+  See the PR for details.
 #743: The handling of deserialization using vararg arguments has been improved to allow deserialization even when the input to the vararg argument is undefined.
  In addition, vararg arguments are now reported as non-required.
 #742: Minor performance improvements to NullToEmptyCollection/Map.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -76,6 +76,13 @@ class KotlinModule @Deprecated(
         }
     }
 
+    @Deprecated(
+        level = DeprecationLevel.HIDDEN,
+        message = "If you have no choice but to initialize KotlinModule from reflection, use this constructor."
+    )
+    @Suppress("DEPRECATION_ERROR")
+    constructor() : this()
+
     @Deprecated(level = DeprecationLevel.HIDDEN, message = "For ABI compatibility. It will be removed in 2.18.")
     constructor(
         reflectionCacheSize: Int,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -38,8 +38,8 @@ fun Class<*>.isKotlinClass(): Boolean {
  *                                      This allows use Kotlin Duration type with [com.fasterxml.jackson.datatype.jsr310.JavaTimeModule].
  */
 class KotlinModule @Deprecated(
-    level = DeprecationLevel.WARNING,
-    message = "Use KotlinModule.Builder instead of named constructor parameters.",
+    level = DeprecationLevel.ERROR,
+    message = "Use KotlinModule.Builder instead of named constructor parameters. It will be PRIVATE at 2.18.",
     replaceWith = ReplaceWith(
         """KotlinModule.Builder()
             .withReflectionCacheSize(reflectionCacheSize)
@@ -103,7 +103,7 @@ class KotlinModule @Deprecated(
             .configure(NullIsSameAsDefault, nullIsSameAsDefault)
     )
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     private constructor(builder: Builder) : this(
         builder.reflectionCacheSize,
         builder.isEnabled(NullToEmptyCollection),

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -205,14 +205,16 @@ class KotlinModule @Deprecated(
             bitSet.intersects(feature.bitSet)
 
         @Deprecated(
-            message = "Deprecated, use withReflectionCacheSize(reflectionCacheSize) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use withReflectionCacheSize(reflectionCacheSize) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith("withReflectionCacheSize(reflectionCacheSize)")
         )
         fun reflectionCacheSize(reflectionCacheSize: Int): Builder =
             withReflectionCacheSize(reflectionCacheSize)
 
         @Deprecated(
-            message = "Deprecated, use isEnabled(NullToEmptyCollection) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use isEnabled(NullToEmptyCollection) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "isEnabled(KotlinFeature.NullToEmptyCollection)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"
@@ -222,7 +224,8 @@ class KotlinModule @Deprecated(
             isEnabled(NullToEmptyCollection)
 
         @Deprecated(
-            message = "Deprecated, use configure(NullToEmptyCollection, enabled) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use configure(NullToEmptyCollection, enabled) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "configure(KotlinFeature.NullToEmptyCollection, nullToEmptyCollection)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"
@@ -232,7 +235,8 @@ class KotlinModule @Deprecated(
             configure(NullToEmptyCollection, nullToEmptyCollection)
 
         @Deprecated(
-            message = "Deprecated, use isEnabled(NullToEmptyMap) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use isEnabled(NullToEmptyMap) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "isEnabled(KotlinFeature.NullToEmptyMap)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"
@@ -242,7 +246,8 @@ class KotlinModule @Deprecated(
             isEnabled(NullToEmptyMap)
 
         @Deprecated(
-            message = "Deprecated, use configure(NullToEmptyMap, enabled) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use configure(NullToEmptyMap, enabled) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "configure(KotlinFeature.NullToEmptyMap, nullToEmptyMap)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"
@@ -252,7 +257,8 @@ class KotlinModule @Deprecated(
             configure(NullToEmptyMap, nullToEmptyMap)
 
         @Deprecated(
-            message = "Deprecated, use isEnabled(NullIsSameAsDefault) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use isEnabled(NullIsSameAsDefault) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "isEnabled(KotlinFeature.NullIsSameAsDefault)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"
@@ -262,7 +268,8 @@ class KotlinModule @Deprecated(
             isEnabled(NullIsSameAsDefault)
 
         @Deprecated(
-            message = "Deprecated, use configure(NullIsSameAsDefault, enabled) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use configure(NullIsSameAsDefault, enabled) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "configure(KotlinFeature.NullIsSameAsDefault, nullIsSameAsDefault)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"
@@ -272,7 +279,8 @@ class KotlinModule @Deprecated(
             configure(NullIsSameAsDefault, nullIsSameAsDefault)
 
         @Deprecated(
-            message = "Deprecated, use isEnabled(SingletonSupport) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use isEnabled(SingletonSupport) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "isEnabled(KotlinFeature.SingletonSupport)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"
@@ -285,7 +293,8 @@ class KotlinModule @Deprecated(
             }
 
         @Deprecated(
-            message = "Deprecated, use configure(SingletonSupport, enabled) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use configure(SingletonSupport, enabled) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "configure(KotlinFeature.SingletonSupport, singletonSupport)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"
@@ -298,7 +307,8 @@ class KotlinModule @Deprecated(
             }
 
         @Deprecated(
-            message = "Deprecated, use isEnabled(StrictNullChecks) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use isEnabled(StrictNullChecks) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "isEnabled(KotlinFeature.StrictNullChecks)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"
@@ -308,7 +318,8 @@ class KotlinModule @Deprecated(
             isEnabled(StrictNullChecks)
 
         @Deprecated(
-            message = "Deprecated, use configure(StrictNullChecks, enabled) instead.",
+            level = DeprecationLevel.ERROR,
+            message = "Deprecated, use configure(StrictNullChecks, enabled) instead. It will be removed in 2.18.",
             replaceWith = ReplaceWith(
                 "configure(KotlinFeature.StrictNullChecks, strictNullChecks)",
                 "com.fasterxml.jackson.module.kotlin.KotlinFeature"

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -76,7 +76,7 @@ class KotlinModule @Deprecated(
         }
     }
 
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "For ABI compatibility")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "For ABI compatibility. It will be removed in 2.18.")
     constructor(
         reflectionCacheSize: Int,
         nullToEmptyCollection: Boolean,
@@ -89,7 +89,7 @@ class KotlinModule @Deprecated(
             .disable(NullIsSameAsDefault)
     )
 
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "For ABI compatibility")
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "For ABI compatibility. It will be removed in 2.18.")
     constructor(
         reflectionCacheSize: Int,
         nullToEmptyCollection: Boolean,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -39,7 +39,7 @@ fun Class<*>.isKotlinClass(): Boolean {
  */
 class KotlinModule @Deprecated(
     level = DeprecationLevel.ERROR,
-    message = "Use KotlinModule.Builder instead of named constructor parameters. It will be PRIVATE at 2.18.",
+    message = "Use KotlinModule.Builder instead of named constructor parameters. It will be HIDDEN at 2.18.",
     replaceWith = ReplaceWith(
         """KotlinModule.Builder()
             .withReflectionCacheSize(reflectionCacheSize)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyCollection
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
@@ -126,5 +127,11 @@ class KotlinModuleTest {
         assertTrue(deserialized.nullIsSameAsDefault)
         assertEquals(CANONICALIZE, deserialized.singletonSupport)
         assertTrue(deserialized.strictNullChecks)
+    }
+
+    @Test
+    fun findAndRegisterModulesTest() {
+        val mapper = ObjectMapper().findAndRegisterModules()
+        assertTrue(mapper.registeredModuleIds.contains("com.fasterxml.jackson.module.kotlin.KotlinModule"))
     }
 }


### PR DESCRIPTION
If the primary constructor of a `KotlinModule` is called directly, bytecode compatibility problems can occur.
For this reason, this has been marked as `Deprecated` for quite some time.

This change raises the `DeprecationLevel` to error and sets the privatization schedule to 2.18.
In addition, hidden constructors and other builder functions marked as `Deprecated` that have long been left out for compatibility purposes are also marked for removal in 2.18.

At the same time, a hidden no-argument constructor has been added to facilitate initializing `KotlinModule` via reflection.
This is useful in situations where `Java` libraries initialize `KotlinModule` via reflection.
However, the `Builder` method of initialization is still recommended for normal use cases.