### PR TITLE
backport: build-helper-maven-plugin to attach kotlin sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,25 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- add kotlin sources for the maven-source-plugin (need this for mixed java/kotlin sources) -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/kotlin</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Backport of #820