### PR TITLE
Fixed problem with code compiled with 2.17.x losing backward compatibility

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -15,7 +15,12 @@ Authors:
 
 Contributors:
 
-# 2.17.1 (not yet released)
+# 2.17.2 (not yet released)
+
+WrongWrong (@k163377)
+* #799: Fixed problem with code compiled with 2.17.x losing backward compatibility.
+
+# 2.17.1 (04-May-2024)
 
 WrongWrong (@k163377)
 * #776: Delete Duration conversion that was no longer needed

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,9 @@ Co-maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.17.2 (not yet released)
+#799: Fixed problem with code compiled with 2.17.x losing backward compatibility.
+
 2.17.1 (04-May-2024)
 
 #776: Delete Duration conversion that was no longer needed.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -33,15 +33,17 @@ fun jsonMapper(initializer: JsonMapper.Builder.() -> Unit = {}): JsonMapper {
     return builder.build()
 }
 
-// region: JvmOverloads is set for bytecode compatibility for versions below 2.17.
-@JvmOverloads
+// region: Do not remove the default argument for functions that take a builder as an argument for compatibility.
+//   The default argument can be removed in 2.21 or later. See #775 for the history.
+fun jacksonObjectMapper(): ObjectMapper = jsonMapper { addModule(kotlinModule()) }
 fun jacksonObjectMapper(initializer: KotlinModule.Builder.() -> Unit = {}): ObjectMapper =
     jsonMapper { addModule(kotlinModule(initializer)) }
-@JvmOverloads
+
+fun jacksonMapperBuilder(): JsonMapper.Builder = JsonMapper.builder().addModule(kotlinModule())
 fun jacksonMapperBuilder(initializer: KotlinModule.Builder.() -> Unit = {}): JsonMapper.Builder =
     JsonMapper.builder().addModule(kotlinModule(initializer))
 
-@JvmOverloads
+fun ObjectMapper.registerKotlinModule(): ObjectMapper = this.registerModule(kotlinModule())
 fun ObjectMapper.registerKotlinModule(initializer: KotlinModule.Builder.() -> Unit = {}): ObjectMapper =
     this.registerModule(kotlinModule(initializer))
 // endregion


### PR DESCRIPTION
As reported in #775, due to changes made in #741, code compiled using 2.17.0 and 2.17.1 is not compatible with older versions.
As far as decompiling and checking, this problem no longer occurs, as this change clearly causes the no-argument function to be called.

Fixes #775