### PR TITLE
Changed the base class of MissingKotlinParameterException to InvalidNullException

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.19.0 (not yet released)
 
 WrongWrong (@k163377)
+* #884: Changed the base class of MissingKotlinParameterException to InvalidNullException
 * #878: Fix for #876
 * #868: Added test case for FAIL_ON_NULL_FOR_PRIMITIVES
 * #866: Upgrade to JUnit5

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -17,6 +17,9 @@ Co-maintainers:
 ------------------------------------------------------------------------
 
 2.19.0 (not yet released)
+#884: The base class for `MissingKotlinParameterException` has been changed to `InvalidNullException`.
+ If you do not catch this exception or catch `MismatchedInputException`, the behavior is unchanged.
+ If you are catching both `MismatchedKotlinParameterException` and `InvalidNullException`, you must catch `MismatchedKotlinParameterException` first.
 #883: The deprecation level has been raised to error for the `MissingKotlinParameterException` secondary constructor.
  This is a problematic process that has been marked as deprecated for a very long time and will be removed in 2.20 or later.
 #878: Fixed a problem where settings like `@JsonSetter(nulls = AS_EMPTY)` were not being applied when the input was `undefined`.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Exceptions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Exceptions.kt
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.JsonMappingException
-import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.fasterxml.jackson.databind.exc.InvalidNullException
 import java.io.Closeable
 import kotlin.reflect.KParameter
 
@@ -31,7 +31,7 @@ class MissingKotlinParameterException(
     val parameter: KParameter,
     processor: JsonParser? = null,
     msg: String
-) : MismatchedInputException(processor, msg) {
+) : InvalidNullException(processor, msg, null) {
     @Deprecated(
         "Use main constructor, ",
         ReplaceWith("MissingKotlinParameterException(KParameter, JsonParser?, String)"),


### PR DESCRIPTION
Since `MissingKotlinParameterException` is an exception raised by an illegal `null`, the base type is changed to make the error clearer.

This is preparation regarding #617.
https://github.com/FasterXML/jackson-module-kotlin/issues/617#issuecomment-1755618574

This is also intended to allow for a staged transition for changes related to #719.