### PR TITLE
Fixed an error when serializing a `value class` that wraps a `Map`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.18.3 (not yet released)
 
 WrongWrong (@k163377)
+* #904: Fixed an error when serializing a `value class` that wraps a `Map`
 * #900: Fixed an issue where some tests were not running
 
 # 2.18.0 (26-Sep-2024)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,10 @@ Co-maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.18.3 (not yet released)
+
+#904: An error that occurred when serializing a `value class` that wraps a `Map`(#873) has been fixed.
+
 2.18.2 (27-Nov-2024)
 2.18.1 (28-Oct-2024)
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -62,7 +62,7 @@ object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
             return
         }
 
-        provider.findValueSerializer(unboxed::class.java).serialize(unboxed, gen, provider)
+        provider.defaultSerializeValue(unboxed, gen)
     }
 }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub873.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub873.kt
@@ -1,0 +1,46 @@
+package com.fasterxml.jackson.module.kotlin.test.github
+
+import com.fasterxml.jackson.module.kotlin.defaultMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import kotlin.test.Test
+
+class GitHub873 {
+    @Test
+    fun `should serialize value class`() {
+
+        val person = Person(
+            mapOf(
+                "id" to "123",
+                "updated" to "2023-11-22 12:11:23",
+                "login" to "2024-01-15",
+            ),
+        )
+
+        val serialized = defaultMapper.writeValueAsString(
+            TimestampedPerson(
+                123L,
+                Person(person.properties),
+            )
+        )
+
+        val deserialized = defaultMapper.readValue<TimestampedPerson>(serialized)
+
+        assert(
+            deserialized == TimestampedPerson(
+                123L,
+                Person(person.properties),
+            )
+        )
+    }
+
+    @JvmInline
+    value class Person(
+        val properties: Map<String, Any>,
+    )
+
+    data class TimestampedPerson(
+        val timestamp: Long,
+        val person: Person,
+    )
+}


### PR DESCRIPTION
fixes #873
relates to https://github.com/FasterXML/jackson-databind/issues/4928