### PR TITLE
Added type match check to read functions

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -17,6 +17,9 @@ Contributors:
 
 # 2.19.0 (not yet released)
 
+WrongWrong (@k163377)
+* #937: Added type match check to read functions
+
 Tatu Saloranta (@cowtowncoder)
 * #889: Upgrade kotlin dep to 1.9.25 (from 1.9.24)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,14 @@ Co-maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.19.0 (not yet released)
+
+#937: For `readValue` and other shorthands for `ObjectMapper` deserialization methods,
+  type consistency checks have been added.
+  A `RuntimeJsonMappingException` will be thrown in case of inconsistency.
+  This fixes a problem that broke `Kotlin` null safety by reading null as a value even if the type parameter was specified as non-null.
+  It also checks for custom errors in ObjectMapper that cause a different value to be read than the specified type parameter.
+
 2.19.0-rc2 (07-Apr-2025)
 
 #929: Added consideration of `JsonProperty.isRequired` added in `2.19` in `hasRequiredMarker` processing.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -70,7 +70,13 @@ inline fun <reified T> Any?.checkTypeMismatch(): T {
 
 inline fun <reified T> ObjectMapper.readValue(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
     .checkTypeMismatch()
-inline fun <reified T> ObjectMapper.readValues(jp: JsonParser): MappingIterator<T> = readValues(jp, jacksonTypeRef<T>())
+inline fun <reified T> ObjectMapper.readValues(jp: JsonParser): MappingIterator<T> {
+    val values = readValues(jp, jacksonTypeRef<T>())
+
+    return object : MappingIterator<T>(values) {
+        override fun nextValue(): T = super.nextValue().checkTypeMismatch()
+    }
+}
 
 inline fun <reified T> ObjectMapper.readValue(src: File): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
 inline fun <reified T> ObjectMapper.readValue(src: URL): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
@@ -89,7 +95,13 @@ inline fun <reified T> ObjectMapper.convertValue(from: Any?): T = convertValue(f
 
 inline fun <reified T> ObjectReader.readValueTyped(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
     .checkTypeMismatch()
-inline fun <reified T> ObjectReader.readValuesTyped(jp: JsonParser): Iterator<T> = readValues(jp, jacksonTypeRef<T>())
+inline fun <reified T> ObjectReader.readValuesTyped(jp: JsonParser): Iterator<T> {
+    val values = readValues(jp, jacksonTypeRef<T>())
+
+    return object : Iterator<T> by values {
+        override fun next(): T = values.next().checkTypeMismatch<T>()
+    }
+}
 inline fun <reified T> ObjectReader.treeToValue(n: TreeNode): T? = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
 
 inline fun <reified T, reified U> ObjectMapper.addMixIn(): ObjectMapper = this.addMixIn(T::class.java, U::class.java)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.TreeNode
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.MappingIterator
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectReader
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.node.ArrayNode
@@ -57,10 +57,11 @@ inline fun <reified T> jacksonTypeRef(): TypeReference<T> = object: TypeReferenc
 inline fun <reified T> Any?.checkTypeMismatch(): T {
     // Basically, this check assumes that T is non-null and the value is null.
     // Since this can be caused by both input or ObjectMapper implementation errors,
-    // a more abstract JsonMappingException is thrown.
+    // a more abstract RuntimeJsonMappingException is thrown.
     if (this !is T) {
-        throw JsonMappingException(
-            null,
+        // Since the databind implementation of MappingIterator throws RuntimeJsonMappingException,
+        // JsonMappingException was not used to unify the behavior.
+        throw RuntimeJsonMappingException(
             "Deserialized value did not match the specified type; " +
                     "specified ${T::class.qualifiedName} but was ${this?.let { it::class.qualifiedName }}"
         )

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -71,8 +71,20 @@ inline fun <reified T> Any?.checkTypeMismatch(): T {
     return this
 }
 
+/**
+ * Shorthand for [ObjectMapper.readValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.readValue(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
     .checkTypeMismatch()
+/**
+ * Shorthand for [ObjectMapper.readValues].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.readValues(jp: JsonParser): MappingIterator<T> {
     val values = readValues(jp, jacksonTypeRef<T>())
 
@@ -81,23 +93,83 @@ inline fun <reified T> ObjectMapper.readValues(jp: JsonParser): MappingIterator<
     }
 }
 
+/**
+ * Shorthand for [ObjectMapper.readValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.readValue(src: File): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
+/**
+ * Shorthand for [ObjectMapper.readValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.readValue(src: URL): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
+/**
+ * Shorthand for [ObjectMapper.readValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.readValue(content: String): T = readValue(content, jacksonTypeRef<T>())
     .checkTypeMismatch()
+/**
+ * Shorthand for [ObjectMapper.readValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.readValue(src: Reader): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
+/**
+ * Shorthand for [ObjectMapper.readValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.readValue(src: InputStream): T = readValue(src, jacksonTypeRef<T>())
     .checkTypeMismatch()
+/**
+ * Shorthand for [ObjectMapper.readValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.readValue(src: ByteArray): T = readValue(src, jacksonTypeRef<T>())
     .checkTypeMismatch()
 
+/**
+ * Shorthand for [ObjectMapper.readValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.treeToValue(n: TreeNode): T = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
     .checkTypeMismatch()
+/**
+ * Shorthand for [ObjectMapper.convertValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectMapper.convertValue(from: Any?): T = convertValue(from, jacksonTypeRef<T>())
     .checkTypeMismatch()
 
+/**
+ * Shorthand for [ObjectMapper.readValue].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectReader.readValueTyped(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
     .checkTypeMismatch()
+/**
+ * Shorthand for [ObjectMapper.readValues].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
 inline fun <reified T> ObjectReader.readValuesTyped(jp: JsonParser): Iterator<T> {
     val values = readValues(jp, jacksonTypeRef<T>())
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -59,11 +59,13 @@ inline fun <reified T> Any?.checkTypeMismatch(): T {
     // Since this can be caused by both input or ObjectMapper implementation errors,
     // a more abstract RuntimeJsonMappingException is thrown.
     if (this !is T) {
+        val nullability = if (null is T) "?" else "(non-null)"
+
         // Since the databind implementation of MappingIterator throws RuntimeJsonMappingException,
         // JsonMappingException was not used to unify the behavior.
         throw RuntimeJsonMappingException(
             "Deserialized value did not match the specified type; " +
-                    "specified ${T::class.qualifiedName} but was ${this?.let { it::class.qualifiedName }}"
+                    "specified ${T::class.qualifiedName}${nullability} but was ${this?.let { it::class.qualifiedName }}"
         )
     }
     return this

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReadValueTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReadValueTest.kt
@@ -1,0 +1,89 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.node.NullNode
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.StringReader
+
+class ReadValueTest {
+    @Nested
+    inner class CheckTypeMismatchTest {
+        @Test
+        fun jsonParser() {
+            val src = defaultMapper.createParser("null")
+            assertThrows<JsonMappingException> {
+                defaultMapper.readValue<String>(src)
+            }
+        }
+
+        @Test
+        fun file() {
+            val src = createTempJson("null")
+            assertThrows<JsonMappingException> {
+                defaultMapper.readValue<String>(src)
+            }
+        }
+
+        // Not implemented because a way to test without mocks was not found
+        // @Test
+        // fun url() {
+        // }
+
+        @Test
+        fun string() {
+            val src = "null"
+            assertThrows<JsonMappingException> {
+                defaultMapper.readValue<String>(src)
+            }
+        }
+
+        @Test
+        fun reader() {
+            val src = StringReader("null")
+            assertThrows<JsonMappingException> {
+                defaultMapper.readValue<String>(src)
+            }
+        }
+
+        @Test
+        fun inputStream() {
+            val src = "null".byteInputStream()
+            assertThrows<JsonMappingException> {
+                defaultMapper.readValue<String>(src)
+            }
+        }
+
+        @Test
+        fun byteArray() {
+            val src = "null".toByteArray()
+            assertThrows<JsonMappingException> {
+                defaultMapper.readValue<String>(src)
+            }
+        }
+
+        @Test
+        fun treeToValueTreeNode() {
+            assertThrows<JsonMappingException> {
+                defaultMapper.treeToValue<String>(NullNode.instance)
+            }
+        }
+
+        @Test
+        fun convertValueAny() {
+            assertThrows<JsonMappingException> {
+                defaultMapper.convertValue<String>(null)
+            }
+        }
+
+        @Test
+        fun readValueTypedJsonParser() {
+            val reader = defaultMapper.reader()
+            val src = reader.createParser("null")
+            assertThrows<JsonMappingException> {
+                reader.readValueTyped<String>(src)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReadValueTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReadValueTest.kt
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
-import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException
 import com.fasterxml.jackson.databind.node.NullNode
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -13,15 +13,15 @@ class ReadValueTest {
         @Test
         fun jsonParser() {
             val src = defaultMapper.createParser("null")
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 defaultMapper.readValue<String>(src)
-            }
+            }.printStackTrace()
         }
 
         @Test
         fun file() {
             val src = createTempJson("null")
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 defaultMapper.readValue<String>(src)
             }
         }
@@ -34,7 +34,7 @@ class ReadValueTest {
         @Test
         fun string() {
             val src = "null"
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 defaultMapper.readValue<String>(src)
             }
         }
@@ -42,7 +42,7 @@ class ReadValueTest {
         @Test
         fun reader() {
             val src = StringReader("null")
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 defaultMapper.readValue<String>(src)
             }
         }
@@ -50,7 +50,7 @@ class ReadValueTest {
         @Test
         fun inputStream() {
             val src = "null".byteInputStream()
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 defaultMapper.readValue<String>(src)
             }
         }
@@ -58,21 +58,21 @@ class ReadValueTest {
         @Test
         fun byteArray() {
             val src = "null".toByteArray()
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 defaultMapper.readValue<String>(src)
             }
         }
 
         @Test
         fun treeToValueTreeNode() {
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 defaultMapper.treeToValue<String>(NullNode.instance)
             }
         }
 
         @Test
         fun convertValueAny() {
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 defaultMapper.convertValue<String>(null)
             }
         }
@@ -81,7 +81,7 @@ class ReadValueTest {
         fun readValueTypedJsonParser() {
             val reader = defaultMapper.reader()
             val src = reader.createParser("null")
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 reader.readValueTyped<String>(src)
             }
         }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReadValuesTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReadValuesTest.kt
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.RuntimeJsonMappingException
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.module.SimpleModule
@@ -46,7 +45,7 @@ class ReadValuesTest {
             val itr = mapper.readValues<String>(src)
 
             assertEquals("foo", itr.nextValue())
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 itr.nextValue()
             }
         }
@@ -58,7 +57,7 @@ class ReadValuesTest {
             val itr = reader.readValuesTyped<String>(src)
 
             assertEquals("foo", itr.next())
-            assertThrows<JsonMappingException> {
+            assertThrows<RuntimeJsonMappingException> {
                 itr.next()
             }
         }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReadValuesTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/ReadValuesTest.kt
@@ -1,0 +1,66 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.module.SimpleModule
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class ReadValuesTest {
+    class MyStrDeser : StdDeserializer<String>(String::class.java) {
+        override fun deserialize(
+            p: JsonParser,
+            ctxt: DeserializationContext
+        ): String? = p.valueAsString.takeIf { it != "bar" }
+    }
+
+    @Nested
+    inner class CheckTypeMismatchTest {
+        val mapper = jacksonObjectMapper().registerModule(
+            object : SimpleModule() {
+                init {
+                    addDeserializer(String::class.java, MyStrDeser())
+                }
+            }
+        )!!
+
+        @Test
+        fun readValuesJsonParserNext() {
+            val src = mapper.createParser(""""foo"${"\n"}"bar"""")
+            val itr = mapper.readValues<String>(src)
+
+            assertEquals("foo", itr.next())
+            assertThrows<RuntimeJsonMappingException> {
+                itr.next()
+            }
+        }
+
+        @Test
+        fun readValuesJsonParserNextValue() {
+            val src = mapper.createParser(""""foo"${"\n"}"bar"""")
+            val itr = mapper.readValues<String>(src)
+
+            assertEquals("foo", itr.nextValue())
+            assertThrows<JsonMappingException> {
+                itr.nextValue()
+            }
+        }
+
+        @Test
+        fun readValuesTypedJsonParser() {
+            val reader = mapper.reader()
+            val src = reader.createParser(""""foo"${"\n"}"bar"""")
+            val itr = reader.readValuesTyped<String>(src)
+
+            assertEquals("foo", itr.next())
+            assertThrows<JsonMappingException> {
+                itr.next()
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/TestCommons.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/TestCommons.kt
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.core.util.DefaultIndenter
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
@@ -29,4 +33,17 @@ internal inline fun <reified T : Any> assertReflectEquals(expected: T, actual: T
     T::class.memberProperties.forEach {
         assertEquals(it.get(expected), it.get(actual))
     }
+}
+
+internal fun createTempJson(json: String): File {
+    val file = File.createTempFile("temp", ".json")
+    file.deleteOnExit()
+    OutputStreamWriter(
+        FileOutputStream(file),
+        StandardCharsets.UTF_8
+    ).use { writer ->
+        writer.write(json)
+        writer.flush()
+    }
+    return file
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
 import java.lang.reflect.InvocationTargetException
+import kotlin.test.assertNotEquals
 
 class WithoutCustomDeserializeMethodTest {
     companion object {
@@ -42,10 +43,8 @@ class WithoutCustomDeserializeMethodTest {
             // failing
             @Test
             fun nullString() {
-                org.junit.jupiter.api.assertThrows<NullPointerException>("#209 has been fixed.") {
-                    val result = defaultMapper.readValue<NullableObject>("null")
-                    assertEquals(NullableObject(null), result)
-                }
+                val result = defaultMapper.readValue<NullableObject?>("null")
+                assertNotEquals(NullableObject(null), result, "kogera #209 has been fixed.")
             }
         }
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.module.kotlin.kogeraIntegration.deser.valueClass.Pr
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import kotlin.test.assertNotEquals
 
 class SpecifiedForObjectMapperTest {
     companion object {
@@ -48,10 +49,8 @@ class SpecifiedForObjectMapperTest {
             // failing
             @Test
             fun nullString() {
-                org.junit.jupiter.api.assertThrows<NullPointerException>("#209 has been fixed.") {
-                    val result = mapper.readValue<NullableObject>("null")
-                    assertEquals(NullableObject("null-value-deser"), result)
-                }
+                val result = mapper.readValue<NullableObject?>("null")
+                assertNotEquals(NullableObject("null-value-deser"), result, "kogera #209 has been fixed.")
             }
         }
     }


### PR DESCRIPTION
Fixed a problem with functions such as `readValue` that could return `null` even if non-null was specified in `Kotlin`.
This fix will close #399 .