### PR TITLE
Performance improvement of `strictNullChecks`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,9 @@
                             <exclude>com.fasterxml.jackson.module.kotlin.KotlinModule#getSingletonSupport()</exclude>
                             <exclude>com.fasterxml.jackson.module.kotlin.SingletonSupport</exclude>
                             <!-- internal -->
-
+                            <exclude>
+                                com.fasterxml.jackson.module.kotlin.KotlinNamesAnnotationIntrospector#KotlinNamesAnnotationIntrospector(com.fasterxml.jackson.module.kotlin.ReflectionCache,boolean)
+                            </exclude>
                         </excludes>
                     </parameter>
                 </configuration>

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.19.0 (not yet released)
 
 WrongWrong (@k163377)
+* #885: Performance improvement of strictNullChecks
 * #884: Changed the base class of MissingKotlinParameterException to InvalidNullException
 * #878: Fix for #876
 * #868: Added test case for FAIL_ON_NULL_FOR_PRIMITIVES

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -17,6 +17,10 @@ Co-maintainers:
 ------------------------------------------------------------------------
 
 2.19.0 (not yet released)
+#885: A new `StrictNullChecks` option(KotlinFeature.NewStrictNullChecks) has been added which greatly improves throughput.
+ Benchmarks show a consistent throughput drop of less than 2% when enabled (prior to the improvement, the worst throughput drop was more than 30%).
+ Note that the new backend changes the exception thrown to `InvalidNullException` and with it the error message.
+ Also note that the base class for `MissingKotlinParameterException` was changed to `InvalidNullException` in #884.
 #884: The base class for `MissingKotlinParameterException` has been changed to `InvalidNullException`.
  If you do not catch this exception or catch `MismatchedInputException`, the behavior is unchanged.
  If you are catching both `MismatchedKotlinParameterException` and `InvalidNullException`, you must catch `MismatchedKotlinParameterException` first.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinFeature.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinFeature.kt
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.module.kotlin
 
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.databind.exc.InvalidNullException
 import java.util.BitSet
 
 /**
@@ -40,6 +42,11 @@ enum class KotlinFeature(internal val enabledByDefault: Boolean) {
      * may contain null values after deserialization.
      * Enabling it protects against this but has significant performance impact.
      */
+    @Deprecated(
+        level = DeprecationLevel.WARNING,
+        message = "This option will be migrated to the new backend in 2.21.",
+        replaceWith = ReplaceWith("NewStrictNullChecks")
+    )
     StrictNullChecks(enabledByDefault = false),
 
     /**
@@ -66,7 +73,23 @@ enum class KotlinFeature(internal val enabledByDefault: Boolean) {
      * `@JsonFormat` annotations need to be declared either on getter using `@get:JsonFormat` or field using `@field:JsonFormat`.
      * See [jackson-module-kotlin#651] for details.
      */
-    UseJavaDurationConversion(enabledByDefault = false);
+    UseJavaDurationConversion(enabledByDefault = false),
+
+    /**
+     * New [StrictNullChecks] feature with improved throughput.
+     * Internally, it will be the same as if [JsonSetter] (contentNulls = FAIL) had been granted.
+     * Benchmarks show that it can check for illegal nulls with throughput nearly identical to the default (see [jackson-module-kotlin#719]).
+     *
+     * Note that in the new backend, the exception thrown has changed from [MissingKotlinParameterException] to [InvalidNullException].
+     * The message will be changed accordingly.
+     * Since 2.19, the base class of [MissingKotlinParameterException] has also been changed to [InvalidNullException],
+     * so be careful when catching it.
+     *
+     * This is a temporary option for a phased backend migration,
+     * which will eventually be merged into [StrictNullChecks].
+     * Also, specifying both this and [StrictNullChecks] is not permitted.
+     */
+    NewStrictNullChecks(enabledByDefault = false);
 
     internal val bitSet: BitSet = (1 shl ordinal).toBitSet()
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -125,7 +125,9 @@ class KotlinModule private constructor(
             nullIsSameAsDefault,
             useJavaDurationConversion
         ))
-        context.appendAnnotationIntrospector(KotlinNamesAnnotationIntrospector(cache, kotlinPropertyNameAsImplicitName))
+        context.appendAnnotationIntrospector(
+            KotlinNamesAnnotationIntrospector(cache, newStrictNullChecks, kotlinPropertyNameAsImplicitName)
+        )
 
         context.addDeserializers(KotlinDeserializers(cache, useJavaDurationConversion))
         context.addKeyDeserializers(KotlinKeyDeserializers)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyCollection
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.SingletonSupport
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
+import com.fasterxml.jackson.module.kotlin.KotlinFeature.NewStrictNullChecks
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.KotlinPropertyNameAsImplicitName
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.UseJavaDurationConversion
 import java.util.*
