### PR TITLE
The KotlinModule#serialVersionUID is set to private

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
                 <!-- public -->
                           <!-- removed -->
                           <exclude>com.fasterxml.jackson.module.kotlin.SequenceSerializer</exclude>
+                          <exclude>com.fasterxml.jackson.module.kotlin.KotlinModule#serialVersionUID</exclude>
                 <!-- internal -->
                         </excludes>
                     </parameter>

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.17.0 (not yet released)
 
 WrongWrong (@k163377)
+* #746: The KotlinModule#serialVersionUID is set to private.
 * #745: Modified isKotlinClass determination method.
 * #744: API deprecation update for KotlinModule.
 * #743: Fix handling of vararg deserialization.

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,7 @@ Co-maintainers:
 
 2.17.0 (not yet released)
 
+#746: The KotlinModule#serialVersionUID is set to private.
 #745: Modified isKotlinClass determination method.
 #744: Functions that were already marked as deprecated,
  such as the primary constructor in KotlinModule and some functions in Builder,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -59,7 +59,7 @@ class KotlinModule @Deprecated(
 ) : SimpleModule(KotlinModule::class.java.name, PackageVersion.VERSION) {
     companion object {
         // Increment when option is added
-        const val serialVersionUID = 2L
+        private const val serialVersionUID = 2L
     }
 
     init {


### PR DESCRIPTION
There was no point in making it public, and in fact, it was set to private elsewhere.
Steps such as deprecation were ignored since the property is of no particular use.