### PR TITLE
Improved performance related to KotlinModule initialization and setupModule.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@
                           <exclude>com.fasterxml.jackson.module.kotlin.SequenceSerializer</exclude>
                           <exclude>com.fasterxml.jackson.module.kotlin.KotlinModule#serialVersionUID</exclude>
                 <!-- internal -->
+                          <exclude>com.fasterxml.jackson.module.kotlin.KotlinNamesAnnotationIntrospector</exclude>
                         </excludes>
                     </parameter>
                 </configuration>

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.17.0 (not yet released)
 
 WrongWrong (@k163377)
+* #747: Improved performance related to KotlinModule initialization and setupModule.
 * #746: The KotlinModule#serialVersionUID is set to private.
 * #745: Modified isKotlinClass determination method.
 * #744: API deprecation update for KotlinModule.

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,8 @@ Co-maintainers:
 
 2.17.0 (not yet released)
 
+#747: Improved performance related to KotlinModule initialization and setupModule.
+ With this change, the KotlinModule initialization error when using Kotlin 1.4 or lower has been eliminated.
 #746: The KotlinModule#serialVersionUID is set to private.
 #745: Modified isKotlinClass determination method.
 #744: Functions that were already marked as deprecated,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.module.kotlin
 
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
@@ -60,16 +59,6 @@ class KotlinModule @Deprecated(
     companion object {
         // Increment when option is added
         private const val serialVersionUID = 2L
-    }
-
-    init {
-        if (!KotlinVersion.CURRENT.isAtLeast(1, 5)) {
-            // Kotlin 1.4 was deprecated when this process was introduced(jackson-module-kotlin 2.15).
-            throw JsonMappingException(
-                null,
-                "KotlinModule requires Kotlin version >= 1.5 - Found ${KotlinVersion.CURRENT}"
-            )
-        }
     }
 
     @Deprecated(

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -140,7 +140,6 @@ class KotlinModule @Deprecated(
         ))
         context.appendAnnotationIntrospector(
             KotlinNamesAnnotationIntrospector(
-                this,
                 cache,
                 ignoredClassesForImplyingJsonCreator,
                 useKotlinPropertyNameForGetter)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -151,15 +151,8 @@ class KotlinModule @Deprecated(
         context.addSerializers(KotlinSerializers())
         context.addKeySerializers(KotlinKeySerializers())
 
-        fun addMixIn(clazz: Class<*>, mixin: Class<*>) {
-            context.setMixInAnnotations(clazz, mixin)
-        }
-
         // ranges
-        addMixIn(IntRange::class.java, ClosedRangeMixin::class.java)
-        addMixIn(CharRange::class.java, ClosedRangeMixin::class.java)
-        addMixIn(LongRange::class.java, ClosedRangeMixin::class.java)
-        addMixIn(ClosedRange::class.java, ClosedRangeMixin::class.java)
+        context.setMixInAnnotations(ClosedRange::class.java, ClosedRangeMixin::class.java)
     }
 
     class Builder {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -26,10 +26,9 @@ import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.kotlinFunction
 
 internal class KotlinNamesAnnotationIntrospector(
-    val module: KotlinModule,
-    val cache: ReflectionCache,
-    val ignoredClassesForImplyingJsonCreator: Set<KClass<*>>,
-    val useKotlinPropertyNameForGetter: Boolean
+    private val cache: ReflectionCache,
+    private val ignoredClassesForImplyingJsonCreator: Set<KClass<*>>,
+    private val useKotlinPropertyNameForGetter: Boolean
 ) : NopAnnotationIntrospector() {
     private fun getterNameFromJava(member: AnnotatedMethod): String? {
         val name = member.name


### PR DESCRIPTION
Slightly improved performance related to `KotlinModule` initialization and `setupModule` by removing unnecessary checks and unnecessary `setMixInAnnotations`.
With this change, the `KotlinModule` initialization error when using `Kotlin 1.4` or lower has been eliminated.