### PR TITLE
Fixed to not process constructors of Java classes

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -19,6 +19,7 @@ Contributors:
 
 WrongWrong (@k163377)
 * #776: Delete Duration conversion that was no longer needed
+* #779: Fixed to not process constructors of Java classes
 
 # 2.17.0
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -19,6 +19,7 @@ Co-maintainers:
 2.17.1 (not yet released)
 
 #776: Delete Duration conversion that was no longer needed.
+#779: Errors no longer occur when processing Record types defined in Java.
 
 2.17.0 (12-Mar-2024)
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -59,8 +59,15 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     private val valueClassBoxConverterCache: LRUMap<KClass<*>, ValueClassBoxConverter<*, *>> =
         LRUMap(0, reflectionCacheSize)
 
-    fun kotlinFromJava(key: Constructor<*>): KFunction<*>? = javaExecutableToKotlin.get(key)
-        ?: key.valueClassAwareKotlinFunction()?.let { javaExecutableToKotlin.putIfAbsent(key, it) ?: it }
+    // If the Record type defined in Java is processed,
+    // an error will occur, so if it is not defined in Kotlin, skip the process.
+    // see https://github.com/FasterXML/jackson-module-kotlin/issues/778
+    fun kotlinFromJava(key: Constructor<*>): KFunction<*>? = if (key.declaringClass.isKotlinClass()) {
+        javaExecutableToKotlin.get(key)
+            ?: key.valueClassAwareKotlinFunction()?.let { javaExecutableToKotlin.putIfAbsent(key, it) ?: it }
+    } else {
+        null
+    }
 
     fun kotlinFromJava(key: Method): KFunction<*>? = javaExecutableToKotlin.get(key)
         ?: key.kotlinFunction?.let { javaExecutableToKotlin.putIfAbsent(key, it) ?: it }


### PR DESCRIPTION
To avoid errors when referencing Record types defined in Java.
Fixed #778.