### PR TITLE
Fixed handling of null and JsonValue as well as #904

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.18.3 (not yet released)
 
 WrongWrong (@k163377)
+* #908: Additional fixes related to #904.
 * #904: Fixed an error when serializing a `value class` that wraps a `Map`
 * #900: Fixed an issue where some tests were not running
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,7 +18,9 @@ Co-maintainers:
 
 2.18.3 (not yet released)
 
-#904: An error that occurred when serializing a `value class` that wraps a `Map`(#873) has been fixed.
+#904: Fixed a problem where context was not being propagated properly when serializing an unboxed value of `value class`
+  or a value retrieved with `JsonValue`.
+  This fixes a problem where an error would occur when serializing a `value class` that wraps a `Map`(#873).
 
 2.18.2 (27-Nov-2024)
 2.18.1 (28-Oct-2024)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -58,7 +58,7 @@ object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
         val unboxed = value::class.java.getMethod("unbox-impl").invoke(value)
 
         if (unboxed == null) {
-            provider.findNullValueSerializer(null).serialize(null, gen, provider)
+            provider.defaultSerializeNull(gen)
             return
         }
 
@@ -77,8 +77,8 @@ internal sealed class ValueClassSerializer<T : Any>(t: Class<T>) : StdSerializer
             // As shown in the processing of the factory function, jsonValueGetter is always a static method.
             val jsonValue: Any? = staticJsonValueGetter.invoke(null, unboxed)
             jsonValue
-                ?.let { provider.findValueSerializer(it::class.java).serialize(it, gen, provider) }
-                ?: provider.findNullValueSerializer(null).serialize(null, gen, provider)
+                ?.let { provider.defaultSerializeValue(it, gen) }
+                ?: provider.defaultSerializeNull(gen)
         }
     }
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -56,12 +56,6 @@ object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
 
     override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
         val unboxed = value::class.java.getMethod("unbox-impl").invoke(value)
-
-        if (unboxed == null) {
-            provider.defaultSerializeNull(gen)
-            return
-        }
-
         provider.defaultSerializeValue(unboxed, gen)
     }
 }
@@ -76,9 +70,7 @@ internal sealed class ValueClassSerializer<T : Any>(t: Class<T>) : StdSerializer
             val unboxed = unboxMethod.invoke(value)
             // As shown in the processing of the factory function, jsonValueGetter is always a static method.
             val jsonValue: Any? = staticJsonValueGetter.invoke(null, unboxed)
-            jsonValue
-                ?.let { provider.defaultSerializeValue(it, gen) }
-                ?: provider.defaultSerializeNull(gen)
+            provider.defaultSerializeValue(jsonValue, gen)
         }
     }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub873.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub873.kt
@@ -1,11 +1,22 @@
 package com.fasterxml.jackson.module.kotlin.test.github
 
+import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.module.kotlin.defaultMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlin.test.Test
 
 class GitHub873 {
+    @JvmInline
+    value class Person(
+        val properties: Map<String, Any>,
+    )
+
+    data class TimestampedPerson(
+        val timestamp: Long,
+        val person: Person,
+    )
+
     @Test
     fun `should serialize value class`() {
 
@@ -35,12 +46,18 @@ class GitHub873 {
     }
 
     @JvmInline
-    value class Person(
-        val properties: Map<String, Any>,
-    )
+    value class MapAsJsonValue(val value: String) {
+        @get:JsonValue
+        val jsonValue get() = mapOf("key" to value)
+    }
 
-    data class TimestampedPerson(
-        val timestamp: Long,
-        val person: Person,
-    )
+    data class JsonValueWrapper(val value: MapAsJsonValue)
+
+    @Test
+    fun `JsonValue is serialized in the same way`() {
+        val data = JsonValueWrapper(MapAsJsonValue("value"))
+        val json = defaultMapper.writeValueAsString(data)
+
+        assert("""{"value":{"key":"value"}}""" == json)
+    }
 }


### PR DESCRIPTION
Because #907 had an error in correcting the release notes, a PR was issued once again.