### PR TITLE
Fix KDoc for KotlinModule.

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.17.0 (not yet released)
 
 WrongWrong (@k163377)
+* #752: Fix KDoc for KotlinModule.
 * #751: Marked useKotlinPropertyNameForGetter as deprecated.
 * #747: Improved performance related to KotlinModule initialization and setupModule.
 * #746: The KotlinModule#serialVersionUID is set to private.

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -26,10 +26,10 @@ Co-maintainers:
 #745: Modified isKotlinClass determination method.
 #744: Functions that were already marked as deprecated,
  such as the primary constructor in KotlinModule and some functions in Builder,
-  are scheduled for removal in 2.18 and their DeprecationLevel has been raised to Error.
-  Hidden constructors that were left in for compatibility are also marked for removal.
-  This PR also adds a hidden no-argument constructor to facilitate initialization from reflection.
-  See the PR for details.
+ are scheduled for removal in 2.18 and their DeprecationLevel has been raised to Error.
+ Hidden constructors that were left in for compatibility are also marked for removal.
+ This PR also adds a hidden no-argument constructor to facilitate initialization from reflection.
+ See the PR for details.
 #743: The handling of deserialization using vararg arguments has been improved to allow deserialization even when the input to the vararg argument is undefined.
  In addition, vararg arguments are now reported as non-required.
 #742: Minor performance improvements to NullToEmptyCollection/Map.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -16,21 +16,23 @@ import kotlin.reflect.KClass
 fun Class<*>.isKotlinClass(): Boolean = this.isAnnotationPresent(Metadata::class.java)
 
 /**
- * @param   reflectionCacheSize     Default: 512.  Size, in items, of the caches used for mapping objects.
- * @param   nullToEmptyCollection   Default: false.  Whether to deserialize null values for collection properties as
- *                                      empty collections.
- * @param   nullToEmptyMap          Default: false.  Whether to deserialize null values for a map property to an empty
- *                                      map object.
- * @param   nullIsSameAsDefault     Default false.  Whether to treat null values as absent when deserializing, thereby
- *                                      using the default value provided in Kotlin.
- * @param   singletonSupport        Default: DISABLED.  Mode for singleton handling.
- *                                      See {@link com.fasterxml.jackson.module.kotlin.SingletonSupport label}
- * @param   strictNullChecks        Default: false.  Whether to check deserialized collections.  With this disabled,
- *                                      the default, collections which are typed to disallow null members
- *                                      (e.g. List<String>) may contain null values after deserialization.  Enabling it
- *                                      protects against this but has significant performance impact.
- * @param   useJavaDurationConversion Default: false.  Whether to use [java.time.Duration] as a bridge for [kotlin.time.Duration].
- *                                      This allows use Kotlin Duration type with [com.fasterxml.jackson.datatype.jsr310.JavaTimeModule].
+ * @property reflectionCacheSize     Default: 512.  Size, in items, of the caches used for mapping objects.
+ * @property nullToEmptyCollection   Default: false.  Whether to deserialize null values for collection properties as
+ *  empty collections.
+ * @property nullToEmptyMap          Default: false.  Whether to deserialize null values for a map property to an empty
+ *  map object.
+ * @property nullIsSameAsDefault     Default false.  Whether to treat null values as absent when deserializing, thereby
+ *  using the default value provided in Kotlin.
+ * @property singletonSupport        Default: DISABLED.  Mode for singleton handling.
+ *  See {@link com.fasterxml.jackson.module.kotlin.SingletonSupport label}
+ * @property strictNullChecks        Default: false.  Whether to check deserialized collections.  With this disabled,
+ *  the default, collections which are typed to disallow null members
+ *  (e.g. List<String>) may contain null values after deserialization.  Enabling it
+ *  protects against this but has significant performance impact.
+ * @property kotlinPropertyNameAsImplicitName Default: false.  Whether to use the Kotlin property name as the implicit name.
+ *  See [KotlinFeature.KotlinPropertyNameAsImplicitName] for details.
+ * @property useJavaDurationConversion Default: false.  Whether to use [java.time.Duration] as a bridge for [kotlin.time.Duration].
+ *  This allows use Kotlin Duration type with [com.fasterxml.jackson.datatype.jsr310.JavaTimeModule].
  */
 class KotlinModule @Deprecated(
     level = DeprecationLevel.ERROR,


### PR DESCRIPTION
Previously, documentation was given for the parameters of the primary constructor, since the properties are the correct target to be referenced.
In addition, some broken links and missing documentation for `kotlinePropertyNameAsImplicitName` have been fixed.