### PR TITLE
Change of default settings for 3.0: `StrictNullChecks` and `SingletonSupport` are now enabled by default

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -17,6 +17,13 @@ Authors:
 
 Contributors:
 
+# 3.0.0-rc2 (not yet released)
+
+WrongWrong (@k163377)
+* #936: Change of default settings for 3.0
+
+# 3.0.0-rc1 (07-Mar-2025)
+
 hokita
 * #702: Fix outdated link in master branch README
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,9 @@ Former maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+3.0.0-rc2 (not yet released)
+#936: `StrictNullChecks` and `SingletonSupport` are now enabled by default
+
 3.0.0-rc1 (07-Mar-2025)
 
 - Minimum Java baseline: Java 17

--- a/src/main/kotlin/tools/jackson/module/kotlin/KotlinFeature.kt
+++ b/src/main/kotlin/tools/jackson/module/kotlin/KotlinFeature.kt
@@ -25,15 +25,14 @@ enum class KotlinFeature(internal val enabledByDefault: Boolean) {
     NullIsSameAsDefault(enabledByDefault = false),
 
     /**
-     * By default, there's no special handling of singletons (pre-2.10 behavior).
-     * Each time a Singleton object is deserialized a new instance is created.
-     *
-     * When this feature is enabled, it will deserialize then canonicalize (was the default in 2.10).
+     * When this feature is enabled, it will deserialize then canonicalize.
      * Deserializing a singleton overwrites the value of the single instance.
+     *
+     * The 2.x default was disabled, and a new instance was created each time a singleton object was deserialized.
      *
      * See [jackson-module-kotlin#225]: keep Kotlin singletons as singletons.
      */
-    SingletonSupport(enabledByDefault = false),
+    SingletonSupport(enabledByDefault = true),
 
     /**
      * This feature represents whether to check deserialized collections.
@@ -88,8 +87,10 @@ enum class KotlinFeature(internal val enabledByDefault: Boolean) {
      * This is a temporary option for a phased backend migration,
      * which will eventually be merged into [StrictNullChecks].
      * Also, specifying both this and [StrictNullChecks] is not permitted.
+     *
+     * Since 3.0, this option is enabled by default.
      */
-    NewStrictNullChecks(enabledByDefault = false);
+    NewStrictNullChecks(enabledByDefault = true);
 
     internal val bitSet: BitSet = (1 shl ordinal).toBitSet()
 

--- a/src/test/kotlin/tools/jackson/module/kotlin/KotlinModuleTest.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/KotlinModuleTest.kt
@@ -13,7 +13,12 @@ class KotlinModuleTest {
     // After the final migration is complete, this test will be removed.
     @Test
     fun strictNullChecksTests() {
-        assertTrue(kotlinModule { enable(StrictNullChecks) }.strictNullChecks)
+        assertTrue(
+            kotlinModule {
+                disable(NewStrictNullChecks)
+                enable(StrictNullChecks)
+            }.strictNullChecks
+        )
         assertTrue(kotlinModule { enable(NewStrictNullChecks) }.strictNullChecks)
 
         assertThrows<IllegalArgumentException> {
@@ -32,8 +37,8 @@ class KotlinModuleTest {
         assertFalse(module.nullToEmptyCollection)
         assertFalse(module.nullToEmptyMap)
         assertFalse(module.nullIsSameAsDefault)
-        assertFalse(module.singletonSupport)
-        assertFalse(module.strictNullChecks)
+        assertTrue(module.singletonSupport)
+        assertTrue(module.strictNullChecks)
         assertFalse(module.kotlinPropertyNameAsImplicitName)
         assertFalse(module.useJavaDurationConversion)
     }

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github27.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github27.kt
@@ -9,12 +9,14 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import tools.jackson.databind.DeserializationFeature
+import tools.jackson.module.kotlin.KotlinFeature
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
 class TestGithub27 {
-    val mapper = jacksonMapperBuilder().disable(SerializationFeature.INDENT_OUTPUT)
-            .build()
+    val mapper = jacksonMapperBuilder { disable(KotlinFeature.NewStrictNullChecks) }
+        .disable(SerializationFeature.INDENT_OUTPUT)
+        .build()
 
     private data class ClassWithNullableInt(val sample: Int?)
 

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/github/failing/Github518.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/github/failing/Github518.kt
@@ -8,6 +8,7 @@ import tools.jackson.module.kotlin.readValue
 import tools.jackson.module.kotlin.test.expectFailure
 import kotlin.test.assertSame
 import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.KotlinFeature
 
 /**
  * An empty object should be deserialized as *the* Unit instance for a nullable Unit reference Type.
@@ -30,7 +31,7 @@ class TestGithub518 {
     @Test
     fun deserializeEmptyObjectToSingletonUnitFails() {
         expectFailure<AssertionError>("GitHub #518 has been fixed!") {
-            assertSame(jacksonObjectMapper().readValue<Unit?>("{}"), Unit)
+            assertSame(jacksonObjectMapper { disable(SingletonSupport) }.readValue<Unit?>("{}"), Unit)
         }
     }
 


### PR DESCRIPTION
wrt #870