### PR TITLE
Added description of Kotlin version upgrade

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -17,6 +17,9 @@ Contributors:
 
 # 2.19.0 (not yet released)
 
+Tatu Saloranta (@cowtowncoder)
+* #889: Upgrade kotlin dep to 1.9.25 (from 1.9.24)
+
 WrongWrong (@k163377)
 * #914: Add test case to serialize Nothing? (for #314)
 * #910: Add default KeyDeserializer for value class


### PR DESCRIPTION
CREDITS only describes the upgrade to 1.9.24, and there seemed to be a risk of inducing a misunderstanding of the version that will eventually be used.