### PR TITLE
Delete Duration conversion that was no longer needed

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -15,7 +15,12 @@ Authors:
 
 Contributors:
 
-# 2.17.0 (not yet released)
+# 2.17.1 (not yet released)
+
+WrongWrong (@k163377)
+* #776: Delete Duration conversion that was no longer needed
+
+# 2.17.0
 
 WrongWrong (@k163377)
 * #768: Added value class deserialization support.

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,10 @@ Co-maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.17.1 (not yet released)
+
+#776: Delete Duration conversion that was no longer needed.
+
 2.17.0 (12-Mar-2024)
 
 #768: Added value class deserialization support.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -86,20 +86,6 @@ internal class KotlinAnnotationIntrospector(
         ?.takeIf { it.wrapsNullable() }
         ?.let { cache.getValueClassBoxConverter(am.rawReturnType, it).delegatingSerializer }
 
-    override fun findDeserializationConverter(a: Annotated): Any? {
-        if (!useJavaDurationConversion) return null
-
-        return (a as? AnnotatedParameter)?.let { param ->
-            val valueParameter = cache.findKotlinParameter(param) ?: return@let null
-
-            if (valueParameter.type.classifier == Duration::class) {
-                JavaToKotlinDurationConverter
-            } else {
-                null
-            }
-        }
-    }
-
     /**
      * Subclasses can be detected automatically for sealed classes, since all possible subclasses are known
      * at compile-time to Kotlin. This makes [com.fasterxml.jackson.annotation.JsonSubTypes] redundant.


### PR DESCRIPTION
Because of `value class` support, they are now converted elsewhere.