### PR TITLE
Add test case to serialize `Nothing?`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.19.0 (not yet released)
 
 WrongWrong (@k163377)
+* #914: Add test case to serialize Nothing? (for #314)
 * #910: Add default KeyDeserializer for value class
 * #885: Performance improvement of strictNullChecks
 * #884: Changed the base class of MissingKotlinParameterException to InvalidNullException

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub314.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/GitHub314.kt
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.module.kotlin.test.github
+
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.module.kotlin.jsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GitHub314 {
+    // Since Nothing? is compiled as a Void, it can be serialized by specifying ALLOW_VOID_VALUED_PROPERTIES
+    data object NothingData {
+        val data: Nothing? = null
+    }
+
+    @Test
+    fun test() {
+        val expected = """{"data":null}"""
+
+        val withoutKotlinModule = jsonMapper { enable(MapperFeature.ALLOW_VOID_VALUED_PROPERTIES) }
+        assertEquals(expected, withoutKotlinModule.writeValueAsString(NothingData))
+
+        val withKotlinModule = jsonMapper {
+            enable(MapperFeature.ALLOW_VOID_VALUED_PROPERTIES)
+            addModule(kotlinModule())
+        }
+
+        assertEquals(expected, withKotlinModule.writeValueAsString(NothingData))
+    }
+}


### PR DESCRIPTION
This is a test case for #314 .