### PR TITLE
Raise the deprecation level to error for the `MissingKotlinParameterException` secondary constructor

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -29,6 +29,7 @@ WrongWrong (@k163377)
 # 2.18.0 (26-Sep-2024)
 
 WrongWrong (@k163377)
+* #883: Raise the deprecation level to error for the MissingKotlinParameterException secondary constructor
 * #869: Replaced Enum.values with Enum.entries
 * #818: Optimize the search process for creators
 * #817: Fixed nullability of convertValue function argument

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -17,7 +17,8 @@ Co-maintainers:
 ------------------------------------------------------------------------
 
 2.19.0 (not yet released)
-
+#883: The deprecation level has been raised to error for the `MissingKotlinParameterException` secondary constructor.
+ This is a problematic process that has been marked as deprecated for a very long time and will be removed in 2.20 or later.
 #878: Fixed a problem where settings like `@JsonSetter(nulls = AS_EMPTY)` were not being applied when the input was `undefined`.
 #869: By using Enum.entries in the acquisition of KotlinFeature.defaults, the initialization load was reduced, albeit slightly.
 #861: Kotlin has been upgraded to 1.9.24.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Exceptions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Exceptions.kt
@@ -32,7 +32,11 @@ class MissingKotlinParameterException(
     processor: JsonParser? = null,
     msg: String
 ) : MismatchedInputException(processor, msg) {
-    @Deprecated("Use main constructor", ReplaceWith("MissingKotlinParameterException(KParameter, JsonParser?, String)"))
+    @Deprecated(
+        "Use main constructor, ",
+        ReplaceWith("MissingKotlinParameterException(KParameter, JsonParser?, String)"),
+        DeprecationLevel.ERROR,
+    )
     constructor(
             parameter: KParameter,
             processor: Closeable? = null,


### PR DESCRIPTION
Because it has remained deprecated for a long time.