### PR TITLE
Performance improvement of `strictNullChecks`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,15 @@
                             <exclude>com.fasterxml.jackson.module.kotlin.KotlinModule#getSingletonSupport()</exclude>
                             <exclude>com.fasterxml.jackson.module.kotlin.SingletonSupport</exclude>
                             <!-- internal -->
-
+                            <exclude>
+                                com.fasterxml.jackson.module.kotlin.KotlinNamesAnnotationIntrospector#KotlinNamesAnnotationIntrospector(com.fasterxml.jackson.module.kotlin.ReflectionCache,boolean)
+                            </exclude>
+                            <exclude>
+                                com.fasterxml.jackson.module.kotlin.KotlinValueInstantiator#KotlinValueInstantiator(com.fasterxml.jackson.databind.deser.std.StdValueInstantiator,com.fasterxml.jackson.module.kotlin.ReflectionCache,boolean,boolean,boolean,boolean)
+                            </exclude>
+                            <exclude>
+                                com.fasterxml.jackson.module.kotlin.KotlinInstantiators#KotlinInstantiators(com.fasterxml.jackson.module.kotlin.ReflectionCache,boolean,boolean,boolean,boolean)
+                            </exclude>
                         </excludes>
                     </parameter>
                 </configuration>

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -95,7 +95,7 @@ class KotlinModule private constructor(
 
         val cache = ReflectionCache(reflectionCacheSize)
 
-        context.addValueInstantiators(KotlinInstantiators(cache, nullToEmptyCollection, nullToEmptyMap, nullIsSameAsDefault, strictNullChecks))
+        context.addValueInstantiators(KotlinInstantiators(cache, nullToEmptyCollection, nullToEmptyMap, nullIsSameAsDefault))
 
         if (singletonSupport) {
             context.addBeanDeserializerModifier(KotlinBeanDeserializerModifier)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -109,7 +109,9 @@ class KotlinModule private constructor(
             nullIsSameAsDefault,
             useJavaDurationConversion
         ))
-        context.appendAnnotationIntrospector(KotlinNamesAnnotationIntrospector(cache, kotlinPropertyNameAsImplicitName))
+        context.appendAnnotationIntrospector(
+            KotlinNamesAnnotationIntrospector(cache, strictNullChecks, kotlinPropertyNameAsImplicitName)
+        )
 
         context.addDeserializers(KotlinDeserializers(cache, useJavaDurationConversion))
         context.addKeyDeserializers(KotlinKeyDeserializers)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -73,14 +73,12 @@ internal class KotlinNamesAnnotationIntrospector(
     }
 
     override fun refineDeserializationType(config: MapperConfig<*>, a: Annotated, baseType: JavaType): JavaType =
-        (a as? AnnotatedParameter)?.let { _ ->
-            cache.findKotlinParameter(a)?.let { param ->
-                val rawType = a.rawType
-                (param.type.classifier as? KClass<*>)
-                    ?.java
-                    ?.takeIf { it.isUnboxableValueClass() && it != rawType }
-                    ?.let { config.constructType(it) }
-            }
+        findKotlinParameter(a)?.let { param ->
+            val rawType = a.rawType
+            (param.type.classifier as? KClass<*>)
+                ?.java
+                ?.takeIf { it.isUnboxableValueClass() && it != rawType }
+                ?.let { config.constructType(it) }
         } ?: baseType
 
     override fun findDefaultCreator(
@@ -106,6 +104,9 @@ internal class KotlinNamesAnnotationIntrospector(
     }
 
     private fun findKotlinParameterName(param: AnnotatedParameter): String? = cache.findKotlinParameter(param)?.name
+
+    private fun findKotlinParameter(param: Annotated) = (param as? AnnotatedParameter)
+        ?.let { cache.findKotlinParameter(it) }
 }
 
 // If it is not a Kotlin class or an Enum, Creator is not used

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinInstantiatorsTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinInstantiatorsTest.kt
@@ -13,7 +13,6 @@ class KotlinInstantiatorsTest {
         nullToEmptyCollection = false,
         nullToEmptyMap = false,
         nullIsSameAsDefault = false,
-        strictNullChecks = false
     )
 
     @Test

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/StrictNullChecksTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/StrictNullChecksTest.kt
@@ -1,0 +1,139 @@
+package com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser
+
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.InvalidNullException
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class StrictNullChecksTest {
+    val mapper: ObjectMapper = ObjectMapper()
+        .registerModule(
+            KotlinModule.Builder()
+                .enable(KotlinFeature.StrictNullChecks)
+                .build()
+        )
+
+    class ArrayWrapper(val value: Array<Int>)
+    data class ListWrapper(val value: List<Int>)
+    data class MapWrapper(val value: Map<String, Int>)
+
+    @Nested
+    inner class NonNullInput {
+        @Test
+        fun array() {
+            val expected = ArrayWrapper(arrayOf(1))
+            val src = mapper.writeValueAsString(expected)
+            val result = mapper.readValue<ArrayWrapper>(src)
+
+            Assertions.assertArrayEquals(expected.value, result.value)
+        }
+
+        @Test
+        fun list() {
+            val expected = ListWrapper(listOf(1))
+            val src = mapper.writeValueAsString(expected)
+            val result = mapper.readValue<ListWrapper>(src)
+
+            Assertions.assertEquals(expected, result)
+        }
+
+        @Test
+        fun map() {
+            val expected = MapWrapper(mapOf("foo" to 1))
+            val src = mapper.writeValueAsString(expected)
+            val result = mapper.readValue<MapWrapper>(src)
+
+            Assertions.assertEquals(expected, result)
+        }
+    }
+
+    data class AnyWrapper(val value: Any)
+
+    @Nested
+    inner class NullInput {
+        @Test
+        fun array() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<InvalidNullException> { mapper.readValue<ArrayWrapper>(src) }
+        }
+
+        @Test
+        fun list() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<InvalidNullException> { mapper.readValue<ListWrapper>(src) }
+        }
+
+        @Test
+        fun map() {
+            val src = mapper.writeValueAsString(AnyWrapper(mapOf("foo" to null)))
+            assertThrows<InvalidNullException> { mapper.readValue<MapWrapper>(src) }
+        }
+    }
+
+    class ContentNullsSkipArrayWrapper(@JsonSetter(contentNulls = Nulls.SKIP) val value: Array<Int>)
+    data class ContentNullsSkipListWrapper(@JsonSetter(contentNulls = Nulls.SKIP) val value: List<Int>)
+    data class ContentNullsSkipMapWrapper(@JsonSetter(contentNulls = Nulls.SKIP) val value: Map<String, Int>)
+
+    @Nested
+    inner class CustomByAnnotationTest {
+        @Test
+        fun array() {
+            val expected = ContentNullsSkipArrayWrapper(emptyArray())
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            val result = mapper.readValue<ContentNullsSkipArrayWrapper>(src)
+
+            Assertions.assertArrayEquals(expected.value, result.value)
+        }
+
+        @Test
+        fun list() {
+            val expected = ContentNullsSkipListWrapper(emptyList())
+            val src = mapper.writeValueAsString(AnyWrapper(listOf<Int?>(null)))
+            val result = mapper.readValue<ContentNullsSkipListWrapper>(src)
+
+            Assertions.assertEquals(expected, result)
+        }
+
+        @Test
+        fun map() {
+            val expected = ContentNullsSkipMapWrapper(emptyMap())
+            val src = mapper.writeValueAsString(AnyWrapper(mapOf("foo" to null)))
+            val result = mapper.readValue<ContentNullsSkipMapWrapper>(src)
+
+            Assertions.assertEquals(expected, result)
+        }
+    }
+
+    class AnnotatedArrayWrapper(@JsonSetter(nulls = Nulls.SKIP) val value: Array<Int> = emptyArray())
+    data class AnnotatedListWrapper(@JsonSetter(nulls = Nulls.SKIP) val value: List<Int> = emptyList())
+    data class AnnotatedMapWrapper(@JsonSetter(nulls = Nulls.SKIP) val value: Map<String, Int> = emptyMap())
+
+    // If Default is specified by annotation, it is not overridden.
+    @Nested
+    inner class AnnotatedNullInput {
+        @Test
+        fun array() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<InvalidNullException> { mapper.readValue<AnnotatedArrayWrapper>(src) }
+        }
+
+        @Test
+        fun list() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<InvalidNullException> { mapper.readValue<AnnotatedListWrapper>(src) }
+        }
+
+        @Test
+        fun map() {
+            val src = mapper.writeValueAsString(AnyWrapper(mapOf("foo" to null)))
+            assertThrows<InvalidNullException> { mapper.readValue<AnnotatedMapWrapper>(src) }
+        }
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTest.kt
@@ -1,8 +1,8 @@
 package com.fasterxml.jackson.module.kotlin.test
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.InvalidNullException
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
-import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -30,7 +30,7 @@ class StrictNullChecksTest {
 
     @Test
     fun testListOfInt() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<ClassWithListOfInt>(json)
         }
