### PR TITLE
Fix databind/4295 to allow KotlinModule auto-registration

### DIFF
--- a/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.JacksonModule
+++ b/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.JacksonModule
@@ -1,1 +1,0 @@
-com.fasterxml.jackson.module.kotlin.KotlinModule

--- a/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
+++ b/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
@@ -1,0 +1,1 @@
+tools.jackson.module.kotlin.KotlinModule


### PR DESCRIPTION
Fixes https://github.com/FasterXML/jackson-databind/issues/4295 by correcting SPI metadata needed for auto-discovery/registration.
