### PR TITLE
Marked useKotlinPropertyNameForGetter as deprecated.

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.17.0 (not yet released)
 
 WrongWrong (@k163377)
+* #751: Marked useKotlinPropertyNameForGetter as deprecated.
 * #747: Improved performance related to KotlinModule initialization and setupModule.
 * #746: The KotlinModule#serialVersionUID is set to private.
 * #745: Modified isKotlinClass determination method.

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,8 @@ Co-maintainers:
 
 2.17.0 (not yet released)
 
+#751: The KotlinModule#useKotlinPropertyNameForGetter property was deprecated because it differed from the name of the KotlinFeature.
+ Please use KotlinModule#kotlinPropertyNameAsImplicitName from now on.
 #747: Improved performance related to KotlinModule initialization and setupModule.
  With this change, the KotlinModule initialization error when using Kotlin 1.4 or lower has been eliminated.
 #746: The KotlinModule#serialVersionUID is set to private.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -53,9 +53,17 @@ class KotlinModule @Deprecated(
     val nullIsSameAsDefault: Boolean = NullIsSameAsDefault.enabledByDefault,
     val singletonSupport: SingletonSupport = DISABLED,
     val strictNullChecks: Boolean = StrictNullChecks.enabledByDefault,
+    @Deprecated(
+        level = DeprecationLevel.WARNING,
+        message = "There was a discrepancy between the property name and the Feature name." +
+            " To migrate to the correct property name, it will be ERROR in 2.18 and removed in 2.19.",
+        replaceWith = ReplaceWith("kotlinPropertyNameAsImplicitName")
+    )
     val useKotlinPropertyNameForGetter: Boolean = KotlinPropertyNameAsImplicitName.enabledByDefault,
     val useJavaDurationConversion: Boolean = UseJavaDurationConversion.enabledByDefault,
 ) : SimpleModule(KotlinModule::class.java.name, PackageVersion.VERSION) {
+    val kotlinPropertyNameAsImplicitName: Boolean get() = useKotlinPropertyNameForGetter
+
     companion object {
         // Increment when option is added
         private const val serialVersionUID = 2L

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
@@ -1,13 +1,7 @@
 package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
-import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyCollection
-import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
-import com.fasterxml.jackson.module.kotlin.KotlinFeature.SingletonSupport
-import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
-import com.fasterxml.jackson.module.kotlin.SingletonSupport.CANONICALIZE
-import com.fasterxml.jackson.module.kotlin.SingletonSupport.DISABLED
+import com.fasterxml.jackson.module.kotlin.KotlinFeature.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -15,21 +9,6 @@ import org.junit.Test
 import kotlin.test.assertNotNull
 
 class KotlinModuleTest {
-    /**
-     * Ensure that the default Builder matches Feature default settings.
-     */
-    @Test
-    fun builderDefaultsMatchFeatures() {
-        val module = KotlinModule.Builder().build()
-
-        assertEquals(module.reflectionCacheSize, 512)
-        assertFalse(module.nullToEmptyCollection)
-        assertFalse(module.nullToEmptyMap)
-        assertFalse(module.nullIsSameAsDefault)
-        assertEquals(module.singletonSupport, DISABLED)
-        assertFalse(module.strictNullChecks)
-    }
-
     @Test
     fun builder_Defaults() {
         val module = KotlinModule.Builder().build()
@@ -38,8 +17,10 @@ class KotlinModuleTest {
         assertFalse(module.nullToEmptyCollection)
         assertFalse(module.nullToEmptyMap)
         assertFalse(module.nullIsSameAsDefault)
-        assertEquals(DISABLED, module.singletonSupport)
+        assertEquals(SingletonSupport.DISABLED, module.singletonSupport)
         assertFalse(module.strictNullChecks)
+        assertFalse(module.kotlinPropertyNameAsImplicitName)
+        assertFalse(module.useJavaDurationConversion)
     }
 
     @Test
@@ -51,14 +32,18 @@ class KotlinModuleTest {
             enable(NullIsSameAsDefault)
             enable(SingletonSupport)
             enable(StrictNullChecks)
+            enable(KotlinPropertyNameAsImplicitName)
+            enable(UseJavaDurationConversion)
         }.build()
 
         assertEquals(123, module.reflectionCacheSize)
         assertTrue(module.nullToEmptyCollection)
         assertTrue(module.nullToEmptyMap)
         assertTrue(module.nullIsSameAsDefault)
-        assertEquals(CANONICALIZE, module.singletonSupport)
+        assertEquals(SingletonSupport.CANONICALIZE, module.singletonSupport)
         assertTrue(module.strictNullChecks)
+        assertTrue(module.kotlinPropertyNameAsImplicitName)
+        assertTrue(module.useJavaDurationConversion)
     }
 
     @Test
@@ -94,7 +79,7 @@ class KotlinModuleTest {
             enable(SingletonSupport)
         }.build()
 
-        assertEquals(CANONICALIZE, module.singletonSupport)
+        assertEquals(SingletonSupport.CANONICALIZE, module.singletonSupport)
     }
 
     @Test
@@ -125,7 +110,7 @@ class KotlinModuleTest {
         assertTrue(deserialized.nullToEmptyCollection)
         assertTrue(deserialized.nullToEmptyMap)
         assertTrue(deserialized.nullIsSameAsDefault)
-        assertEquals(CANONICALIZE, deserialized.singletonSupport)
+        assertEquals(SingletonSupport.CANONICALIZE, deserialized.singletonSupport)
         assertTrue(deserialized.strictNullChecks)
     }
 


### PR DESCRIPTION
Because, there was a discrepancy between the property name and the Feature name.