### PR TITLE
Reproduce dispatched build failure

### DIFF
--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
@@ -18,6 +18,7 @@ class DslTest {
     @Test
     fun createModuleWithoutUsingInitializer() {
         val module = kotlinModule()
+        
         assertNotNull(module)
     }
 


### PR DESCRIPTION
This PR is to "demonstrate" that Github Action `Re-build on jackson-databind v2 push` workflow fails