@@ -42,9 +43,10 @@ class KotlinModule private constructor(
     val nullToEmptyMap: Boolean = NullToEmptyMap.enabledByDefault,
     val nullIsSameAsDefault: Boolean = NullIsSameAsDefault.enabledByDefault,
     val singletonSupport: Boolean = SingletonSupport.enabledByDefault,
-    val strictNullChecks: Boolean = StrictNullChecks.enabledByDefault,
+    strictNullChecks: Boolean = StrictNullChecks.enabledByDefault,
     val kotlinPropertyNameAsImplicitName: Boolean = KotlinPropertyNameAsImplicitName.enabledByDefault,
     val useJavaDurationConversion: Boolean = UseJavaDurationConversion.enabledByDefault,
+    private val newStrictNullChecks: Boolean = NewStrictNullChecks.enabledByDefault,
 ) : SimpleModule(KotlinModule::class.java.name, PackageVersion.VERSION) {
     /*
      * Prior to 2.18, an older Enum called SingletonSupport was used to manage feature.
@@ -63,6 +65,19 @@ class KotlinModule private constructor(
         replaceWith = ReplaceWith("singletonSupport")
     )
     val enabledSingletonSupport: Boolean get() = singletonSupport
+
+    private val oldStrictNullChecks: Boolean = strictNullChecks
+
+    // To reduce the amount of destructive changes, no properties will be added to the public.
+    val strictNullChecks: Boolean = if (strictNullChecks) {
+        if (newStrictNullChecks) {
+            throw IllegalArgumentException("Enabling both StrictNullChecks and NewStrictNullChecks is not permitted.")
+        }
+
+        true
+    } else {
+        newStrictNullChecks
+    }
 
     companion object {
         // Increment when option is added
@@ -84,6 +99,7 @@ class KotlinModule private constructor(
         builder.isEnabled(StrictNullChecks),
         builder.isEnabled(KotlinPropertyNameAsImplicitName),
         builder.isEnabled(UseJavaDurationConversion),
+        builder.isEnabled(NewStrictNullChecks),
     )
 
     override fun setupModule(context: SetupContext) {
@@ -95,7 +111,7 @@ class KotlinModule private constructor(
 
         val cache = ReflectionCache(reflectionCacheSize)
 
-        context.addValueInstantiators(KotlinInstantiators(cache, nullToEmptyCollection, nullToEmptyMap, nullIsSameAsDefault, strictNullChecks))
+        context.addValueInstantiators(KotlinInstantiators(cache, nullToEmptyCollection, nullToEmptyMap, nullIsSameAsDefault, oldStrictNullChecks))
 
         if (singletonSupport) {
             context.addBeanDeserializerModifier(KotlinBeanDeserializerModifier)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -73,14 +73,12 @@ internal class KotlinNamesAnnotationIntrospector(
     }
 
     override fun refineDeserializationType(config: MapperConfig<*>, a: Annotated, baseType: JavaType): JavaType =
-        (a as? AnnotatedParameter)?.let { _ ->
-            cache.findKotlinParameter(a)?.let { param ->
-                val rawType = a.rawType
-                (param.type.classifier as? KClass<*>)
-                    ?.java
-                    ?.takeIf { it.isUnboxableValueClass() && it != rawType }
-                    ?.let { config.constructType(it) }
-            }
+        findKotlinParameter(a)?.let { param ->
+            val rawType = a.rawType
+            (param.type.classifier as? KClass<*>)
+                ?.java
+                ?.takeIf { it.isUnboxableValueClass() && it != rawType }
+                ?.let { config.constructType(it) }
         } ?: baseType
 
     override fun findDefaultCreator(
@@ -106,6 +104,9 @@ internal class KotlinNamesAnnotationIntrospector(
     }
 
     private fun findKotlinParameterName(param: AnnotatedParameter): String? = cache.findKotlinParameter(param)?.name
+
+    private fun findKotlinParameter(param: Annotated) = (param as? AnnotatedParameter)
+        ?.let { cache.findKotlinParameter(it) }
 }
 
 // If it is not a Kotlin class or an Enum, Creator is not used

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/DslTest.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyCollection
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
 import com.fasterxml.jackson.module.kotlin.KotlinFeature.SingletonSupport
-import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
+import com.fasterxml.jackson.module.kotlin.KotlinFeature.NewStrictNullChecks
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -35,7 +35,7 @@ class DslTest {
             enable(NullToEmptyMap)
             enable(NullIsSameAsDefault)
             enable(SingletonSupport)
-            enable(StrictNullChecks)
+            enable(NewStrictNullChecks)
         }
 
         assertNotNull(module)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModuleTest.kt
@@ -6,9 +6,24 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertNotNull
 
 class KotlinModuleTest {
+    // After the final migration is complete, this test will be removed.
+    @Test
+    fun strictNullChecksTests() {
+        assertTrue(kotlinModule { enable(StrictNullChecks) }.strictNullChecks)
+        assertTrue(kotlinModule { enable(NewStrictNullChecks) }.strictNullChecks)
+
+        assertThrows<IllegalArgumentException> {
+            kotlinModule {
+                enable(StrictNullChecks)
+                enable(NewStrictNullChecks)
+            }
+        }
+    }
+
     @Test
     fun builder_Defaults() {
         val module = KotlinModule.Builder().build()

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/StrictNullChecksTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/StrictNullChecksTest.kt
@@ -1,0 +1,139 @@
+package com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser
+
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.InvalidNullException
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class StrictNullChecksTest {
+    val mapper: ObjectMapper = ObjectMapper()
+        .registerModule(
+            KotlinModule.Builder()
+                .enable(KotlinFeature.NewStrictNullChecks)
+                .build()
+        )
+
+    class ArrayWrapper(val value: Array<Int>)
+    data class ListWrapper(val value: List<Int>)
+    data class MapWrapper(val value: Map<String, Int>)
+
+    @Nested
+    inner class NonNullInput {
+        @Test
+        fun array() {
+            val expected = ArrayWrapper(arrayOf(1))
+            val src = mapper.writeValueAsString(expected)
+            val result = mapper.readValue<ArrayWrapper>(src)
+
+            Assertions.assertArrayEquals(expected.value, result.value)
+        }
+
+        @Test
+        fun list() {
+            val expected = ListWrapper(listOf(1))
+            val src = mapper.writeValueAsString(expected)
+            val result = mapper.readValue<ListWrapper>(src)
+
+            Assertions.assertEquals(expected, result)
+        }
+
+        @Test
+        fun map() {
+            val expected = MapWrapper(mapOf("foo" to 1))
+            val src = mapper.writeValueAsString(expected)
+            val result = mapper.readValue<MapWrapper>(src)
+
+            Assertions.assertEquals(expected, result)
+        }
+    }
+
+    data class AnyWrapper(val value: Any)
+
+    @Nested
+    inner class NullInput {
+        @Test
+        fun array() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<InvalidNullException> { mapper.readValue<ArrayWrapper>(src) }
+        }
+
+        @Test
+        fun list() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<InvalidNullException> { mapper.readValue<ListWrapper>(src) }
+        }
+
+        @Test
+        fun map() {
+            val src = mapper.writeValueAsString(AnyWrapper(mapOf("foo" to null)))
+            assertThrows<InvalidNullException> { mapper.readValue<MapWrapper>(src) }
+        }
+    }
+
+    class ContentNullsSkipArrayWrapper(@JsonSetter(contentNulls = Nulls.SKIP) val value: Array<Int>)
+    data class ContentNullsSkipListWrapper(@JsonSetter(contentNulls = Nulls.SKIP) val value: List<Int>)
+    data class ContentNullsSkipMapWrapper(@JsonSetter(contentNulls = Nulls.SKIP) val value: Map<String, Int>)
+
+    @Nested
+    inner class CustomByAnnotationTest {
+        @Test
+        fun array() {
+            val expected = ContentNullsSkipArrayWrapper(emptyArray())
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            val result = mapper.readValue<ContentNullsSkipArrayWrapper>(src)
+
+            Assertions.assertArrayEquals(expected.value, result.value)
+        }
+
+        @Test
+        fun list() {
+            val expected = ContentNullsSkipListWrapper(emptyList())
+            val src = mapper.writeValueAsString(AnyWrapper(listOf<Int?>(null)))
+            val result = mapper.readValue<ContentNullsSkipListWrapper>(src)
+
+            Assertions.assertEquals(expected, result)
+        }
+
+        @Test
+        fun map() {
+            val expected = ContentNullsSkipMapWrapper(emptyMap())
+            val src = mapper.writeValueAsString(AnyWrapper(mapOf("foo" to null)))
+            val result = mapper.readValue<ContentNullsSkipMapWrapper>(src)
+
+            Assertions.assertEquals(expected, result)
+        }
+    }
+
+    class AnnotatedArrayWrapper(@JsonSetter(nulls = Nulls.SKIP) val value: Array<Int> = emptyArray())
+    data class AnnotatedListWrapper(@JsonSetter(nulls = Nulls.SKIP) val value: List<Int> = emptyList())
+    data class AnnotatedMapWrapper(@JsonSetter(nulls = Nulls.SKIP) val value: Map<String, Int> = emptyMap())
+
+    // If Default is specified by annotation, it is not overridden.
+    @Nested
+    inner class AnnotatedNullInput {
+        @Test
+        fun array() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<InvalidNullException> { mapper.readValue<AnnotatedArrayWrapper>(src) }
+        }
+
+        @Test
+        fun list() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<InvalidNullException> { mapper.readValue<AnnotatedListWrapper>(src) }
+        }
+
+        @Test
+        fun map() {
+            val src = mapper.writeValueAsString(AnyWrapper(mapOf("foo" to null)))
+            assertThrows<InvalidNullException> { mapper.readValue<AnnotatedMapWrapper>(src) }
+        }
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTestOld.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTestOld.kt
@@ -1,8 +1,8 @@
 package com.fasterxml.jackson.module.kotlin.test
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.exc.InvalidNullException
-import com.fasterxml.jackson.module.kotlin.KotlinFeature.NewStrictNullChecks
+import com.fasterxml.jackson.module.kotlin.KotlinFeature.StrictNullChecks
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -12,8 +12,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertNull
 
-class StrictNullChecksTest {
-    private val mapper = ObjectMapper().registerModule(kotlinModule { enable(NewStrictNullChecks) })
+class StrictNullChecksTestOld {
+    private val mapper = ObjectMapper().registerModule(kotlinModule { enable(StrictNullChecks) })
 
     /** collection tests */
 
@@ -30,7 +30,7 @@ class StrictNullChecksTest {
 
     @Test
     fun testListOfInt() {
-        assertThrows<InvalidNullException> {
+        assertThrows<MissingKotlinParameterException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<ClassWithListOfInt>(json)
         }
@@ -60,7 +60,7 @@ class StrictNullChecksTest {
 
     @Test
     fun testArrayOfInt() {
-        assertThrows<InvalidNullException> {
+        assertThrows<MissingKotlinParameterException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<ClassWithArrayOfInt>(json)
         }
@@ -90,7 +90,7 @@ class StrictNullChecksTest {
 
     @Test
     fun testMapOfStringToIntWithNullValue() {
-        assertThrows<InvalidNullException> {
+        assertThrows<MissingKotlinParameterException> {
             val json = """{ "samples": { "key": null } }"""
             mapper.readValue<ClassWithMapOfStringToInt>(json)
         }
@@ -119,7 +119,7 @@ class StrictNullChecksTest {
     @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testListOfGenericWithNullValue() {
-        assertThrows<InvalidNullException> {
+        assertThrows<MissingKotlinParameterException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<TestClass<List<Int>>>(json)
         }
@@ -135,7 +135,7 @@ class StrictNullChecksTest {
     @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testMapOfGenericWithNullValue() {
-        assertThrows<InvalidNullException> {
+        assertThrows<MissingKotlinParameterException> {
             val json = """{ "samples": { "key": null } }"""
             mapper.readValue<TestClass<Map<String, Int>>>(json)
         }
@@ -151,7 +151,7 @@ class StrictNullChecksTest {
     @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testArrayOfGenericWithNullValue() {
-        assertThrows<InvalidNullException> {
+        assertThrows<MissingKotlinParameterException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<TestClass<Array<Int>>>(json)
         }


### PR DESCRIPTION
Currently, if the strictNullChecks option is enabled, the deserialization performance of collections is significantly degraded.
It also reduces the performance of all deserialization, although very slightly.

The cause of the significant performance degradation is the dynamic definition checks on `Kotlin` at each deserialization.
Therefore, by moving the processing backend to `JsonSetter` and limiting the definition checks to initialization time, I have greatly improved performance.

This change closes #719.

---

The results of the improvements are summarized below.

| Benchmark             | Deterioration rate (before) | Deterioration rate (after) | Improvement rate |
|-----------------------|-----------------------------|----------------------------|------------------|
| E_5P.empty            | 0.7383099866                | 0.9977718738               | 1.388225409      |
| E_5P.fiveContents     | 0.7999091212                | 0.9869712419               | 1.258111096      |
| T_20P.empty           | 0.671255694                 | 0.9969159641               | 1.46163136       |
| T_20P.fiveContents    | 0.7351224299                | 1.051081106                | 1.295783134      |

`Deterioration rate` shows the rate of degradation of throughput if the check was enabled.
The closer this is to 1, the smaller the degradation.

`Improvement rate` shows how much the throughput improved before and after the change when the check was enabled.
The larger this value is, the greater the improvement.

With the new implementation, there is virtually no degradation in throughput even when checks are enabled.
Also, throughput is at least 1.25 times better than before the change.

For a complete benchmark and explanation of the results, please see below.
https://github.com/k163377/strict-null-checks-benchmark