@@ -60,7 +60,7 @@ class StrictNullChecksTest {
 
     @Test
     fun testArrayOfInt() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<ClassWithArrayOfInt>(json)
         }
@@ -90,7 +90,7 @@ class StrictNullChecksTest {
 
     @Test
     fun testMapOfStringToIntWithNullValue() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{ "samples": { "key": null } }"""
             mapper.readValue<ClassWithMapOfStringToInt>(json)
         }
@@ -119,7 +119,7 @@ class StrictNullChecksTest {
     @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testListOfGenericWithNullValue() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<TestClass<List<Int>>>(json)
         }
@@ -135,7 +135,7 @@ class StrictNullChecksTest {
     @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testMapOfGenericWithNullValue() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{ "samples": { "key": null } }"""
             mapper.readValue<TestClass<Map<String, Int>>>(json)
         }
@@ -151,7 +151,7 @@ class StrictNullChecksTest {
     @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testArrayOfGenericWithNullValue() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<TestClass<Array<Int>>>(json)
         }


### PR DESCRIPTION
Currently, if the strictNullChecks option is enabled, the deserialization performance of collections is significantly degraded.
It also reduces the performance of all deserialization, although very slightly.

The cause of the significant performance degradation is the dynamic definition checks on `Kotlin` at each deserialization.
Therefore, by moving the processing backend to `JsonSetter` and limiting the definition checks to initialization time, I have greatly improved performance.

This change closes #719.

---

The results of the improvements are summarized below.

| Benchmark          | Deterioration rate(before) | Deterioration rate(after) | Improvement rate | 
| ------------------ | -------------------------- | ------------------------- | ---------------- | 
| E_5P.empty         | 0.721498147                | 0.9893744169              | 1.396036277      | 
| E_5P.fiveContents  | 0.7992864106               | 1.019547368               | 1.266283685      | 
| T_20P.empty        | 0.6930720275               | 0.9940202384              | 1.445030387      | 
| T_20P.fiveContents | 0.775168912                | 0.9815612061              | 1.261301297      | 

`Deterioration rate` shows the rate of degradation of throughput if the check was enabled.
The closer this is to 1, the smaller the degradation.

`Improvement rate` shows how much the throughput improved before and after the change when the check was enabled.
The larger this value is, the greater the improvement.

With the new implementation, there is virtually no degradation in throughput even when checks are enabled.
Also, throughput is at least 1.25 times better than before the change.

For a complete benchmark and explanation of the results, please see below.
https://github.com/k163377/strict-null-checks-benchmark