### PR TITLE
Upgrade to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,8 +111,13 @@
 
         <!-- only for testing... -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
             <artifactId>kotlin-test-junit</artifactId>
             <version>${version.kotlin}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.19.0 (not yet released)
 
 WrongWrong (@k163377)
+* #866: Upgrade to JUnit5
 * #861: Update Kotlin to 1.9.24
 * #858: Refactor findDefaultCreator
 * #839: Remove useKotlinPropertyNameForGetter and unify with kotlinPropertyNameAsImplicitName

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ArgumentBucketTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ArgumentBucketTest.kt
@@ -1,9 +1,7 @@
 package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import org.junit.Ignore
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Nested
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.hasAnnotation
@@ -12,13 +10,19 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-
-@RunWith(Enclosed::class)
 class ArgumentBucketTest {
-    class Normal {
-        @Ignore
-        data class Constructor(val foo: String, val bar: String)
+    data class Constructor(val foo: String, val bar: String)
 
+    data class Method(val foo: String, val bar: String) {
+        companion object {
+            @JvmStatic
+            @JsonCreator
+            fun of(foo: String, bar: String): Method = Method(foo, bar)
+        }
+    }
+
+    @Nested
+    inner class Normal {
         @Test
         fun constructorTest() {
             val function: KFunction<*> = ::Constructor
@@ -43,15 +47,6 @@ class ArgumentBucketTest {
             assertEquals(2, bucket.size)
             assertTrue(bucket.isFullInitialized)
             assertEquals("bar", bucket[params[1]])
-        }
-
-        @Ignore
-        data class Method(val foo: String, val bar: String) {
-            companion object {
-                @JvmStatic
-                @JsonCreator
-                fun of(foo: String, bar: String): Method = Method(foo, bar)
-            }
         }
 
         @Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ArgumentBucketTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ArgumentBucketTest.kt
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.hasAnnotation
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyCollection
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.SingletonSupport
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
-import org.junit.Assert.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.SingletonSupport
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
 import org.junit.Assert.assertNotNull
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/JDKSerializabilityTestHelper.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/JDKSerializabilityTestHelper.kt
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
-import junit.framework.TestCase
+import org.junit.jupiter.api.Assertions.fail
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.ObjectInputStream
@@ -14,14 +14,13 @@ fun jdkSerialize(o: Any): ByteArray {
     return bytes.toByteArray()
 }
 
-fun <T> jdkDeserialize(raw: ByteArray): T? {
+fun <T> jdkDeserialize(raw: ByteArray): T {
     val objIn = ObjectInputStream(ByteArrayInputStream(raw))
     return try {
         @Suppress("UNCHECKED_CAST")
         objIn.readObject() as T
     } catch (e: ClassNotFoundException) {
-        TestCase.fail("Missing class: " + e.message)
-        null
+        fail("Missing class: " + e.message)
     } finally {
         objIn.close()
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinInstantiatorsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinInstantiatorsTest.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import org.junit.Assert.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class KotlinInstantiatorsTest {
     private val mapper = jacksonObjectMapper()

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinInstantiatorsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinInstantiatorsTest.kt
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
-import org.junit.Assert.*
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 class KotlinInstantiatorsTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.*
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.test.assertNotNull
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertNotNull
 
 class KotlinModuleTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/MissingKotlinParameterExceptionTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/MissingKotlinParameterExceptionTest.kt
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCacheTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCacheTest.kt
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertNotNull
 
 class ReflectionCacheTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/JacksonInjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/JacksonInjectTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.InjectableValues
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class JacksonInjectTest {
     // This is specified as a getter because there is a possibility of problems if it is assigned to a field.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/JacksonInjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/JacksonInjectTest.kt
@@ -3,8 +3,8 @@ package com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass
 import com.fasterxml.jackson.annotation.JacksonInject
 import com.fasterxml.jackson.databind.InjectableValues
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 class JacksonInjectTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/NullableObjectEdgeCases.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/NullableObjectEdgeCases.kt
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.module.kotlin.WrapsNullableValueClassDeserializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class NullableObjectEdgeCases {
     @JvmInline
@@ -61,7 +61,7 @@ class NullableObjectEdgeCases {
     // There is a problem with #51, so it is a failing test.
     @Test
     fun `Nulls_SKIP works`() {
-        assertThrows("#761(KT-57357) fixed", KotlinReflectionInternalError::class.java) {
+        assertThrows<KotlinReflectionInternalError>("#761(KT-57357) fixed") {
             val result = jacksonObjectMapper().readValue<NullsSkip>("""{"nn":null,"n":null}""")
             assertEquals(NullValue(VC("skip"), VC("skip")), result)
         }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/NullableObjectEdgeCases.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/NullableObjectEdgeCases.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NullableObjectEdgeCases {
     @JvmInline

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
@@ -10,7 +10,7 @@ import org.junit.Ignore
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import java.lang.reflect.InvocationTargetException
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @RunWith(Enclosed::class)
 class WithoutCustomDeserializeMethodTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
@@ -3,8 +3,8 @@ package com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
@@ -4,23 +4,20 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
-import java.lang.reflect.InvocationTargetException
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
+import java.lang.reflect.InvocationTargetException
 
-@RunWith(Enclosed::class)
 class WithoutCustomDeserializeMethodTest {
-    @Ignore
     companion object {
         val mapper = jacksonObjectMapper()
         val throwable = IllegalArgumentException("test")
     }
 
-    class DirectDeserializeTest {
+    @Nested
+    inner class DirectDeserializeTest {
         @Test
         fun primitive() {
             val result = defaultMapper.readValue<Primitive>("1")
@@ -34,7 +31,8 @@ class WithoutCustomDeserializeMethodTest {
         }
 
         @Suppress("ClassName")
-        class NullableObject_ {
+        @Nested
+        inner class NullableObject_ {
             @Test
             fun value() {
                 val result = defaultMapper.readValue<NullableObject>(""""foo"""")
@@ -44,32 +42,14 @@ class WithoutCustomDeserializeMethodTest {
             // failing
             @Test
             fun nullString() {
-                // #209 has been fixed.
-                assertThrows(NullPointerException::class.java) {
+                org.junit.jupiter.api.assertThrows<NullPointerException>("#209 has been fixed.") {
                     val result = defaultMapper.readValue<NullableObject>("null")
                     assertEquals(NullableObject(null), result)
                 }
             }
         }
-
-        @Ignore
-        @JvmInline
-        value class HasCheckConstructor(val value: Int) {
-            init {
-                if (value < 0) throw throwable
-            }
-        }
-
-        @Test
-        fun callConstructorCheckTest() {
-            val e = assertThrows(InvocationTargetException::class.java) {
-                defaultMapper.readValue<HasCheckConstructor>("-1")
-            }
-            assertTrue(e.cause === throwable)
-        }
     }
 
-    @Ignore
     data class Dst(
         val pNn: Primitive,
         val pN: Primitive?,
@@ -79,38 +59,49 @@ class WithoutCustomDeserializeMethodTest {
         val noN: NullableObject?
     )
 
-    class InParameterDeserialize {
-        @Test
-        fun withoutNull() {
-            val expected = Dst(
-                Primitive(1),
-                Primitive(2),
-                NonNullObject("foo"),
-                NonNullObject("bar"),
-                NullableObject("baz"),
-                NullableObject("qux")
-            )
-            val src = mapper.writeValueAsString(expected)
-            val result = mapper.readValue<Dst>(src)
+    @Test
+    fun withoutNull() {
+        val expected = Dst(
+            Primitive(1),
+            Primitive(2),
+            NonNullObject("foo"),
+            NonNullObject("bar"),
+            NullableObject("baz"),
+            NullableObject("qux")
+        )
+        val src = mapper.writeValueAsString(expected)
+        val result = mapper.readValue<Dst>(src)
 
-            assertEquals(expected, result)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun withNull() {
+        val expected = Dst(
+            Primitive(1),
+            null,
+            NonNullObject("foo"),
+            null,
+            NullableObject(null),
+            null
+        )
+        val src = mapper.writeValueAsString(expected)
+        val result = mapper.readValue<Dst>(src)
+
+        assertEquals(expected, result)
+    }
+
+    @JvmInline
+    value class HasCheckConstructor(val value: Int) {
+        init {
+            if (value < 0) throw throwable
         }
+    }
 
-        @Test
-        fun withNull() {
-            val expected = Dst(
-                Primitive(1),
-                null,
-                NonNullObject("foo"),
-                null,
-                NullableObject(null),
-                null
-            )
-            val src = mapper.writeValueAsString(expected)
-            val result = mapper.readValue<Dst>(src)
-
-            assertEquals(expected, result)
-        }
+    @Test
+    fun callConstructorCheckTest() {
+        val e = assertThrows<InvocationTargetException> { defaultMapper.readValue<HasCheckConstructor>("-1") }
+        assertTrue(e.cause === throwable)
     }
 
     // If all JsonCreator tests are OK, no need to check throws from factory functions.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/NonNullObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/NonNullObjectTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NonNullObjectTest {
     companion object {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/NonNullObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/NonNullObjectTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class NonNullObjectTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/NullableObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/NullableObjectTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 class NullableObjectTest {
     companion object {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/NullableObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/NullableObjectTest.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 class NullableObjectTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/PrimitiveTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/PrimitiveTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class PrimitiveTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/PrimitiveTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/defaultArgument/PrimitiveTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class PrimitiveTest {
     companion object {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
@@ -7,15 +7,10 @@ import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.No
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
-import org.junit.Ignore
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@RunWith(Enclosed::class)
 class SpecifiedForObjectMapperTest {
-    @Ignore
     companion object {
         val mapper = jacksonObjectMapper().apply {
             val module = SimpleModule().apply {
@@ -27,7 +22,8 @@ class SpecifiedForObjectMapperTest {
         }
     }
 
-    class DirectDeserialize {
+    @Nested
+    inner class DirectDeserialize {
         @Test
         fun primitive() {
             val result = mapper.readValue<Primitive>("1")
@@ -41,7 +37,8 @@ class SpecifiedForObjectMapperTest {
         }
 
         @Suppress("ClassName")
-        class NullableObject_ {
+        @Nested
+        inner class NullableObject_ {
             @Test
             fun value() {
                 val result = mapper.readValue<NullableObject>(""""foo"""")
@@ -51,8 +48,7 @@ class SpecifiedForObjectMapperTest {
             // failing
             @Test
             fun nullString() {
-                // #209 has been fixed.
-                assertThrows(NullPointerException::class.java) {
+                org.junit.jupiter.api.assertThrows<NullPointerException>("#209 has been fixed.") {
                     val result = mapper.readValue<NullableObject>("null")
                     assertEquals(NullableObject("null-value-deser"), result)
                 }
@@ -60,7 +56,6 @@ class SpecifiedForObjectMapperTest {
         }
     }
 
-    @Ignore
     data class Dst(
         val pNn: Primitive,
         val pN: Primitive?,
@@ -70,53 +65,51 @@ class SpecifiedForObjectMapperTest {
         val noN: NullableObject?
     )
 
-    class InParameterDeserialize {
-        @Test
-        fun nonNull() {
-            val base = Dst(
-                Primitive(1),
-                Primitive(2),
-                NonNullObject("foo"),
-                NonNullObject("bar"),
-                NullableObject("baz"),
-                NullableObject("qux")
-            )
-            val src = mapper.writeValueAsString(base)
-            val result = mapper.readValue<Dst>(src)
+    @Test
+    fun nonNull() {
+        val base = Dst(
+            Primitive(1),
+            Primitive(2),
+            NonNullObject("foo"),
+            NonNullObject("bar"),
+            NullableObject("baz"),
+            NullableObject("qux")
+        )
+        val src = mapper.writeValueAsString(base)
+        val result = mapper.readValue<Dst>(src)
 
-            val expected = Dst(
-                Primitive(101),
-                Primitive(102),
-                NonNullObject("foo-deser"),
-                NonNullObject("bar-deser"),
-                NullableObject("baz-deser"),
-                NullableObject("qux-deser")
-            )
-            assertEquals(expected, result)
-        }
+        val expected = Dst(
+            Primitive(101),
+            Primitive(102),
+            NonNullObject("foo-deser"),
+            NonNullObject("bar-deser"),
+            NullableObject("baz-deser"),
+            NullableObject("qux-deser")
+        )
+        assertEquals(expected, result)
+    }
 
-        @Test
-        fun withNull() {
-            val base = Dst(
-                Primitive(1),
-                null,
-                NonNullObject("foo"),
-                null,
-                NullableObject(null),
-                null
-            )
-            val src = mapper.writeValueAsString(base)
-            val result = mapper.readValue<Dst>(src)
+    @Test
+    fun withNull() {
+        val base = Dst(
+            Primitive(1),
+            null,
+            NonNullObject("foo"),
+            null,
+            NullableObject(null),
+            null
+        )
+        val src = mapper.writeValueAsString(base)
+        val result = mapper.readValue<Dst>(src)
 
-            val expected = Dst(
-                Primitive(101),
-                null,
-                NonNullObject("foo-deser"),
-                null,
-                NullableObject("null-value-deser"),
-                null
-            )
-            assertEquals(expected, result)
-        }
+        val expected = Dst(
+            Primitive(101),
+            null,
+            NonNullObject("foo-deser"),
+            null,
+            NullableObject("null-value-deser"),
+            null
+        )
+        assertEquals(expected, result)
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
@@ -11,7 +11,7 @@ import org.junit.Assert.assertThrows
 import org.junit.Ignore
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @RunWith(Enclosed::class)
 class SpecifiedForObjectMapperTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/SpecifiedForClassTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/SpecifiedForClassTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 class SpecifiedForClassTest {
     @JsonDeserialize(using = Value.Deserializer::class)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/SpecifiedForClassTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/SpecifiedForClassTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class SpecifiedForClassTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NonNullObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NonNullObjectTest.kt
@@ -8,7 +8,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Ignore
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @RunWith(Enclosed::class)
 class NonNullObjectTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NonNullObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NonNullObjectTest.kt
@@ -5,19 +5,14 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@RunWith(Enclosed::class)
 class NonNullObjectTest {
-    @Ignore
     companion object {
         val mapper = jacksonObjectMapper()
     }
 
-    @Ignore
     data class NonNull(
         @get:JsonDeserialize(using = NonNullObject.Deserializer::class)
         val getterAnn: NonNullObject,
@@ -25,22 +20,19 @@ class NonNullObjectTest {
         val fieldAnn: NonNullObject
     )
 
-    class NonNullTest {
-        @Test
-        fun nonNull() {
-            val result = mapper.readValue<NonNull>(
-                """
+    @Test
+    fun nonNull() {
+        val result = mapper.readValue<NonNull>(
+            """
                 {
                   "getterAnn" : "foo",
                   "fieldAnn" : "bar"
                 }
             """.trimIndent()
-            )
-            assertEquals(NonNull(NonNullObject("foo-deser"), NonNullObject("bar-deser")), result)
-        }
+        )
+        assertEquals(NonNull(NonNullObject("foo-deser"), NonNullObject("bar-deser")), result)
     }
 
-    @Ignore
     data class Nullable(
         @get:JsonDeserialize(using = NonNullObject.Deserializer::class)
         val getterAnn: NonNullObject?,
@@ -48,7 +40,8 @@ class NonNullObjectTest {
         val fieldAnn: NonNullObject?
     )
 
-    class NullableTest {
+    @Nested
+    inner class NullableTest {
         @Test
         fun nonNullInput() {
             val result = mapper.readValue<Nullable>(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NonNullObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NonNullObjectTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NullableObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NullableObjectTest.kt
@@ -8,7 +8,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Ignore
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @RunWith(Enclosed::class)
 class NullableObjectTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NullableObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NullableObjectTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NullableObjectTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NullableObjectTest.kt
@@ -5,19 +5,14 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@RunWith(Enclosed::class)
 class NullableObjectTest {
-    @Ignore
     companion object {
         val mapper = jacksonObjectMapper()
     }
 
-    @Ignore
     data class NonNull(
         @get:JsonDeserialize(using = NullableObject.DeserializerWrapsNullable::class)
         val getterAnn: NullableObject,
@@ -25,22 +20,19 @@ class NullableObjectTest {
         val fieldAnn: NullableObject
     )
 
-    class NonNullTest {
-        @Test
-        fun nonNull() {
-            val result = mapper.readValue<NonNull>(
-                """
+    @Test
+    fun nonNull() {
+        val result = mapper.readValue<NonNull>(
+            """
                 {
                   "getterAnn" : "foo",
                   "fieldAnn" : "bar"
                 }
             """.trimIndent()
-            )
-            assertEquals(NonNull(NullableObject("foo-deser"), NullableObject("bar-deser")), result)
-        }
+        )
+        assertEquals(NonNull(NullableObject("foo-deser"), NullableObject("bar-deser")), result)
     }
 
-    @Ignore
     data class Nullable(
         @get:JsonDeserialize(using = NullableObject.DeserializerWrapsNullable::class)
         val getterAnn: NullableObject?,
@@ -48,7 +40,8 @@ class NullableObjectTest {
         val fieldAnn: NullableObject?
     )
 
-    class NullableTest {
+    @Nested
+    inner class NullableTest {
         @Test
         fun nonNullInput() {
             val result = mapper.readValue<Nullable>(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/PrimitiveTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/PrimitiveTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/PrimitiveTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/PrimitiveTest.kt
@@ -8,7 +8,7 @@ import org.junit.Assert.assertEquals
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import kotlin.test.Ignore
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 @RunWith(Enclosed::class)
 class PrimitiveTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/PrimitiveTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/PrimitiveTest.kt
@@ -5,19 +5,14 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import org.junit.Assert.assertEquals
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
-import kotlin.test.Ignore
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@RunWith(Enclosed::class)
 class PrimitiveTest {
-    @Ignore
     companion object {
         val mapper = jacksonObjectMapper()
     }
 
-    @Ignore
     data class NonNull(
         @get:JsonDeserialize(using = Primitive.Deserializer::class)
         val getterAnn: Primitive,
@@ -25,22 +20,19 @@ class PrimitiveTest {
         val fieldAnn: Primitive
     )
 
-    class NonNullTest {
-        @Test
-        fun nonNull() {
-            val result = mapper.readValue<NonNull>(
-                """
+    @Test
+    fun nonNull() {
+        val result = mapper.readValue<NonNull>(
+            """
                 {
                   "getterAnn" : 1,
                   "fieldAnn" : 2
                 }
             """.trimIndent()
-            )
-            assertEquals(NonNull(Primitive(101), Primitive(102)), result)
-        }
+        )
+        assertEquals(NonNull(Primitive(101), Primitive(102)), result)
     }
 
-    @Ignore
     data class Nullable(
         @get:JsonDeserialize(using = Primitive.Deserializer::class)
         val getterAnn: Primitive?,
@@ -48,7 +40,8 @@ class PrimitiveTest {
         val fieldAnn: Primitive?
     )
 
-    class NullableTest {
+    @Nested
+    inner class NullableTest {
         @Test
         fun nonNullInput() {
             val result = mapper.readValue<Nullable>(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/HandledByJacksonTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/HandledByJacksonTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 // Test for Creator that can be handled by the Jackson mechanism.
 class HandledByJacksonTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/HandledByJacksonTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/HandledByJacksonTest.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.j
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 // Test for Creator that can be handled by the Jackson mechanism.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/HandledByKogeraTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/HandledByKogeraTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 // Test on the case of deserialization by ValueClassBoxDeserializer
 class HandledByKogeraTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/HandledByKogeraTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/HandledByKogeraTest.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 // Test on the case of deserialization by ValueClassBoxDeserializer

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/InCreatorArgumentTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/InCreatorArgumentTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Nu
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 private fun Primitive.modify(): Primitive = Primitive(v + 100)
 private fun NonNullObject.modify(): NonNullObject = NonNullObject("$v-creator")

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/InCreatorArgumentTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/jsonCreator/InCreatorArgumentTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.No
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 private fun Primitive.modify(): Primitive = Primitive(v + 100)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.No
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Up to argument size 32 there is one mask argument for the default argument,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
 import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.test.Test
 
@@ -50,12 +51,14 @@ class DeserializeByConstructorWithDefaultArgumentsTest {
         val p31: NonNullObject = NonNullObject("31")
     )
 
-    @Test(expected = KotlinReflectionInternalError::class)
+    @Test
     fun test32() {
-        assertEquals(Dst32(), defaultMapper.readValue<Dst32>("{}"))
-        // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
-        //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
-        if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        assertThrows<KotlinReflectionInternalError> {
+            assertEquals(Dst32(), defaultMapper.readValue<Dst32>("{}"))
+            // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
+            //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
+            if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        }
     }
 
     data class Dst33(
@@ -166,12 +169,14 @@ class DeserializeByConstructorWithDefaultArgumentsTest {
         val p63: NonNullObject = NonNullObject("63")
     )
 
-    @Test(expected = KotlinReflectionInternalError::class)
+    @Test
     fun test64() {
-        assertEquals(Dst64(), defaultMapper.readValue<Dst64>("{}"))
-        // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
-        //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
-        if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        assertThrows<KotlinReflectionInternalError> {
+            assertEquals(Dst64(), defaultMapper.readValue<Dst64>("{}"))
+            // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
+            //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
+            if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        }
     }
 
     data class Dst65(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.callPrimaryConstructor
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Up to argument size 32 there is one mask argument for the default argument,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByFactoryWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByFactoryWithDefaultArgumentsTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByFactoryWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByFactoryWithDefaultArgumentsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Up to argument size 32 there is one mask argument for the default argument,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.callPrimaryConstructor
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 // Convert the property p to q (but not the value) to make it an input to the factory function.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nonNullObject/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NonNullObject
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 // Convert the property p to q (but not the value) to make it an input to the factory function.
 private fun replacePQ(src: String) = src.replace(Regex("""p\d+":""")) { "q" + it.value.substring(1) }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Nu
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Up to argument size 32 there is one mask argument for the default argument,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
 import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.test.Test
 
@@ -50,12 +51,14 @@ class DeserializeByConstructorWithDefaultArgumentsTest {
         val p31: NullableObject? = NullableObject("31")
     )
 
-    @Test(expected = KotlinReflectionInternalError::class)
+    @Test
     fun test32() {
-        assertEquals(Dst32(), defaultMapper.readValue<Dst32>("{}"))
-        // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
-        //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
-        if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        assertThrows<KotlinReflectionInternalError> {
+            assertEquals(Dst32(), defaultMapper.readValue<Dst32>("{}"))
+            // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
+            //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
+            if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        }
     }
 
     data class Dst33(
@@ -166,12 +169,14 @@ class DeserializeByConstructorWithDefaultArgumentsTest {
         val p63: NullableObject? = NullableObject("63")
     )
 
-    @Test(expected = KotlinReflectionInternalError::class)
+    @Test
     fun test64() {
-        assertEquals(Dst64(), defaultMapper.readValue<Dst64>("{}"))
-        // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
-        //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
-        if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        assertThrows<KotlinReflectionInternalError> {
+            assertEquals(Dst64(), defaultMapper.readValue<Dst64>("{}"))
+            // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
+            //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
+            if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        }
     }
 
     data class Dst65(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Up to argument size 32 there is one mask argument for the default argument,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.callPrimaryConstructor
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByFactoryWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByFactoryWithDefaultArgumentsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Up to argument size 32 there is one mask argument for the default argument,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByFactoryWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByFactoryWithDefaultArgumentsTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.callPrimaryConstructor
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 // Convert the property p to q (but not the value) to make it an input to the factory function.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/nullableObject/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.NullableObject
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 // Convert the property p to q (but not the value) to make it an input to the factory function.
 private fun replacePQ(src: String) = src.replace(Regex("""p\d+":""")) { "q" + it.value.substring(1) }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.test.Test
 
@@ -50,12 +51,14 @@ class DeserializeByConstructorWithDefaultArgumentsTest {
         val p31: Primitive = Primitive(31)
     )
 
-    @Test(expected = KotlinReflectionInternalError::class)
+    @Test
     fun test32() {
-        assertEquals(Dst32(), defaultMapper.readValue<Dst32>("{}"))
-        // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
-        //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
-        if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        assertThrows<KotlinReflectionInternalError> {
+            assertEquals(Dst32(), defaultMapper.readValue<Dst32>("{}"))
+            // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
+            //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
+            if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        }
     }
 
     data class Dst33(
@@ -166,12 +169,14 @@ class DeserializeByConstructorWithDefaultArgumentsTest {
         val p63: Primitive = Primitive(63)
     )
 
-    @Test(expected = KotlinReflectionInternalError::class)
+    @Test
     fun test64() {
-        assertEquals(Dst64(), defaultMapper.readValue<Dst64>("{}"))
-        // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
-        //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
-        if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        assertThrows<KotlinReflectionInternalError> {
+            assertEquals(Dst64(), defaultMapper.readValue<Dst64>("{}"))
+            // TODO: #762 is resolved after Kotlin 2.0, so the reason why throw is done is to make CI with Kotlin 2.0 succeed.
+            //   After upgrading to Kotlin 2.0, remove exception-related descriptions.
+            if (KotlinVersion.CURRENT.major >= 2) throw KotlinReflectionInternalError("")
+        }
     }
 
     data class Dst65(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Pr
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Up to argument size 32 there is one mask argument for the default argument,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.callPrimaryConstructor
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Up to argument size 32 there is one mask argument for the default argument,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByFactoryWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByFactoryWithDefaultArgumentsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Up to argument size 32 there is one mask argument for the default argument,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByFactoryWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByFactoryWithDefaultArgumentsTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.callPrimaryConstructor
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 // Convert the property p to q (but not the value) to make it an input to the factory function.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/parameterSize/primitive/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Primitive
 import org.junit.Assert.assertEquals
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 // Convert the property p to q (but not the value) to make it an input to the factory function.
 private fun replacePQ(src: String) = src.replace(Regex("""p\d+":""")) { "q" + it.value.substring(1) }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/DurationTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/DurationTests.kt
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.UseJavaDurationConversi
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.Instant
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ExtensionMethodsTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ExtensionMethodsTests.kt
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestExtensionMethods {
     val mapper: ObjectMapper = jacksonObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ExtensionMethodsTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ExtensionMethodsTests.kt
@@ -14,12 +14,11 @@ import com.fasterxml.jackson.module.kotlin.minusAssign
 import com.fasterxml.jackson.module.kotlin.plusAssign
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.treeToValue
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
-class TestExtensionMethods {
+private class TestExtensionMethods {
     val mapper: ObjectMapper = jacksonObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)
 
     data class BasicPerson(val name: String, val age: Int)
@@ -33,9 +32,9 @@ class TestExtensionMethods {
 
         val expectedPerson = BasicPerson("John Smith", 30)
 
-        assertThat(inferRightSide, equalTo(expectedPerson))
-        assertThat(inferLeftSide, equalTo(expectedPerson))
-        assertThat(person, equalTo(expectedPerson))
+        assertEquals(expectedPerson, inferRightSide)
+        assertEquals(expectedPerson, inferLeftSide)
+        assertEquals(expectedPerson, person)
     }
 
     data class MyData(val a: String, val b: Int)
@@ -43,7 +42,7 @@ class TestExtensionMethods {
     @Test fun testStackOverflow33368328() {
         val jsonStr = """[{"a": "value1", "b": 1}, {"a": "value2", "b": 2}]"""
         val myList: List<MyData> = mapper.readValue(jsonStr)
-        assertThat(myList, equalTo(listOf(MyData("value1", 1), MyData("value2", 2))))
+        assertEquals(listOf(MyData("value1", 1), MyData("value2", 2)), myList)
     }
 
     @Test fun testOperatorFunExtensions() {
@@ -56,8 +55,8 @@ class TestExtensionMethods {
         objectNode -= "foo1"
         objectNode -= listOf("foo2")
 
-        assertThat("foo1" !in objectNode, `is`(true))
-        assertThat("foo3" in objectNode, `is`(true))
+        assertTrue("foo1" !in objectNode)
+        assertTrue("foo3" in objectNode)
 
         val arrayNode = factory.arrayNode()
         arrayNode += "foo"
@@ -66,35 +65,34 @@ class TestExtensionMethods {
         arrayNode += 1.0
         arrayNode += "bar".toByteArray()
 
-        assertThat(arrayNode.size(), `is`(5))
+        assertEquals(5, arrayNode.size())
 
         (4 downTo 0).forEach { arrayNode -= it }
-        assertThat(arrayNode.size(), `is`(0))
+        assertEquals(0, arrayNode.size())
     }
 
-    @Test fun noTypeErasure(){
+    @Test fun noTypeErasure() {
         data class Person(val name: String)
         val source = """[ { "name" : "Neo" } ]"""
         val tree = mapper.readTree(source)
 
         val readValueResult: List<Person> = mapper.readValue(source)
-        assertThat(readValueResult, `is`(listOf(Person("Neo"))))
+        assertEquals(listOf(Person("Neo")), readValueResult)
 
         val treeToValueResult: List<Person> = mapper.treeToValue(tree)
-        assertThat(treeToValueResult, `is`(listOf(Person("Neo"))))
+        assertEquals(listOf(Person("Neo")), treeToValueResult)
 
         val convertValueResult: List<Person> = mapper.convertValue(tree)
-        assertThat(convertValueResult, `is`(listOf(Person("Neo"))))
+        assertEquals(listOf(Person("Neo")), convertValueResult)
     }
 
     @Test fun mixInExtensionTest() {
-
         data class Person(val name: String)
         abstract class PersonMixIn { @JsonIgnore var name: String = "" }
 
         val mapper: JsonMapper = jsonMapper { addMixIn<Person, PersonMixIn>() }
         val serializedPerson: String = mapper.writeValueAsString(Person("test"))
 
-        assertThat(serializedPerson, `is`("{}"))
+        assertEquals("{}", serializedPerson)
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/FailNullForPrimitiveTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/FailNullForPrimitiveTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import junit.framework.TestCase.assertEquals
 import org.junit.Assert.assertThrows
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 class FailNullForPrimitiveTest {
     data class Dto(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/FailNullForPrimitiveTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/FailNullForPrimitiveTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import junit.framework.TestCase.assertEquals
-import org.junit.Assert.assertThrows
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 class FailNullForPrimitiveTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/FailNullForPrimitiveTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/FailNullForPrimitiveTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import junit.framework.TestCase.assertEquals
+ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/IteratorTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/IteratorTests.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestIteratorSubclass {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KClassSerializerDeserializerTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KClassSerializerDeserializerTest.kt
@@ -8,8 +8,7 @@ import com.fasterxml.jackson.module.kotlin.addDeserializer
 import com.fasterxml.jackson.module.kotlin.addSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -26,8 +25,8 @@ class KClassSerializerDeserializerTest {
     fun `test custom serializer expecting object serialized with rounding serializer applied`() {
         val jsonString = objectMapper.writeValueAsString(TestDoubleData(nonNullVal = 1.5567, nullVal = 1.5678))
         val testResult = objectMapper.readValue(jsonString, TestDoubleData::class.java)
-        assertThat(testResult.nonNullVal, equalTo(1.56))
-        assertThat(testResult.nullVal, equalTo(1.57))
+        assertEquals(1.56, testResult.nonNullVal)
+        assertEquals(1.57, testResult.nullVal)
     }
 
     @Test
@@ -38,8 +37,8 @@ class KClassSerializerDeserializerTest {
                 "nullVal":1.5678
             }
         """.trimIndent())
-        assertThat(testResult.nonNullVal, equalTo(1.56))
-        assertThat(testResult.nullVal, equalTo(1.57))
+        assertEquals(1.56, testResult.nonNullVal)
+        assertEquals(1.57, testResult.nullVal)
     }
 }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KClassSerializerDeserializerTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KClassSerializerDeserializerTest.kt
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.math.RoundingMode
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KotlinBuiltinsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KotlinBuiltinsTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestJacksonWithKotlinBuiltins {
     private val mapper: ObjectMapper = jacksonObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KotlinBuiltinsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KotlinBuiltinsTest.kt
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class TestJacksonWithKotlinBuiltins {
@@ -17,9 +16,9 @@ class TestJacksonWithKotlinBuiltins {
         val json = """{"name":{"first":"John","second":"Smith"},"age":30}"""
         val expected = ClassWithPair(Pair("John", "Smith"), 30)
 
-        assertThat(mapper.writeValueAsString(expected), equalTo(json))
+        assertEquals(json, mapper.writeValueAsString(expected))
         val stateObj = mapper.readValue<ClassWithPair>(json)
-        assertThat(stateObj, equalTo(expected))
+        assertEquals(expected, stateObj)
     }
 
     private data class ClassWithPairMixedTypes(val person: Pair<String, Int>)
@@ -28,9 +27,9 @@ class TestJacksonWithKotlinBuiltins {
         val json = """{"person":{"first":"John","second":30}}"""
         val expected = ClassWithPairMixedTypes(Pair("John", 30))
 
-        assertThat(mapper.writeValueAsString(expected), equalTo(json))
+        assertEquals(json, mapper.writeValueAsString(expected))
         val stateObj = mapper.readValue<ClassWithPairMixedTypes>(json)
-        assertThat(stateObj, equalTo(expected))
+        assertEquals(expected, stateObj)
     }
 
     private data class ClassWithTriple(val name: Triple<String, String, String>, val age: Int)
@@ -39,9 +38,9 @@ class TestJacksonWithKotlinBuiltins {
         val json = """{"name":{"first":"John","second":"Davey","third":"Smith"},"age":30}"""
         val expected = ClassWithTriple(Triple("John", "Davey", "Smith"), 30)
 
-        assertThat(mapper.writeValueAsString(expected), equalTo(json))
+        assertEquals(json, mapper.writeValueAsString(expected))
         val stateObj = mapper.readValue<ClassWithTriple>(json)
-        assertThat(stateObj, equalTo(expected))
+        assertEquals(expected, stateObj)
     }
 
     private data class ClassWithRanges(val ages: IntRange, val distance: LongRange)
@@ -50,9 +49,9 @@ class TestJacksonWithKotlinBuiltins {
         val json = """{"ages":{"start":18,"end":40},"distance":{"start":5,"end":50}}"""
         val expected = ClassWithRanges(IntRange(18, 40), LongRange(5, 50))
 
-        assertThat(mapper.writeValueAsString(expected), equalTo(json))
+        assertEquals(json, mapper.writeValueAsString(expected))
         val stateObj = mapper.readValue<ClassWithRanges>(json)
-        assertThat(stateObj, equalTo(expected))
+        assertEquals(expected, stateObj)
     }
 
     private data class ClassWithPairMixedNullableTypes(val person: Pair<String?, Int?>)
@@ -61,20 +60,20 @@ class TestJacksonWithKotlinBuiltins {
         val json = """{"person":{"first":"John","second":null}}"""
         val expected = ClassWithPairMixedNullableTypes(Pair("John", null))
 
-        assertThat(mapper.writeValueAsString(expected), equalTo(json))
+        assertEquals(json, mapper.writeValueAsString(expected))
         val stateObj = mapper.readValue<ClassWithPairMixedNullableTypes>(json)
-        assertThat(stateObj, equalTo(expected))
+        assertEquals(expected, stateObj)
     }
 
-    private data class GenericParametersClass<A, B: Any>(val one: A, val two: B)
+    private data class GenericParametersClass<A, B : Any>(val one: A, val two: B)
     private data class GenericParameterConsumer(val thing: GenericParametersClass<String?, Int>)
 
     @Test fun testGenericParametersInConstructor() {
         val json = """{"thing":{"one":null,"two":123}}"""
         val expected = GenericParameterConsumer(GenericParametersClass(null, 123))
 
-        assertThat(mapper.writeValueAsString(expected), equalTo(json))
+        assertEquals(json, mapper.writeValueAsString(expected))
         val stateObj = mapper.readValue<GenericParameterConsumer>(json)
-        assertThat(stateObj, equalTo(expected))
+        assertEquals(expected, stateObj)
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KotlinFeatures.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KotlinFeatures.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.module.kotlin.*
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.properties.Delegates
 import kotlin.test.assertNull
 import kotlin.test.fail

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KotlinFeatures.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/KotlinFeatures.kt
@@ -7,17 +7,15 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.*
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import kotlin.properties.Delegates
 import kotlin.test.assertNull
 import kotlin.test.fail
 
-
 private data class DataClassPerson(val name: String, val age: Int)
 
-class TestM11Changes {
+private class TestM11Changes {
     val mapper = jacksonObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)
 
     private class Class_With_One_Constructor(val name: String, val age: Int)
@@ -27,26 +25,24 @@ class TestM11Changes {
         val expectedPerson = Class_With_One_Constructor("John Smith", 30)
 
         val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson  = mapper.readValue<Class_With_One_Constructor>(actualJson)
+        val newPerson = mapper.readValue<Class_With_One_Constructor>(actualJson)
 
-        assertThat(actualJson, equalTo(expectedJson))
-        assertThat(newPerson.name, equalTo(expectedPerson.name))
-        assertThat(newPerson.age, equalTo(expectedPerson.age))
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedPerson.name, newPerson.name)
+        assertEquals(expectedPerson.age, newPerson.age)
     }
 
     private data class Class_Data_Annotation_With_One_Constructor(val name: String, val age: Int)
 
     @Test fun testDataClass_One_Constructor() {
-
-
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_Data_Annotation_With_One_Constructor("John Smith", 30)
 
         val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson  = mapper.readValue<Class_Data_Annotation_With_One_Constructor>(actualJson)
+        val newPerson = mapper.readValue<Class_Data_Annotation_With_One_Constructor>(actualJson)
 
-        assertThat(actualJson, equalTo(expectedJson))
-        assertThat(newPerson, equalTo(expectedPerson))
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedPerson, newPerson)
     }
 
     private data class Class_With_Init_Constructor(val name: String, val age: Int) {
@@ -57,15 +53,14 @@ class TestM11Changes {
     }
 
     @Test fun testDataClass_Init_Constructor() {
-
         val expectedJson = """{"name":"John Smith","age":30,"otherThing":"franky"}"""
         val expectedPerson = Class_With_Init_Constructor("John Smith", 30)
 
         val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson  = mapper.readValue<Class_With_Init_Constructor>(actualJson)
+        val newPerson = mapper.readValue<Class_With_Init_Constructor>(actualJson)
 
-        assertThat(actualJson, equalTo(expectedJson))
-        assertThat(newPerson, equalTo(expectedPerson))
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedPerson, newPerson)
     }
 
     private data class Class_With_Init_Constructor_And_Ignored_Property(val name: String, val age: Int) {
@@ -76,15 +71,14 @@ class TestM11Changes {
     }
 
     @Test fun testDataClass_Init_Constructor_And_Ignored_Property() {
-
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_With_Init_Constructor_And_Ignored_Property("John Smith", 30)
 
         val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson  = mapper.readValue<Class_With_Init_Constructor_And_Ignored_Property>(actualJson)
+        val newPerson = mapper.readValue<Class_With_Init_Constructor_And_Ignored_Property>(actualJson)
 
-        assertThat(actualJson, equalTo(expectedJson))
-        assertThat(newPerson, equalTo(expectedPerson))
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedPerson, newPerson)
     }
 
     private class Class_With_No_Field_Parameters_But_Field_Declared_Inside_initialized_from_parameter(val name: String, age: Int) {
@@ -92,89 +86,84 @@ class TestM11Changes {
     }
 
     @Test fun testDataClass_With_No_Field_Parameters_But_Field_Declared_Inside_initialized_from_parameter() {
-
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_With_No_Field_Parameters_But_Field_Declared_Inside_initialized_from_parameter("John Smith", 30)
 
         val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson  = mapper.readValue<Class_With_No_Field_Parameters_But_Field_Declared_Inside_initialized_from_parameter>(actualJson)
+        val newPerson = mapper.readValue<Class_With_No_Field_Parameters_But_Field_Declared_Inside_initialized_from_parameter>(actualJson)
 
-        assertThat(actualJson, equalTo(expectedJson))
-        assertThat(newPerson.name, equalTo(expectedPerson.name))
-        assertThat(newPerson.age, equalTo(expectedPerson.age))
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedPerson.name, newPerson.name)
+        assertEquals(expectedPerson.age, newPerson.age)
     }
 
     private class ClassFor_testDataClass_WithOnlySecondaryConstructor {
         val name: String
         val age: Int
         constructor(name: String, age: Int) {
-           this.name = name
+            this.name = name
             this.age = age
         }
     }
 
     @Test fun testDataClass_WithOnlySecondaryConstructor() {
-
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = ClassFor_testDataClass_WithOnlySecondaryConstructor("John Smith", 30)
 
         val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson  = mapper.readValue<ClassFor_testDataClass_WithOnlySecondaryConstructor>(actualJson)
+        val newPerson = mapper.readValue<ClassFor_testDataClass_WithOnlySecondaryConstructor>(actualJson)
 
-        assertThat(actualJson, equalTo(expectedJson))
-        assertThat(newPerson.name, equalTo(expectedPerson.name))
-        assertThat(newPerson.age, equalTo(expectedPerson.age))
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedPerson.name, newPerson.name)
+        assertEquals(expectedPerson.age, newPerson.age)
     }
-
 
     private class Class_WithPrimaryAndSecondaryConstructor(val name: String, val age: Int) {
         constructor(nameAndAge: String) : this(nameAndAge.substringBefore(':'), nameAndAge.substringAfter(':').toInt()) {
-
         }
     }
 
     @Test fun testDataClass_WithPrimaryAndSecondaryConstructor() {
-
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_WithPrimaryAndSecondaryConstructor("John Smith", 30)
 
         val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson  = mapper.readValue<Class_WithPrimaryAndSecondaryConstructor>(actualJson)
+        val newPerson = mapper.readValue<Class_WithPrimaryAndSecondaryConstructor>(actualJson)
 
-        assertThat(actualJson, equalTo(expectedJson))
-        assertThat(newPerson.name, equalTo(expectedPerson.name))
-        assertThat(newPerson.age, equalTo(expectedPerson.age))
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedPerson.name, newPerson.name)
+        assertEquals(expectedPerson.age, newPerson.age)
     }
 
     private class Class_WithPrimaryAndSecondaryConstructorAnnotated(name: String) {
         val name: String = name
         var age: Int = 0
+
         @JsonCreator constructor(name: String, age: Int) : this(name) {
             this.age = age
         }
     }
 
     @Test fun testDataClass_WithPrimaryAndSecondaryConstructorBothCouldBeUsedToDeserialize() {
-
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_WithPrimaryAndSecondaryConstructorAnnotated("John Smith", 30)
 
         val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson  = mapper.readValue<Class_WithPrimaryAndSecondaryConstructorAnnotated>(actualJson)
+        val newPerson = mapper.readValue<Class_WithPrimaryAndSecondaryConstructorAnnotated>(actualJson)
 
-        assertThat(actualJson, equalTo(expectedJson))
-        assertThat(newPerson.name, equalTo(expectedPerson.name))
-        assertThat(newPerson.age, equalTo(expectedPerson.age))
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedPerson.name, newPerson.name)
+        assertEquals(expectedPerson.age, newPerson.age)
 
         val jsonWithNoAge = """{"name":"John Smith"}"""
-        val personNoAge  = mapper.readValue<Class_WithPrimaryAndSecondaryConstructorAnnotated>(jsonWithNoAge)
+        val personNoAge = mapper.readValue<Class_WithPrimaryAndSecondaryConstructorAnnotated>(jsonWithNoAge)
 
-        assertThat(personNoAge.age, equalTo(0))
-        assertThat(personNoAge.name, equalTo("John Smith"))
+        assertEquals(0, personNoAge.age)
+        assertEquals("John Smith", personNoAge.name)
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    class Class_WithPartialFieldsInConstructor(val name: String, @JsonProperty("age") val years: Int)    {
+    class Class_WithPartialFieldsInConstructor(val name: String, @JsonProperty("age") val years: Int) {
         @JsonProperty("address") var primaryAddress: String = ""
         var phone: String by Delegates.notNull()
     }
@@ -187,11 +176,11 @@ class TestM11Changes {
         val actualJson = mapper.writeValueAsString(expectedPerson)
         val newPerson = mapper.readValue<Class_WithPartialFieldsInConstructor>(actualJson)
 
-        assertThat(actualJson, equalTo(expectedJson))
-        assertThat(newPerson.name, equalTo(expectedPerson.name))
-        assertThat(newPerson.years, equalTo(expectedPerson.years))
-        assertThat(newPerson.phone, equalTo(expectedPerson.phone))
-        assertThat(newPerson.primaryAddress, equalTo(expectedPerson.primaryAddress))
+        assertEquals(expectedJson, actualJson)
+        assertEquals(expectedPerson.name, newPerson.name)
+        assertEquals(expectedPerson.years, newPerson.years)
+        assertEquals(expectedPerson.phone, newPerson.phone)
+        assertEquals(expectedPerson.primaryAddress, newPerson.primaryAddress)
 
         val jsonWithNullPhone = """{"name":"John Smith","age":30}"""
         val person = mapper.readValue<Class_WithPartialFieldsInConstructor>(jsonWithNullPhone)
@@ -199,7 +188,7 @@ class TestM11Changes {
         try {
             person.phone
             fail("While person can be deserialized without a phone, phone must be set before attempting to access it")
-        } catch(e: IllegalStateException) { // expected
+        } catch (e: IllegalStateException) { // expected
         }
     }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefaultTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefaultTests.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class TestNullToDefault {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefaultTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefaultTests.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 
 class TestNullToDefault {
 
@@ -139,13 +140,15 @@ class TestNullToDefault {
         Assert.assertEquals(true, item.canBeProcessed)
     }
 
-    @Test(expected = MissingKotlinParameterException::class)
+    @Test
     fun shouldThrowExceptionWhenProvidedNullForNotNullFieldWithoutDefault() {
-        createMapper(true).readValue<TestClass>(
-            """{
+        assertThrows<MissingKotlinParameterException> {
+            createMapper(true).readValue<TestClass>(
+                """{
 						"text": null
  				}"""
-        )
+            )
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefaultTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToDefaultTests.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -43,12 +43,12 @@ class TestNullToDefault {
 				}"""
         )
 
-        Assert.assertEquals(-1, item.sku)
-        Assert.assertEquals("plain", item.text)
-        Assert.assertEquals("some image", item.images)
-        Assert.assertEquals("uk", item.language)
-		Assert.assertTrue(item.temperature == 24.7)
-		Assert.assertEquals(true, item.canBeProcessed)
+        assertEquals(-1, item.sku)
+        assertEquals("plain", item.text)
+        assertEquals("some image", item.images)
+        assertEquals("uk", item.language)
+		assertTrue(item.temperature == 24.7)
+		assertEquals(true, item.canBeProcessed)
     }
 
     @Test
@@ -64,12 +64,12 @@ class TestNullToDefault {
 				}"""
         )
 
-        Assert.assertEquals(0, item.sku)
-        Assert.assertEquals("plain", item.text)
-        Assert.assertEquals("image1", item.images)
-        Assert.assertEquals("pl", item.language)
-        Assert.assertTrue(item.temperature == 0.0)
-        Assert.assertEquals(false, item.canBeProcessed)
+        assertEquals(0, item.sku)
+        assertEquals("plain", item.text)
+        assertEquals("image1", item.images)
+        assertEquals("pl", item.language)
+        assertTrue(item.temperature == 0.0)
+        assertEquals(false, item.canBeProcessed)
     }
 
     @Test
@@ -85,12 +85,12 @@ class TestNullToDefault {
 				}"""
         )
 
-        Assert.assertEquals(974, item.sku)
-        Assert.assertEquals("plain", item.text)
-        Assert.assertEquals(null, item.images)
-        Assert.assertEquals("pl", item.language)
-		Assert.assertTrue(item.temperature == 36.6)
-        Assert.assertEquals(false, item.canBeProcessed)
+        assertEquals(974, item.sku)
+        assertEquals("plain", item.text)
+        assertEquals(null, item.images)
+        assertEquals("pl", item.language)
+		assertTrue(item.temperature == 36.6)
+        assertEquals(false, item.canBeProcessed)
     }
 
 	@Test
@@ -104,10 +104,10 @@ class TestNullToDefault {
 				}"""
 		)
 
-		Assert.assertEquals(0, item.sku)
-		Assert.assertEquals("plain", item.text)
-		Assert.assertTrue(item.temperature == 0.0)
-		Assert.assertEquals(false, item.canBeProcessed)
+		assertEquals(0, item.sku)
+		assertEquals("plain", item.text)
+		assertTrue(item.temperature == 0.0)
+		assertEquals(false, item.canBeProcessed)
 	}
 
     @Test
@@ -118,10 +118,10 @@ class TestNullToDefault {
 				}"""
         )
 
-        Assert.assertEquals(-1, item.sku)
-        Assert.assertEquals("plain", item.text)
-        Assert.assertTrue(item.temperature == 24.7)
-        Assert.assertEquals(true, item.canBeProcessed)
+        assertEquals(-1, item.sku)
+        assertEquals("plain", item.text)
+        assertTrue(item.temperature == 24.7)
+        assertEquals(true, item.canBeProcessed)
     }
 
     @Test
@@ -132,12 +132,12 @@ class TestNullToDefault {
 				}"""
         )
 
-        Assert.assertEquals(-1, item.sku)
-        Assert.assertEquals("plain", item.text)
-        Assert.assertEquals("some image", item.images)
-        Assert.assertEquals("uk", item.language)
-		Assert.assertTrue(item.temperature == 24.7)
-        Assert.assertEquals(true, item.canBeProcessed)
+        assertEquals(-1, item.sku)
+        assertEquals("plain", item.text)
+        assertEquals("some image", item.images)
+        assertEquals("uk", item.language)
+		assertTrue(item.temperature == 24.7)
+        assertEquals(true, item.canBeProcessed)
     }
 
     @Test
@@ -163,6 +163,6 @@ class TestNullToDefault {
         )
 
         val expectedResult = OuterDataClass(InnerDataClass("someString"))
-        Assert.assertEquals(expectedResult, outerDataClassInstance)
+        assertEquals(expectedResult, outerDataClassInstance)
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyCollectionTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyCollectionTest.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyCollection
 import com.fasterxml.jackson.module.kotlin.kotlinModule
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestNullToEmptyCollection {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyMapTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/NullToEmptyMapTest.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
 import com.fasterxml.jackson.module.kotlin.kotlinModule
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestNullToEmptyMap {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectSingletonTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectSingletonTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 // [module-kotlin#225]: keep Kotlin singletons as singletons
 class TestObjectSingleton {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectSingletonTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ObjectSingletonTest.kt
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.SingletonSupport
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 // [module-kotlin#225]: keep Kotlin singletons as singletons
@@ -22,7 +21,7 @@ class TestObjectSingleton {
         val js = mapper.writeValueAsString(Singleton)
         val newSingleton = mapper.readValue<Singleton>(js)
 
-        assertThat(newSingleton, equalTo(Singleton))
+        assertEquals(Singleton, newSingleton)
     }
 
     @Test
@@ -34,22 +33,22 @@ class TestObjectSingleton {
         // mutate the in-memory singleton state
         val after = initial + 1
         Singleton.content = after
-        assertThat(Singleton.content, equalTo(after))
+        assertEquals(Singleton.content, after)
 
         // read back persisted state resets singleton state
         val newSingleton = mapper.readValue<Singleton>(js)
-        assertThat(newSingleton.content, equalTo(initial))
-        assertThat(Singleton.content, equalTo(initial))
+        assertEquals(initial, Singleton.content)
+        assertEquals(initial, newSingleton.content)
     }
 
     @Test
     fun deserializedObjectsBehaveLikeSingletons() {
         val js = mapper.writeValueAsString(Singleton)
         val newSingleton = mapper.readValue<Singleton>(js)
-        assertThat(newSingleton.content, equalTo(Singleton.content))
+        assertEquals(Singleton.content, newSingleton.content)
 
         newSingleton.content += 1
 
-        assertThat(Singleton.content, equalTo(newSingleton.content))
+        assertEquals(Singleton.content, newSingleton.content)
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.*
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.StringWriter
 import java.util.*
 import kotlin.properties.Delegates

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/ParameterNameTests.kt
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.*
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
 import java.util.*
@@ -35,12 +33,12 @@ class TestJacksonWithKotlin {
             createDtField: Date = createdDt,
             isNameField: Boolean = isName,
         ) {
-            assertThat(nameField, equalTo("Frank"))
-            assertThat(ageField, equalTo(30))
-            assertThat(addressField, equalTo("something here"))
-            assertThat(wrongNameField, equalTo(true))
-            assertThat(createDtField, equalTo(Date(1477419948000)))
-            assertThat(isNameField, equalTo(false))
+            assertEquals("Frank", nameField)
+            assertEquals(30, ageField)
+            assertEquals("something here", addressField)
+            assertEquals(true, wrongNameField)
+            assertEquals(Date(1477419948000), createDtField)
+            assertFalse(isNameField)
         }
     }
 
@@ -117,7 +115,7 @@ class TestJacksonWithKotlin {
         val test1out = StringWriter()
         normalCasedMapper.writeValue(test1out, stateObj)
 
-        assertThat(test1out.getBuffer().toString(), equalTo(normalCasedJson))
+        assertEquals(normalCasedJson, test1out.getBuffer().toString())
     }
 
     // ==================
@@ -138,7 +136,7 @@ class TestJacksonWithKotlin {
         stateObj.validate()
 
         val test1out = normalCasedMapper.writeValueAsString(stateObj)
-        assertThat(test1out, equalTo(normalCasedJson))
+        assertEquals(normalCasedJson, test1out)
     }
 
     // ==================
@@ -206,7 +204,7 @@ class TestJacksonWithKotlin {
         stateObj.validate()
 
         val test1out = pascalCasedMapper.writeValueAsString(stateObj)
-        assertThat(test1out, equalTo(pascalCasedJson))
+        assertEquals(pascalCasedJson, test1out)
     }
 
     private class HasSameParamNameConstructor(val value: Int) {
@@ -250,7 +248,7 @@ class TestJacksonWithKotlin {
     @Test fun findingFactoryMethod() {
         val stateObj = normalCasedMapper.readValue(normalCasedJson, StateObjectWithFactory::class.java)
         stateObj.validate()
-        assertThat(stateObj.factoryUsed, equalTo(true))
+        assertEquals(true, stateObj.factoryUsed)
     }
 
     private class StateObjectWithFactoryNoParamAnnotations(
@@ -278,8 +276,7 @@ class TestJacksonWithKotlin {
     @Test fun findingFactoryMethod2() {
         try {
             normalCasedMapper.readValue(normalCasedJson, StateObjectWithFactoryNoParamAnnotations::class.java)
-        }
-        catch (ex: Exception) {
+        } catch (ex: Exception) {
             ex.printStackTrace()
             fail("Exception not expected")
         }
@@ -313,7 +310,7 @@ class TestJacksonWithKotlin {
     @Test fun findingFactoryMethod3() {
         val stateObj = normalCasedMapper.readValue(normalCasedJson, StateObjectWithFactoryOnNamedCompanion::class.java)
         stateObj.validate()
-        assertThat(stateObj.factoryUsed, equalTo(true))
+        assertTrue(stateObj.factoryUsed)
     }
 
     // GH #14 failing due to this enum type
@@ -346,4 +343,3 @@ class TestJacksonWithKotlin {
         assertTrue(Gh14FailureWithEnum::class.java.isKotlinClass())
     }
 }
-

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/PropertyRequirednessTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/PropertyRequirednessTests.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SealedClassTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SealedClassTest.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.test.SealedClassTest.SuperClass.B
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SequenceSerdesTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/SequenceSerdesTests.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -23,7 +23,7 @@ class StrictNullChecksTest {
     fun testListOfNullableInt() {
         val json = """{"samples":[1, null]}"""
         val stateObj = mapper.readValue<ClassWithListOfNullableInt>(json)
-        assertThat(stateObj.samples, equalTo(listOf(1, null)))
+        assertEquals(listOf(1, null), stateObj.samples)
     }
 
     private data class ClassWithListOfInt(val samples: List<Int>)
@@ -53,7 +53,7 @@ class StrictNullChecksTest {
     fun testArrayOfNullableInt() {
         val json = """{"samples":[1, null]}"""
         val stateObj = mapper.readValue<ClassWithArrayOfNullableInt>(json)
-        assertThat(stateObj.samples, equalTo(arrayOf(1, null)))
+        assertArrayEquals(arrayOf(1, null), stateObj.samples)
     }
 
     private data class ClassWithArrayOfInt(val samples: Array<Int>)
@@ -83,7 +83,7 @@ class StrictNullChecksTest {
     fun testMapOfStringToNullableInt() {
         val json = """{ "samples": { "key": null } }"""
         val stateObj = mapper.readValue<ClassWithMapOfStringToNullableInt>(json)
-        assertThat(stateObj.samples, equalTo(mapOf<String, Int?>("key" to null)))
+        assertEquals(mapOf<String, Int?>("key" to null), stateObj.samples)
     }
 
     private data class ClassWithMapOfStringToInt(val samples: Map<String, Int>)
@@ -113,7 +113,7 @@ class StrictNullChecksTest {
     fun testListOfGeneric() {
         val json = """{"samples":[1, 2]}"""
         val stateObj = mapper.readValue<TestClass<List<Int>>>(json)
-        assertThat(stateObj.samples, equalTo(listOf(1, 2)))
+        assertEquals(listOf(1, 2), stateObj.samples)
     }
 
     @Disabled // this is a hard problem to solve and is currently not addressed
@@ -129,7 +129,7 @@ class StrictNullChecksTest {
     fun testMapOfGeneric() {
         val json = """{ "samples": { "key": 1 } }"""
         val stateObj = mapper.readValue<TestClass<Map<String, Int>>>(json)
-        assertThat(stateObj.samples, equalTo(mapOf("key" to 1)))
+        assertEquals(mapOf("key" to 1), stateObj.samples)
     }
 
     @Disabled // this is a hard problem to solve and is currently not addressed
@@ -145,7 +145,7 @@ class StrictNullChecksTest {
     fun testArrayOfGeneric() {
         val json = """{"samples":[1, 2]}"""
         val stateObj = mapper.readValue<TestClass<Array<Int>>>(json)
-        assertThat(stateObj.samples, equalTo(arrayOf(1, 2)))
+        assertArrayEquals(arrayOf(1, 2), stateObj.samples)
     }
 
     @Disabled // this is a hard problem to solve and is currently not addressed

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertNull
 
@@ -116,7 +116,7 @@ class StrictNullChecksTest {
         assertThat(stateObj.samples, equalTo(listOf(1, 2)))
     }
 
-    @Ignore // this is a hard problem to solve and is currently not addressed
+    @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testListOfGenericWithNullValue() {
         assertThrows<MissingKotlinParameterException> {
@@ -132,7 +132,7 @@ class StrictNullChecksTest {
         assertThat(stateObj.samples, equalTo(mapOf("key" to 1)))
     }
 
-    @Ignore // this is a hard problem to solve and is currently not addressed
+    @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testMapOfGenericWithNullValue() {
         assertThrows<MissingKotlinParameterException> {
@@ -148,7 +148,7 @@ class StrictNullChecksTest {
         assertThat(stateObj.samples, equalTo(arrayOf(1, 2)))
     }
 
-    @Ignore // this is a hard problem to solve and is currently not addressed
+    @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testArrayOfGenericWithNullValue() {
         assertThrows<MissingKotlinParameterException> {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
@@ -9,6 +9,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Ignore
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertNull
 
 class StrictNullChecksTest {
@@ -27,10 +28,12 @@ class StrictNullChecksTest {
 
     private data class ClassWithListOfInt(val samples: List<Int>)
 
-    @Test(expected = MissingKotlinParameterException::class)
+    @Test
     fun testListOfInt() {
-        val json = """{"samples":[1, null]}"""
-        mapper.readValue<ClassWithListOfInt>(json)
+        assertThrows<MissingKotlinParameterException> {
+            val json = """{"samples":[1, null]}"""
+            mapper.readValue<ClassWithListOfInt>(json)
+        }
     }
 
     private data class ClassWithNullableListOfInt(val samples: List<Int>?)
@@ -55,10 +58,12 @@ class StrictNullChecksTest {
 
     private data class ClassWithArrayOfInt(val samples: Array<Int>)
 
-    @Test(expected = MissingKotlinParameterException::class)
+    @Test
     fun testArrayOfInt() {
-        val json = """{"samples":[1, null]}"""
-        mapper.readValue<ClassWithArrayOfInt>(json)
+        assertThrows<MissingKotlinParameterException> {
+            val json = """{"samples":[1, null]}"""
+            mapper.readValue<ClassWithArrayOfInt>(json)
+        }
     }
 
     private data class ClassWithNullableArrayOfInt(val samples: Array<Int>?)
@@ -83,10 +88,12 @@ class StrictNullChecksTest {
 
     private data class ClassWithMapOfStringToInt(val samples: Map<String, Int>)
 
-    @Test(expected = MissingKotlinParameterException::class)
+    @Test
     fun testMapOfStringToIntWithNullValue() {
-        val json = """{ "samples": { "key": null } }"""
-        mapper.readValue<ClassWithMapOfStringToInt>(json)
+        assertThrows<MissingKotlinParameterException> {
+            val json = """{ "samples": { "key": null } }"""
+            mapper.readValue<ClassWithMapOfStringToInt>(json)
+        }
     }
 
     private data class ClassWithNullableMapOfStringToInt(val samples: Map<String, Int>?)
@@ -110,10 +117,12 @@ class StrictNullChecksTest {
     }
 
     @Ignore // this is a hard problem to solve and is currently not addressed
-    @Test(expected = MissingKotlinParameterException::class)
+    @Test
     fun testListOfGenericWithNullValue() {
-        val json = """{"samples":[1, null]}"""
-        mapper.readValue<TestClass<List<Int>>>(json)
+        assertThrows<MissingKotlinParameterException> {
+            val json = """{"samples":[1, null]}"""
+            mapper.readValue<TestClass<List<Int>>>(json)
+        }
     }
 
     @Test
@@ -124,10 +133,12 @@ class StrictNullChecksTest {
     }
 
     @Ignore // this is a hard problem to solve and is currently not addressed
-    @Test(expected = MissingKotlinParameterException::class)
+    @Test
     fun testMapOfGenericWithNullValue() {
-        val json = """{ "samples": { "key": null } }"""
-        mapper.readValue<TestClass<Map<String, Int>>>(json)
+        assertThrows<MissingKotlinParameterException> {
+            val json = """{ "samples": { "key": null } }"""
+            mapper.readValue<TestClass<Map<String, Int>>>(json)
+        }
     }
 
     @Test
@@ -138,9 +149,11 @@ class StrictNullChecksTest {
     }
 
     @Ignore // this is a hard problem to solve and is currently not addressed
-    @Test(expected = MissingKotlinParameterException::class)
+    @Test
     fun testArrayOfGenericWithNullValue() {
-        val json = """{"samples":[1, null]}"""
-        mapper.readValue<TestClass<Array<Int>>>(json)
+        assertThrows<MissingKotlinParameterException> {
+            val json = """{"samples":[1, null]}"""
+            mapper.readValue<TestClass<Array<Int>>>(json)
+        }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpersTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpersTest.kt
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test
 
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestHelpersTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpersTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/TestHelpersTest.kt
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.kotlin.test
 
-import org.junit.Assert.assertThrows
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersOnKeyTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersOnKeyTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.exc.InputCoercionException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.math.BigInteger
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersOnKeyTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersOnKeyTest.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test
 import com.fasterxml.jackson.core.exc.InputCoercionException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertThrows
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.math.BigInteger
 import kotlin.test.assertEquals

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersTests.kt
@@ -6,9 +6,8 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Test
 import java.math.BigInteger
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 
 internal class UnsignedNumbersTests {
 
@@ -18,76 +17,76 @@ internal class UnsignedNumbersTests {
     fun `test UByte`() {
         val json = mapper.writeValueAsString(UByte.MAX_VALUE)
         val deserialized = mapper.readValue<UByte>(json)
-        assertThat(deserialized, equalTo(UByte.MAX_VALUE))
+        assertEquals(UByte.MAX_VALUE, deserialized)
     }
 
     @Test
     fun `test UByte overflow`() {
         val json = mapper.writeValueAsString(UByte.MAX_VALUE + 1u)
-        assertThrows(InputCoercionException::class.java) { mapper.readValue<UByte>(json) }
+        assertThrows<InputCoercionException> { mapper.readValue<UByte>(json) }
     }
 
     @Test
     fun `test UByte underflow`() {
         val json = mapper.writeValueAsString(-1)
-        assertThrows(InputCoercionException::class.java) { mapper.readValue<UByte>(json) }
+        assertThrows<InputCoercionException> { mapper.readValue<UByte>(json) }
     }
 
     @Test
     fun `test UShort`() {
         val json = mapper.writeValueAsString(UShort.MAX_VALUE)
         val deserialized = mapper.readValue<UShort>(json)
-        assertThat(deserialized, equalTo(UShort.MAX_VALUE))
+        assertEquals(UShort.MAX_VALUE, deserialized)
     }
 
     @Test
     fun `test UShort overflow`() {
         val json = mapper.writeValueAsString(UShort.MAX_VALUE + 1u)
-        assertThrows(InputCoercionException::class.java) {  mapper.readValue<UShort>(json) }
+        assertThrows<InputCoercionException> { mapper.readValue<UShort>(json) }
     }
 
     @Test
     fun `test UShort underflow`() {
         val json = mapper.writeValueAsString(-1)
-        assertThrows(InputCoercionException::class.java) { mapper.readValue<UShort>(json) }
+        assertThrows<InputCoercionException> { mapper.readValue<UShort>(json) }
     }
 
     @Test
     fun `test UInt`() {
         val json = mapper.writeValueAsString(UInt.MAX_VALUE)
         val deserialized = mapper.readValue<UInt>(json)
-        assertThat(deserialized, equalTo(UInt.MAX_VALUE))
+        assertEquals(UInt.MAX_VALUE, deserialized)
     }
 
     @Test
     fun `test UInt overflow`() {
         val json = mapper.writeValueAsString(UInt.MAX_VALUE.toULong() + 1u)
-        assertThrows(InputCoercionException::class.java) { mapper.readValue<UInt>(json) }
+        assertThrows<InputCoercionException> { mapper.readValue<UInt>(json) }
     }
 
     @Test
     fun `test UInt underflow`() {
         val json = mapper.writeValueAsString(-1)
-        assertThrows(InputCoercionException::class.java) { mapper.readValue<UInt>(json) }
+        assertThrows<InputCoercionException> { mapper.readValue<UInt>(json) }
     }
 
     @Test
     fun `test ULong`() {
         val json = mapper.writeValueAsString(ULong.MAX_VALUE)
         val deserialized = mapper.readValue<ULong>(json)
-        assertThat(deserialized, equalTo(ULong.MAX_VALUE))
+        assertEquals(ULong.MAX_VALUE, deserialized)
     }
 
     @Test
     fun `test ULong overflow`() {
         val value = BigInteger(ULong.MAX_VALUE.toString()) + BigInteger.ONE
         val json = mapper.writeValueAsString(value)
-        assertThrows(InputCoercionException::class.java) { mapper.readValue<ULong>(json) }
+        assertThrows<InputCoercionException> { mapper.readValue<ULong>(json) }
     }
 
     @Test
     fun `test ULong underflow`() {
         val json = mapper.writeValueAsString(-1)
-        assertThrows(InputCoercionException::class.java) { mapper.readValue<ULong>(json) }
+        assertThrows<InputCoercionException> { mapper.readValue<ULong>(json) }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersTests.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 import java.math.BigInteger
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Assert.assertThrows
+import org.junit.jupiter.api.Assertions.assertThrows
 
 internal class UnsignedNumbersTests {
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersTests.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/UnsignedNumbersTests.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.exc.InputCoercionException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.math.BigInteger
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/VarargDeserTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/VarargDeserTest.kt
@@ -7,7 +7,7 @@ import junit.framework.TestCase.assertTrue
 import org.junit.Ignore
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 // from https://github.com/ProjectMapK/jackson-module-kogera/blob/0631cd3b07c7fb6971a00ac1f6811b4367a1720e/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/VarargTest.kt#L1
 @RunWith(Enclosed::class)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/VarargDeserTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/VarargDeserTest.kt
@@ -2,8 +2,8 @@ package com.fasterxml.jackson.module.kotlin.test
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertTrue
+ import org.junit.jupiter.api.Assertions.assertEquals
+ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/VarargDeserTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/VarargDeserTest.kt
@@ -4,23 +4,17 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
-import org.junit.Ignore
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-// from https://github.com/ProjectMapK/jackson-module-kogera/blob/0631cd3b07c7fb6971a00ac1f6811b4367a1720e/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/VarargTest.kt#L1
-@RunWith(Enclosed::class)
+// from https://github.com/ProjectMapK/jackson-module-kogera/blob/7872116052c9a4744c6d4e84ddd5cab6bb525024/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/VarargTest.kt
 class VarargDeserTest {
-    @Ignore
-    companion object {
-        val mapper = jacksonObjectMapper()
-    }
+    val mapper = jacksonObjectMapper()
 
-    @Ignore
     class OnlyVararg(vararg val v: Int)
 
-    class OnlyVarargTest {
+    @Nested
+    inner class OnlyVarargTest {
         @Test
         fun hasArgs() {
             val r = mapper.readValue<OnlyVararg>("""{"v":[1,2,3]}""")
@@ -40,10 +34,10 @@ class VarargDeserTest {
         }
     }
 
-    @Ignore
     class HeadVararg(vararg val v: Int?, val i: Int)
 
-    class HeadVarargTest {
+    @Nested
+    inner class HeadVarargTest {
         @Test
         fun hasArgs() {
             val r = mapper.readValue<HeadVararg>("""{"i":0,"v":[1,2,null]}""")
@@ -66,10 +60,10 @@ class VarargDeserTest {
         }
     }
 
-    @Ignore
     class TailVararg(val i: Int, vararg val v: String)
 
-    class TailVarargTest {
+    @Nested
+    inner class TailVarargTest {
         @Test
         fun hasArgs() {
             val r = mapper.readValue<TailVararg>("""{"i":0,"v":["foo","bar","baz"]}""")
@@ -92,10 +86,10 @@ class VarargDeserTest {
         }
     }
 
-    @Ignore
     class HasDefaultVararg(vararg val v: String? = arrayOf("foo", "bar"))
 
-    class HasDefaultVarargTest {
+    @Nested
+    inner class HasDefaultVarargTest {
         @Test
         fun hasArgs() {
             val r = mapper.readValue<HasDefaultVararg>("""{"v":["foo","bar",null]}""")

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub524.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub524.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.testPrettyWriter
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 // Most of the current behavior has been tested on GitHub464, so only serializer-related behavior is tested here.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub530.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub530.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.testPrettyWriter
 import kotlin.test.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class GitHub530 {
     // At the moment, the output is the same with or without `JsonValue`,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub618.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub618.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class GitHub618 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub625.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub625.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.testPrettyWriter
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub757.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub757.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.convertValue
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertNull
 
 class GitHub757 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub841.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub841.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class GitHub841 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub844.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub844.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_type")

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github101.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github101.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.annotation.JacksonInject
 import com.fasterxml.jackson.databind.InjectableValues
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github104.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github104.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub104 {
     abstract class SuperClass(val name: String)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github114.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github114.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.kotlinFunction
 import kotlin.test.assertEquals

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github120.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github120.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub120 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github124.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github124.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub124 {
     // test for [module-kotlin#124]: broken in 2.9.3, fixed in 2.9.6

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github131.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github131.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub131 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github145.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github145.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @Suppress("UNUSED_VARIABLE")
 class TestGithub145 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github148.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github148.kt
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub148 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github149.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github149.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonBackReference
 import com.fasterxml.jackson.annotation.JsonManagedReference
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @Suppress("UNUSED_VARIABLE")
 class TestGithub149 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github15.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github15.kt
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub15 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github153.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github153.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import com.fasterxml.jackson.module.kotlin.test.github.TestGithub153.MyPojo
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub153 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github155.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github155.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub155 {
     data class Foo @JvmOverloads constructor(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github158.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github158.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub158 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github161.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github161.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.fail
 
 class TestGithub161 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github165.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github165.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github167.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github167.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.function.IntSupplier
 
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github168.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github168.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github168.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github168.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
 
 class TestGithub168 {
@@ -17,10 +18,12 @@ class TestGithub168 {
         assertEquals("whatever", obj.baz)
     }
 
-    @Test(expected = MissingKotlinParameterException::class)
+    @Test
     fun testIfRequiredIsReallyRequiredWhenAbsent() {
-        val obj = jacksonObjectMapper().readValue<TestClass>("""{"baz":"whatever"}""")
-        assertEquals("whatever", obj.baz)
+        assertThrows<MissingKotlinParameterException> {
+            val obj = jacksonObjectMapper().readValue<TestClass>("""{"baz":"whatever"}""")
+            assertEquals("whatever", obj.baz)
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github179.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github179.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 // verifying work around for this issue, no bug present

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github180.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github180.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertNull
 
 class TestGithub180 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github181.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github181.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub181 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github194.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github194.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.annotation.JsonIdentityInfo
 import com.fasterxml.jackson.annotation.ObjectIdGenerators
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github196.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github196.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertSame
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github207.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github207.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub207 {
     open class Wrapper(@JsonValue val value: String) {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github207.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github207.kt
@@ -1,10 +1,9 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
-
 import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 class TestGithub207 {
@@ -42,7 +41,7 @@ class TestGithub207 {
         val deserialized = objectMapper.readValue<Wrapper>(json)
 
         // then
-        Assert.assertEquals(Wrapper("foo"), deserialized)
+        assertEquals(Wrapper("foo"), deserialized)
     }
 
     @Test
@@ -54,7 +53,7 @@ class TestGithub207 {
         val serialized = objectMapper.writeValueAsString(wrapperObject)
 
         // then
-        Assert.assertEquals("\"foo\"", serialized)
+        assertEquals("\"foo\"", serialized)
     }
 
     @Test
@@ -66,7 +65,7 @@ class TestGithub207 {
         val deserialized = objectMapper.readValue<ExtendedWrapper>(json)
 
         // then
-        Assert.assertEquals(ExtendedWrapper("foo"), deserialized)
+        assertEquals(ExtendedWrapper("foo"), deserialized)
     }
 
     @Test
@@ -78,7 +77,7 @@ class TestGithub207 {
         val serialized = objectMapper.writeValueAsString(wrapperObject)
 
         // then
-        Assert.assertEquals("\"foo\"", serialized)
+        assertEquals("\"foo\"", serialized)
     }
 
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github210.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github210.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 
 class TestGithub210 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github22.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github22.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub22 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github239.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github239.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github25.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github25.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.module.kotlin.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.properties.Delegates
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github26.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github26.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 data class ClassWithPrimitivesWithDefaults(val i: Int = 5, val x: Int)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github269.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github269.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub269 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
 import kotlin.test.fail
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github27.kt
@@ -6,12 +6,11 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
 import kotlin.test.fail
-
 
 class TestGithub27 {
     val mapper: ObjectMapper = jacksonObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, false)
@@ -21,7 +20,7 @@ class TestGithub27 {
     @Test fun testNullableInt() {
         val json = """{"sample":null}"""
         val stateObj = mapper.readValue<ClassWithNullableInt>(json)
-        assertThat(stateObj, equalTo(ClassWithNullableInt(null)))
+        assertEquals(ClassWithNullableInt(null), stateObj)
     }
 
     private data class ClassWithInt(val sample: Int)
@@ -29,7 +28,7 @@ class TestGithub27 {
     @Test fun testInt() {
         val json = """{"sample":null}"""
         val stateObj = mapper.readValue<ClassWithInt>(json)
-        assertThat(stateObj, equalTo(ClassWithInt(0)))
+        assertEquals(ClassWithInt(0), stateObj)
     }
 
     private data class ClassWithListOfNullableInt(val samples: List<Int?>)
@@ -37,7 +36,7 @@ class TestGithub27 {
     @Test fun testListOfNullableInt() {
         val json = """{"samples":[1, null]}"""
         val stateObj = mapper.readValue<ClassWithListOfInt>(json)
-        assertThat(stateObj.samples, equalTo(listOf(1, null)))
+        assertEquals(listOf(1, null), stateObj.samples)
     }
 
     private data class ClassWithListOfInt(val samples: List<Int>)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github270.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github270.kt
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub270 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github29.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github29.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub29 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github308.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github308.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github32.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github32.kt
@@ -1,22 +1,14 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.hamcrest.CustomTypeSafeMatcher
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.ExpectedException
-import kotlin.reflect.KParameter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
-
-class TestGithub32 {
-
-    @Rule
-    @JvmField
-    var thrown: ExpectedException = ExpectedException.none()
-
+private class TestGithub32 {
     @Test fun `valid mandatory data class constructor param`() {
         jacksonObjectMapper().readValue<Person>("""
         {
@@ -27,73 +19,88 @@ class TestGithub32 {
     }
 
     @Test fun `missing mandatory data class constructor param`() {
-        thrown.expect(missingFirstNameParameter())
-        thrown.expect(pathMatches("firstName"))
-        thrown.expect(location(line = 3, column = 1))
-        jacksonObjectMapper().readValue<Person>("""
-        {
-            "lastName": "Bond"
+        val thrown = assertThrows<MismatchedInputException>(
+            "MissingKotlinParameterException with missing `firstName` parameter"
+        ) {
+            jacksonObjectMapper().readValue<Person>("""
+            {
+                "lastName": "Bond"
+            }
+            """.trimIndent())
         }
-        """.trimIndent())
+
+        assertEquals("firstName", thrown.getHumanReadablePath())
+        assertEquals(3, thrown.location?.lineNr)
+        assertEquals(1, thrown.location?.columnNr)
     }
 
     @Test fun `null mandatory data class constructor param`() {
-        thrown.expect(missingFirstNameParameter())
-        thrown.expect(pathMatches("firstName"))
-        thrown.expect(location(line = 4, column = 1))
-        jacksonObjectMapper().readValue<Person>("""
-        {
-            "firstName": null,
-            "lastName": "Bond"
+        val thrown = assertThrows<MismatchedInputException> {
+            jacksonObjectMapper().readValue<Person>("""
+            {
+                "firstName": null,
+                "lastName": "Bond"
+            }
+            """.trimIndent())
         }
-        """.trimIndent())
+
+        assertEquals("firstName", thrown.getHumanReadablePath())
+        assertEquals(4, thrown.location?.lineNr)
+        assertEquals(1, thrown.location?.columnNr)
     }
 
     @Test fun `missing mandatory constructor param - nested in class with default constructor`() {
-        thrown.expect(missingFirstNameParameter())
-        thrown.expect(pathMatches("person.firstName"))
-        thrown.expect(location(line = 4, column = 5))
-        jacksonObjectMapper().readValue<WrapperWithDefaultContructor>("""
-        {
-            "person": {
-                "lastName": "Bond"
+        val thrown = assertThrows<MismatchedInputException> {
+            jacksonObjectMapper().readValue<WrapperWithDefaultContructor>("""
+            {
+                "person": {
+                    "lastName": "Bond"
+                }
             }
+            """.trimIndent())
         }
-        """.trimIndent())
+
+        assertEquals("person.firstName", thrown.getHumanReadablePath())
+        assertEquals(4, thrown.location?.lineNr)
+        assertEquals(5, thrown.location?.columnNr)
     }
 
     @Test fun `missing mandatory constructor param - nested in class with single arg constructor`() {
-        thrown.expect(missingFirstNameParameter())
-        thrown.expect(pathMatches("person.firstName"))
-        thrown.expect(location(line = 4, column = 5))
-        jacksonObjectMapper().readValue<WrapperWithArgsContructor>("""
-        {
-            "person": {
-                "lastName": "Bond"
+        val thrown = assertThrows<MismatchedInputException> {
+            jacksonObjectMapper().readValue<WrapperWithArgsContructor>("""
+            {
+                "person": {
+                    "lastName": "Bond"
+                }
             }
+            """.trimIndent())
         }
-        """.trimIndent())
+
+        assertEquals("person.firstName", thrown.getHumanReadablePath())
+        assertEquals(4, thrown.location?.lineNr)
+        assertEquals(5, thrown.location?.columnNr)
     }
 
     @Test fun `missing mandatory constructor param - nested in class with List arg constructor`() {
-        thrown.expect(missingFirstNameParameter())
-        thrown.expect(pathMatches("people[0].firstName"))
-        thrown.expect(location(line = 7, column = 9))
-        jacksonObjectMapper().readValue<Crowd>("""
-        {
-            "people": [
-                {
-                    "person": {
-                        "lastName": "Bond"
+        val thrown = assertThrows<MismatchedInputException> {
+            jacksonObjectMapper().readValue<Crowd>("""
+            {
+                "people": [
+                    {
+                        "person": {
+                            "lastName": "Bond"
+                        }
                     }
-                }
-            ]
+                ]
+            }
+            """.trimIndent())
         }
-        """.trimIndent())
+
+        assertEquals("people[0].firstName", thrown.getHumanReadablePath())
+        assertEquals(7, thrown.location?.lineNr)
+        assertEquals(9, thrown.location?.columnNr)
     }
-
 }
-
 
 private data class Person(val firstName: String, val lastName: String)
 
@@ -103,23 +110,6 @@ private data class WrapperWithDefaultContructor(val person: Person? = null)
 
 private data class Crowd(val people: List<Person>)
 
-
-private fun missingFirstNameParameter() = missingConstructorParam(::Person.parameters[0])
-
-private fun missingConstructorParam(param: KParameter) = object : CustomTypeSafeMatcher<MissingKotlinParameterException>("MissingKotlinParameterException with missing `${param.name}` parameter") {
-    override fun matchesSafely(e: MissingKotlinParameterException): Boolean = e.parameter.equals(param)
-}
-
-private fun pathMatches(path: String) = object : CustomTypeSafeMatcher<MissingKotlinParameterException>("MissingKotlinParameterException with path `$path`") {
-    override fun matchesSafely(e: MissingKotlinParameterException): Boolean = e.getHumanReadablePath().equals(path)
-}
-
-private fun location(line: Int, column: Int) = object : CustomTypeSafeMatcher<MissingKotlinParameterException>("MissingKotlinParameterException with location (line=$line, column=$column)") {
-    override fun matchesSafely(e: MissingKotlinParameterException): Boolean {
-        return e.location != null && line.equals(e.location.lineNr) && column.equals(e.location.columnNr)
-    }
-}
-
 private fun JsonMappingException.getHumanReadablePath(): String {
     val builder = StringBuilder()
     this.path.forEachIndexed { i, reference ->
@@ -127,7 +117,7 @@ private fun JsonMappingException.getHumanReadablePath(): String {
             builder.append("[${reference.index}]")
         } else {
             if (i > 0) builder.append(".")
-            builder.append("${reference.fieldName}")
+            builder.append(reference.fieldName)
         }
     }
     return builder.toString()

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github335.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github335.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class Github335Test {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github340.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github340.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class OwnerRequestTest {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github356.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github356.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub356 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github396.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github396.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class Github396 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github42.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github42.kt
@@ -4,21 +4,15 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.ExpectedException
-import kotlin.test.assertEquals
-
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class TestGithub42_FailOnNullForPrimitives {
 
     data class OptionalIntRequiredBoolean(val optInt: Int = -1, val reqBool: Boolean)
 
     val mapper = jacksonObjectMapper().enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-
-    @Rule
-    @JvmField
-    var thrown: ExpectedException = ExpectedException.none()
 
     @Test fun `optional primitive parameter defaulted if not in json when FAIL_ON_NULL_FOR_PRIMITIVES is true`() {
         val actualObj: OptionalIntRequiredBoolean = mapper.readValue("""
@@ -31,11 +25,9 @@ class TestGithub42_FailOnNullForPrimitives {
     }
 
     @Test fun `Exception thrown if required primitive parameter not in json when FAIL_ON_NULL_FOR_PRIMITIVES is true`() {
-        thrown.expect(JsonMappingException::class.java)
-
-        mapper.readValue<OptionalIntRequiredBoolean>("""
-        {"optInt": 2}
-        """)
+        assertThrows<JsonMappingException> {
+            mapper.readValue<OptionalIntRequiredBoolean>("""{"optInt": 2}""")
+        }
     }
 
     @Test fun `optional parameter has json value if provided when FAIL_ON_NULL_FOR_PRIMITIVES is true`() {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github46.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github46.kt
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.*
-import org.junit.Assert
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertEquals
@@ -19,7 +19,7 @@ class TestGithub46 {
         val rejson = mapper.writeValueAsString(data)
 
         // then
-        Assert.assertEquals(json, rejson)
+        assertEquals(json, rejson)
     }
 
     @Test fun byReflectionDo32() {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github46.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github46.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.*
 import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github464.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github464.kt
@@ -12,47 +12,56 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.testPrettyWriter
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class Github464 {
-    class UnboxTest {
-        object NullValueClassKeySerializer : StdSerializer<ValueClass>(ValueClass::class.java) {
-            override fun serialize(value: ValueClass?, gen: JsonGenerator, provider: SerializerProvider) {
-                gen.writeFieldName("null-key")
-            }
+    object NullValueClassKeySerializer : StdSerializer<ValueClass>(ValueClass::class.java) {
+        override fun serialize(value: ValueClass?, gen: JsonGenerator, provider: SerializerProvider) {
+            gen.writeFieldName("null-key")
         }
+    }
 
-        interface IValue
-        @JvmInline
-        value class ValueClass(val value: Int?) : IValue
-        data class WrapperClass(val inlineField: ValueClass)
+    interface IValue
 
-        abstract class AbstractGetter<T> {
-            abstract val qux: T
+    @JvmInline
+    value class ValueClass(val value: Int?) : IValue
+    data class WrapperClass(val inlineField: ValueClass)
 
-            fun <T> getPlugh() = qux
+    abstract class AbstractGetter<T> {
+        abstract val qux: T
+
+        fun <T> getPlugh() = qux
+    }
+    interface IGetter<T> {
+        val quux: T
+
+        fun <T> getXyzzy() = quux
+    }
+
+    class Poko(
+        val foo: ValueClass,
+        val bar: ValueClass?,
+        val baz: IValue,
+        override val qux: ValueClass,
+        override val quux: ValueClass,
+        val corge: Collection<ValueClass?>,
+        val grault: Array<ValueClass?>,
+        val garply: WrapperClass,
+        val waldo: WrapperClass?,
+        val fred: Map<ValueClass, ValueClass?>
+    ) : AbstractGetter<ValueClass>(), IGetter<ValueClass>
+
+    object NullValueSerializer : StdSerializer<Any>(Any::class.java) {
+        override fun serialize(value: Any?, gen: JsonGenerator, provider: SerializerProvider) {
+            gen.writeString("null-value")
         }
-        interface IGetter<T> {
-            val quux: T
+    }
 
-            fun <T> getXyzzy() = quux
-        }
-
-
-        class Poko(
-            val foo: ValueClass,
-            val bar: ValueClass?,
-            val baz: IValue,
-            override val qux: ValueClass,
-            override val quux: ValueClass,
-            val corge: Collection<ValueClass?>,
-            val grault: Array<ValueClass?>,
-            val garply: WrapperClass,
-            val waldo: WrapperClass?,
-            val fred: Map<ValueClass, ValueClass?>
-        ) : AbstractGetter<ValueClass>(), IGetter<ValueClass>
+    @Nested
+    inner class UnboxTest {
 
         private val zeroValue = ValueClass(0)
         private val oneValue = ValueClass(1)
@@ -105,12 +114,6 @@ class Github464 {
             )
         }
 
-        object NullValueSerializer : StdSerializer<Any>(Any::class.java) {
-            override fun serialize(value: Any?, gen: JsonGenerator, provider: SerializerProvider) {
-                gen.writeString("null-value")
-            }
-        }
-
         @Test
         fun nullValueSerializerTest() {
             @Suppress("UNCHECKED_CAST")
@@ -148,20 +151,22 @@ class Github464 {
         }
     }
 
-    class SerializerPriorityTest {
-        @JvmInline
-        value class ValueBySerializer(val value: Int)
+    @JvmInline
+    value class ValueBySerializer(val value: Int)
 
-        object Serializer : StdSerializer<ValueBySerializer>(ValueBySerializer::class.java) {
-            override fun serialize(value: ValueBySerializer, gen: JsonGenerator, provider: SerializerProvider) {
-                gen.writeString(value.value.toString())
-            }
+    object Serializer : StdSerializer<ValueBySerializer>(ValueBySerializer::class.java) {
+        override fun serialize(value: ValueBySerializer, gen: JsonGenerator, provider: SerializerProvider) {
+            gen.writeString(value.value.toString())
         }
-        object KeySerializer : StdSerializer<ValueBySerializer>(ValueBySerializer::class.java) {
-            override fun serialize(value: ValueBySerializer, gen: JsonGenerator, provider: SerializerProvider) {
-                gen.writeFieldName(value.value.toString())
-            }
+    }
+    object KeySerializer : StdSerializer<ValueBySerializer>(ValueBySerializer::class.java) {
+        override fun serialize(value: ValueBySerializer, gen: JsonGenerator, provider: SerializerProvider) {
+            gen.writeFieldName(value.value.toString())
         }
+    }
+
+    @Nested
+    inner class SerializerPriorityTest {
 
         private val target = mapOf(ValueBySerializer(1) to ValueBySerializer(2))
         private val sm = SimpleModule()
@@ -178,7 +183,6 @@ class Github464 {
         // Currently, there is a situation where the serialization results are different depending on the registration order of the modules.
         // This problem is not addressed because the serializer registered by the user has priority over Extensions.kt,
         // since KotlinModule is basically registered first.
-        @Ignore
         @Test
         fun priorityTest() {
             val km = KotlinModule.Builder().build()
@@ -187,7 +191,7 @@ class Github464 {
 
             // om1(collect) -> """{"1":"2"}"""
             // om2(broken)  -> """{"1":2}"""
-            assertEquals(om1.writeValueAsString(target), om2.writeValueAsString(target))
+            assertNotEquals(om1.writeValueAsString(target), om2.writeValueAsString(target))
         }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github47.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github47.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub47 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github490.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github490.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub490 {
     val mapper = jacksonObjectMapper()

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github490.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github490.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.NullNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class TestGithub490 {
@@ -18,55 +18,45 @@ class TestGithub490 {
 
     @Test
     fun testKotlinDeserialization_intValue() {
-        assertThat(
-            "Nullable missing Int value should be deserialized as null",
-            value.intValue,
-            CoreMatchers.nullValue()
-        )
+        assertNull(value.intValue, "Nullable missing Int value should be deserialized as null")
     }
 
     @Test
     fun testKotlinDeserialization_stringValue() {
-        assertThat(
-            "Nullable missing String value should be deserialized as null",
-            value.stringValue,
-            CoreMatchers.nullValue()
-        )
+        assertNull(value.stringValue, "Nullable missing String value should be deserialized as null")
     }
 
     @Test
     fun testKotlinDeserialization_jsonNodeValue() {
-        assertThat(
-            "Nullable missing JsonNode value should be deserialized as null and not as NullNode",
+        assertNull(
             value.jsonNodeValue,
-            CoreMatchers.nullValue()
+            "Nullable missing JsonNode value should be deserialized as null and not as NullNode"
         )
     }
 
     @Test
     fun testKotlinDeserialization_jsonNodeValueProvidedNull() {
-        assertThat(
-            "Nullable JsonNode value provided as null should be deserialized as NullNode",
+        assertEquals(
+            NullNode.instance,
             value.jsonNodeValueProvidedNull,
-            CoreMatchers.equalTo(NullNode.instance)
+            "Nullable JsonNode value provided as null should be deserialized as NullNode"
         )
     }
 
     @Test
     fun testKotlinDeserialization_jsonNodeValueWithNullAsDefault() {
-        assertThat(
-            "Nullable by default missing JsonNode value should be deserialized as null and not as NullNode",
+        assertNull(
             value.jsonNodeValueWithNullAsDefault,
-            CoreMatchers.nullValue()
+            "Nullable by default missing JsonNode value should be deserialized as null and not as NullNode"
         )
     }
 
     @Test
     fun testKotlinDeserialization_jsonNodeValueWithNullAsDefaultProvidedNull() {
-        assertThat(
-            "Nullable by default JsonNode with provided null value in payload should be deserialized as NullNode",
+        assertEquals(
+            NullNode.instance,
             value.jsonNodeValueWithNullAsDefaultProvidedNull,
-            CoreMatchers.equalTo(NullNode.instance)
+            "Nullable by default JsonNode with provided null value in payload should be deserialized as NullNode"
         )
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github50.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github50.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub50 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github52.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github52.kt
@@ -3,12 +3,13 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub52 {
     private val mapper = jacksonObjectMapper()
 
-    @org.junit.Test
+    @Test
     fun testBooleanPropertyInConstructor() {
         data class BooleanPropertyInConstructor(
                 @JsonProperty("is_bar")
@@ -18,7 +19,7 @@ class TestGithub52 {
         assertEquals("""{"is_bar":true}""", mapper.writeValueAsString(BooleanPropertyInConstructor()))
     }
 
-    @org.junit.Test
+    @Test
     fun testIsPrefixedBooleanPropertyInConstructor() {
         data class IsPrefixedBooleanPropertyInConstructor(
                 @JsonProperty("is_bar2")
@@ -28,7 +29,7 @@ class TestGithub52 {
         assertEquals("""{"is_bar2":true}""", mapper.writeValueAsString(IsPrefixedBooleanPropertyInConstructor()))
     }
 
-    @org.junit.Test
+    @Test
     fun testIsPrefixedStringPropertyInConstructor() {
         data class IsPrefixedStringPropertyInConstructor(
                 @JsonProperty("is_lol")
@@ -38,7 +39,7 @@ class TestGithub52 {
         assertEquals("""{"is_lol":"sdf"}""", mapper.writeValueAsString(IsPrefixedStringPropertyInConstructor()))
     }
 
-    @org.junit.Test
+    @Test
     fun testBooleanPropertyInBody() {
         data class BooleanPropertyInBody(
                 @JsonIgnore val placeholder: String = "placeholder"
@@ -50,7 +51,7 @@ class TestGithub52 {
         assertEquals("""{"is_foo":true}""", mapper.writeValueAsString(BooleanPropertyInBody()))
     }
 
-    @org.junit.Test
+    @Test
     fun testIsPrefixedBooleanPropertyInBody() {
         data class IsPrefixedBooleanPropertyInBody(
                 @JsonIgnore val placeholder: String = "placeholder"

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github526.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github526.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.annotation.Nulls
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class Github526 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github536.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github536.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.annotation.JsonKey
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.testPrettyWriter
-import junit.framework.TestCase.assertEquals
+ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class Github536 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github536.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github536.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonKey
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.testPrettyWriter
 import junit.framework.TestCase.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class Github536 {
     @JvmInline

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github56.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github56.kt
@@ -4,12 +4,10 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.*
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-
-class TestGithub56 {
+private class TestGithub56 {
 
     private data class TestGalleryWidget_BAD(
             val widgetReferenceId: String,
@@ -19,7 +17,6 @@ class TestGithub56 {
     private data class TestGalleryWidget_GOOD(val widgetReferenceId: String) {
         @JsonUnwrapped lateinit var gallery: TestGallery
     }
-
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private data class TestGallery(
@@ -39,7 +36,7 @@ class TestGithub56 {
             val crops: Map<String, String>? = null
     )
 
-    lateinit var mapper: ObjectMapper
+    val mapper: ObjectMapper = jacksonObjectMapper()
 
     private val gallery = TestGallery(
             id = "id",
@@ -54,11 +51,6 @@ class TestGithub56 {
     val validJson = """
          {"widgetReferenceId":"widgetReferenceId","id":"id","headline":"headline","intro":"intro","role":"role","images":[{"id":"testImage1"},{"id":"testImage2"}]}
     """.trim()
-
-    @Before
-    fun setUp() {
-        mapper = jacksonObjectMapper()
-    }
 
     @Test
     fun serializes() {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github57.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github57.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.KeyDeserializer
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub57 {
     data class Github57Data(val map: Map<Pair<String, String>, String>)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github62.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github62.kt
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub62 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github630.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github630.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class Github630 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github710.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github710.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class Github710 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github722.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github722.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.InjectableValues
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import kotlin.math.exp
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github738.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github738.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class Github738 {
     data class D(@JsonSetter(nulls = Nulls.FAIL) val v: Int)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github738.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github738.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.Nulls
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertThrows
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 class Github738 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github80.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github80.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub80 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github88.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github88.kt
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub88 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github91.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github91.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub91 {
     data class DataClass1(val name: String, val content: DataClass2)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github91.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github91.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class TestGithub91 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GithubDatabind1005Test.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GithubDatabind1005Test.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithubDatabind1005 {
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GithubDatabind1328.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GithubDatabind1328.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithubDatabind1328 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/TestCasesFromSlack.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/TestCasesFromSlack.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.*
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestCasesFromSlack1 {
     data class Host @JsonCreator constructor(

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub337.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub337.kt
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.MapperFeature.SORT_PROPERTIES_ALPHABETICALLY
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.testPrettyWriter
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -20,7 +19,6 @@ class TestGitHub337 {
     private val writer = mapper.testPrettyWriter()
 
     @Test
-    @Ignore
     fun test_ClassWithIsFields() {
         data class ClassWithIsFields(
             val isBooleanField: Boolean,
@@ -37,7 +35,6 @@ class TestGitHub337 {
     }
 
     @Test
-    @Ignore
     fun test_AnnotatedClassWithIsFields() {
         data class ClassWithIsFields(
             @JsonProperty("isBooleanField") val isBooleanField: Boolean,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub451.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub451.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github.failing
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.ComparisonFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class GitHub451 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub451.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub451.kt
@@ -2,8 +2,9 @@ package com.fasterxml.jackson.module.kotlin.test.github.failing
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.ComparisonFailure
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.opentest4j.AssertionFailedError
 import kotlin.test.assertEquals
 
 class GitHub451 {
@@ -25,7 +26,7 @@ class GitHub451 {
 
         val src = Target("a", "b")
         val json = mapper.writeValueAsString(src)
-        expectFailure<ComparisonFailure>("GitHub #451 has been fixed!") {
+        assertThrows<AssertionFailedError>("GitHub #451 has been fixed!") {
             assertEquals(expected, json)
         }
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub478.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub478.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin.jsonMapper
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.ComparisonFailure
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -19,14 +18,14 @@ class GitHub478Test {
 
     @Test
     fun omitsDefaultValueWhenSerializing() {
-        expectFailure<ComparisonFailure>("GitHub478 has been fixed!") {
+        expectFailure<AssertionError>("GitHub478 has been fixed!") {
             assertEquals("""{}""", mapper.writeValueAsString(Data()))
         }
     }
 
     @Test
     fun serializesNonDefaultValue() {
-        expectFailure<ComparisonFailure>("GitHub478 has been fixed!") {
+        expectFailure<AssertionError>("GitHub478 has been fixed!") {
             assertEquals("""{"flag": false}""", mapper.writeValueAsString(Data(flag = false)))
         }
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub478.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GitHub478.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.ComparisonFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class GitHub478Test {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github138.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github138.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub138 {
     @JacksonXmlRootElement(localName = "sms")

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github160DisableAnnotations.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github160DisableAnnotations.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub160 {
     data class DataClass(val blah: String)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github242.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github242.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test.github.failing
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 // Also see https://github.com/FasterXML/jackson-databind/issues/3392

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github271AlphaSortProperties.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github271AlphaSortProperties.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github.failing
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub271 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github474.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github474.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import org.junit.ComparisonFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub474 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github474.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github474.kt
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.module.kotlin.test.github.failing
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.ComparisonFailure
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -13,7 +12,7 @@ class TestGithub474 {
         open class Parent(@JsonProperty("parent-prop") val parent: String)
         class Child(@JsonProperty("child-prop") val child: String) : Parent(child)
 
-        expectFailure<ComparisonFailure>("GitHub #474 has been fixed!") {
+        expectFailure<AssertionError>("GitHub #474 has been fixed!") {
             assertEquals(
                 """{"child-prop":"foo","parent-prop":"foo"}""",
                 jacksonObjectMapper().writeValueAsString(Child("foo"))

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github518.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github518.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
 import kotlin.test.assertSame
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * An empty object should be deserialized as *the* Unit instance for a nullable Unit reference Type.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github54.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github54.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.deser.UnresolvedForwardReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TestGithub54 {
     @Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github611.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github611.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github.failing
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub611 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github71.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/Github71.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.github.failing
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class TestGithub71 {

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GithubDatabind1329.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/failing/GithubDatabind1329.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.test.expectFailure
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/parameterSize/DeserializeByConstructorWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/parameterSize/DeserializeByConstructorWithDefaultArgumentsTest.kt
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.kotlin.test.parameterSize
 import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/parameterSize/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/parameterSize/DeserializeByConstructorWithoutDefaultArgumentsTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.callPrimaryConstructor
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/parameterSize/DeserializeByFactoryWithDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/parameterSize/DeserializeByFactoryWithDefaultArgumentsTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/parameterSize/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/parameterSize/DeserializeByFactoryWithoutDefaultArgumentsTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.assertReflectEquals
 import com.fasterxml.jackson.module.kotlin.callPrimaryConstructor
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 // Convert the property p to q (but not the value) to make it an input to the factory function.


### PR DESCRIPTION
Since `databind` has been migrated to `JUnit5`, we will do the same for `kotlin-module`.
For the migration, I referred to the code of `kogera` which has already been migrated.
https://github.com/ProjectMapK/jackson-module-kogera