### PR TITLE
Modified isKotlinClass determination method

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.17.0 (not yet released)
 
 WrongWrong (@k163377)
+* #745: Modified isKotlinClass determination method.
 * #744: API deprecation update for KotlinModule.
 * #743: Fix handling of vararg deserialization.
 * #742: Minor performance improvements to NullToEmptyCollection/Map.

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,7 @@ Co-maintainers:
 
 2.17.0 (not yet released)
 
+#745: Modified isKotlinClass determination method.
 #744: Functions that were already marked as deprecated,
  such as the primary constructor in KotlinModule and some functions in Builder,
   are scheduled for removal in 2.18 and their DeprecationLevel has been raised to Error.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -14,11 +14,7 @@ import com.fasterxml.jackson.module.kotlin.SingletonSupport.DISABLED
 import java.util.*
 import kotlin.reflect.KClass
 
-private const val metadataFqName = "kotlin.Metadata"
-
-fun Class<*>.isKotlinClass(): Boolean {
-    return declaredAnnotations.any { it.annotationClass.java.name == metadataFqName }
-}
+fun Class<*>.isKotlinClass(): Boolean = this.isAnnotationPresent(Metadata::class.java)
 
 /**
  * @param   reflectionCacheSize     Default: 512.  Size, in items, of the caches used for mapping objects.


### PR DESCRIPTION
The kotlin-reflect method was used as a reference
https://github.com/JetBrains/kotlin/blob/c4fc0b919dfe9b746f9ecfcc08668fa05b839064/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KClassImpl.kt#L59

Perhaps only a slight improvement in performance.