### PR TITLE
Remove (indirect) JUnit 4 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,28 +109,13 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- only for testing... -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
+        <!-- Test dependencies -->
+
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test-junit5</artifactId>
             <version>${version.kotlin}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
Looks like there was indirect dependency to JUnit5 via `kotlin-test-junit`, as well as (now) redundant JUnit5 (jupiter) direct deps. So let's trim `pom.xml` a bit.
