### PR TITLE
[`master`] fix failing tests after `FAIL_ON_NULL_FOR_PRIMITIVES` to `true` [databind#4890]

### DIFF
--- a/src/test/kotlin/tools/jackson/module/kotlin/test/KotlinFeatures.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/KotlinFeatures.kt
@@ -9,6 +9,7 @@ import tools.jackson.module.kotlin.readValue
 import tools.jackson.databind.MapperFeature
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.DeserializationFeature
 import kotlin.properties.Delegates
 import kotlin.test.assertNull
 import kotlin.test.fail
@@ -16,7 +17,7 @@ import kotlin.test.fail
 private data class DataClassPerson(val name: String, val age: Int)
 
 private class TestM11Changes {
-    val mapper = jacksonObjectMapper()
+    val MAPPER = jacksonObjectMapper()
     val mapperWithFinalFieldsAsMutators = jacksonMapperBuilder()
         .enable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS)
         .build()
@@ -27,8 +28,8 @@ private class TestM11Changes {
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_With_One_Constructor("John Smith", 30)
 
-        val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson = mapper.readValue<Class_With_One_Constructor>(actualJson)
+        val actualJson = MAPPER.writeValueAsString(expectedPerson)
+        val newPerson = MAPPER.readValue<Class_With_One_Constructor>(actualJson)
 
         assertEquals(expectedJson, actualJson)
         assertEquals(expectedPerson.name, newPerson.name)
@@ -41,8 +42,8 @@ private class TestM11Changes {
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_Data_Annotation_With_One_Constructor("John Smith", 30)
 
-        val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson = mapper.readValue<Class_Data_Annotation_With_One_Constructor>(actualJson)
+        val actualJson = MAPPER.writeValueAsString(expectedPerson)
+        val newPerson = MAPPER.readValue<Class_Data_Annotation_With_One_Constructor>(actualJson)
 
         assertEquals(expectedJson, actualJson)
         assertEquals(expectedPerson, newPerson)
@@ -78,8 +79,8 @@ private class TestM11Changes {
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_With_Init_Constructor_And_Ignored_Property("John Smith", 30)
 
-        val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson = mapper.readValue<Class_With_Init_Constructor_And_Ignored_Property>(actualJson)
+        val actualJson = MAPPER.writeValueAsString(expectedPerson)
+        val newPerson = MAPPER.readValue<Class_With_Init_Constructor_And_Ignored_Property>(actualJson)
 
         assertEquals(expectedJson, actualJson)
         assertEquals(expectedPerson, newPerson)
@@ -93,8 +94,8 @@ private class TestM11Changes {
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_With_No_Field_Parameters_But_Field_Declared_Inside_initialized_from_parameter("John Smith", 30)
 
-        val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson = mapper.readValue<Class_With_No_Field_Parameters_But_Field_Declared_Inside_initialized_from_parameter>(actualJson)
+        val actualJson = MAPPER.writeValueAsString(expectedPerson)
+        val newPerson = MAPPER.readValue<Class_With_No_Field_Parameters_But_Field_Declared_Inside_initialized_from_parameter>(actualJson)
 
         assertEquals(expectedJson, actualJson)
         assertEquals(expectedPerson.name, newPerson.name)
@@ -114,8 +115,8 @@ private class TestM11Changes {
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = ClassFor_testDataClass_WithOnlySecondaryConstructor("John Smith", 30)
 
-        val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson = mapper.readValue<ClassFor_testDataClass_WithOnlySecondaryConstructor>(actualJson)
+        val actualJson = MAPPER.writeValueAsString(expectedPerson)
+        val newPerson = MAPPER.readValue<ClassFor_testDataClass_WithOnlySecondaryConstructor>(actualJson)
 
         assertEquals(expectedJson, actualJson)
         assertEquals(expectedPerson.name, newPerson.name)
@@ -131,8 +132,8 @@ private class TestM11Changes {
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_WithPrimaryAndSecondaryConstructor("John Smith", 30)
 
-        val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson = mapper.readValue<Class_WithPrimaryAndSecondaryConstructor>(actualJson)
+        val actualJson = MAPPER.writeValueAsString(expectedPerson)
+        val newPerson = MAPPER.readValue<Class_WithPrimaryAndSecondaryConstructor>(actualJson)
 
         assertEquals(expectedJson, actualJson)
         assertEquals(expectedPerson.name, newPerson.name)
@@ -145,17 +146,21 @@ private class TestM11Changes {
     )
 
     @Test fun testDataClass_WithPrimaryAndSecondaryConstructorBothCouldBeUsedToDeserialize() {
+        val disabledMapper = jacksonMapperBuilder()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
+
         val expectedJson = """{"name":"John Smith","age":30}"""
         val expectedPerson = Class_WithPrimaryAndSecondaryConstructorAnnotated("John Smith", 30)
 
-        val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson = mapper.readValue<Class_WithPrimaryAndSecondaryConstructorAnnotated>(actualJson)
+        val actualJson = disabledMapper.writeValueAsString(expectedPerson)
+        val newPerson = disabledMapper.readValue<Class_WithPrimaryAndSecondaryConstructorAnnotated>(actualJson)
 
         assertEquals(expectedJson, actualJson)
         assertEquals(expectedPerson.name, newPerson.name)
         assertEquals(expectedPerson.age, newPerson.age)
 
-        val newPerson2 = mapper.readValue<Class_WithPrimaryAndSecondaryConstructorAnnotated>("""{"name":"John Smith"}""")
+        val newPerson2 = disabledMapper.readValue<Class_WithPrimaryAndSecondaryConstructorAnnotated>("""{"name":"John Smith"}""")
         assertEquals(0, newPerson2.age)
         assertEquals("John Smith", newPerson2.name)
     }
@@ -171,8 +176,8 @@ private class TestM11Changes {
         val expectedPerson = Class_WithPartialFieldsInConstructor("John Smith", 30)
         expectedPerson.phone = "1234567890"
 
-        val actualJson = mapper.writeValueAsString(expectedPerson)
-        val newPerson = mapper.readValue<Class_WithPartialFieldsInConstructor>(actualJson)
+        val actualJson = MAPPER.writeValueAsString(expectedPerson)
+        val newPerson = MAPPER.readValue<Class_WithPartialFieldsInConstructor>(actualJson)
 
         assertEquals(expectedJson, actualJson)
         assertEquals(expectedPerson.name, newPerson.name)
@@ -181,7 +186,7 @@ private class TestM11Changes {
         assertEquals(expectedPerson.primaryAddress, newPerson.primaryAddress)
 
         val jsonWithNullPhone = """{"name":"John Smith","age":30}"""
-        val person = mapper.readValue<Class_WithPartialFieldsInConstructor>(jsonWithNullPhone)
+        val person = MAPPER.readValue<Class_WithPartialFieldsInConstructor>(jsonWithNullPhone)
 
         try {
             person.phone
@@ -191,7 +196,7 @@ private class TestM11Changes {
     }
 
     @Test fun testNullableType() {
-        val newPerson = mapper.readValue<Class_WithPartialFieldsInConstructor?>("null")
+        val newPerson = MAPPER.readValue<Class_WithPartialFieldsInConstructor?>("null")
         assertNull(newPerson)
     }
 }

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/NullToDefaultTests.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/NullToDefaultTests.kt
@@ -8,6 +8,7 @@ import tools.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tools.jackson.databind.DeserializationFeature
 
 class TestNullToDefault {
 	private fun createMapper(allowDefaultingByNull: Boolean) = JsonMapper.builder()
@@ -100,7 +101,11 @@ class TestNullToDefault {
 
 	@Test
 	fun shouldUseDefaultPrimitiveValuesInsteadOfDefaultsWhenProvidingNullForNotNullPrimitives() {
-		val item = createMapper(false).readValue<TestClassWithNotNullPrimitives>(
+		val item = createMapper(false)
+            .rebuild()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build()
+            .readValue<TestClassWithNotNullPrimitives>(
 			"""{
 					"sku": null,
 					"text": "plain",

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/ParameterNameTests.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/ParameterNameTests.kt
@@ -8,6 +8,7 @@ import tools.jackson.databind.SerializationFeature
 import tools.jackson.module.kotlin.*
 import tools.jackson.databind.MapperFeature
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.DeserializationFeature
 import java.io.StringWriter
 import java.util.*
 import kotlin.properties.Delegates
@@ -192,8 +193,11 @@ class ParameterNameTests {
         // data class with non fields appearing as parameters in constructor, this works but null values or defaults for primitive types are passed to
         // the unrecognized fields in the constructor.  Does not work with default values for parameters, because a null does not get converted to the
         // default.
+        val disabledMapper = normalCasedMapper.rebuild()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
 
-        val stateObj = normalCasedMapper.readValue<StateObjectAsDataClassConfusingConstructor>(normalCasedJson)
+        val stateObj = disabledMapper.readValue<StateObjectAsDataClassConfusingConstructor>(normalCasedJson)
         stateObj.validate()
     }
 

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github26.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github26.kt
@@ -3,27 +3,36 @@ package tools.jackson.module.kotlin.test.github
 import tools.jackson.module.kotlin.jacksonObjectMapper
 import tools.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 import kotlin.test.assertEquals
 
 data class ClassWithPrimitivesWithDefaults(val i: Int = 5, val x: Int)
 
 class TestGithub26 {
     @Test fun testConstructorWithPrimitiveTypesDefaultedExplicitlyAndImplicitly() {
-        val check1: ClassWithPrimitivesWithDefaults = jacksonObjectMapper()
+        val check1: ClassWithPrimitivesWithDefaults = _createMapper()
             .readValue("""{"i":3,"x":2}""")
         assertEquals(3, check1.i)
         assertEquals(2, check1.x)
 
-        val check2: ClassWithPrimitivesWithDefaults = jacksonObjectMapper()
+        val check2: ClassWithPrimitivesWithDefaults = _createMapper()
             .readValue("""{}""")
         assertEquals(5, check2.i)
         assertEquals(0, check2.x)
 
-        val check3: ClassWithPrimitivesWithDefaults = jacksonObjectMapper()
+        val check3: ClassWithPrimitivesWithDefaults = _createMapper()
             .readValue("""{"i": 2}""")
         assertEquals(2, check3.i)
         assertEquals(0, check3.x)
 
+    }
+
+    private fun _createMapper(): ObjectMapper {
+        return jacksonMapperBuilder()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build()
     }
 
 }

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github27.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github27.kt
@@ -8,6 +8,7 @@ import tools.jackson.module.kotlin.test.expectFailure
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.DeserializationFeature
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -26,8 +27,12 @@ class TestGithub27 {
     private data class ClassWithInt(val sample: Int)
 
     @Test fun testInt() {
+        val disabledMapper = mapper.rebuild()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
+
         val json = """{"sample":null}"""
-        val stateObj = mapper.readValue<ClassWithInt>(json)
+        val stateObj = disabledMapper.readValue<ClassWithInt>(json)
         assertEquals(ClassWithInt(0), stateObj)
     }
 


### PR DESCRIPTION
Resolves failing tests affected by https://github.com/FasterXML/jackson-databind/issues/4858