### PR TITLE
Fixed nullability of `convertValue` function argument

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -16,6 +16,9 @@ Authors:
 Contributors:
 
 # 2.18.0 (not yet released)
+
+WrongWrong (@k163377)
+* #817: Fixed nullability of convertValue function argument
 * #782: Organize deprecated contents
 * #542: Remove meaningless checks and properties in KNAI
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,7 @@ Co-maintainers:
 
 2.18.0 (not yet released)
 
+#817: The convertValue extension function now accepts null
 #803: Kotlin has been upgraded to 1.8.10.
   The reason 1.8.22 is not used is to avoid KT-65156.
 #782: Content marked as deprecated has been reorganized.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -61,7 +61,7 @@ inline fun <reified T> ObjectMapper.readValue(src: InputStream): T = readValue(s
 inline fun <reified T> ObjectMapper.readValue(src: ByteArray): T = readValue(src, jacksonTypeRef<T>())
 
 inline fun <reified T> ObjectMapper.treeToValue(n: TreeNode): T = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
-inline fun <reified T> ObjectMapper.convertValue(from: Any): T = convertValue(from, jacksonTypeRef<T>())
+inline fun <reified T> ObjectMapper.convertValue(from: Any?): T = convertValue(from, jacksonTypeRef<T>())
 
 inline fun <reified T> ObjectReader.readValueTyped(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
 inline fun <reified T> ObjectReader.readValuesTyped(jp: JsonParser): Iterator<T> = readValues(jp, jacksonTypeRef<T>())

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub757.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub757.kt
@@ -1,0 +1,22 @@
+package com.fasterxml.jackson.module.kotlin.test.github
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.convertValue
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class GitHub757 {
+    @Test
+    fun test() {
+        val kotlinModule = KotlinModule.Builder()
+            .enable(KotlinFeature.StrictNullChecks)
+            .build()
+        val mapper = JsonMapper.builder()
+            .addModule(kotlinModule)
+            .build()
+        val convertValue = mapper.convertValue<String?>(null)
+        assertNull(convertValue)
+    }
+}


### PR DESCRIPTION
The convertValue method can accept null, but was defined as non-null.