### PR TITLE
Add kotlin sources for maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,18 +264,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,37 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- add kotlin sources for the maven-source-plugin (need this for mixed java/kotlin sources) -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/kotlin</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Add maven-source-plugin and build-helper-maven-plugin to attach mixed java+kotlin sources, as this [SO answer](https://stackoverflow.com/a/42748502/11044798) suggests.

I see that the `source:jar` command is called in a GitHub workflow, so explicitly putting the maven-source-plugin in the pom is not necessary. If I run `./mvnw source:jar` locally, it will generate the sources including the kotlin files correctly, where the plugin configuration is inherited from oss-parent.

This should fix #171. In the first pull request to fix this, #175, I find that that author also included:
```
 <!-- explicitly define maven-deploy-plugin after other to force exec order -->
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-deploy-plugin</artifactId>
...
```
But I didn't see how this is necessary.

When this fix is verified, it can also be backported to 2.18 and 2.17.

Since I didn't make any code changes, do I still need to fill out the Contributor Licence Agreement?