### PR TITLE
Fixed to use common util for Member accessibility override

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.19.0 (not yet released)
 
 WrongWrong (@k163377)
+* #944: Fixed to use common util for Member accessibility override
 * #937: Added type match check to read functions
 
 Tatu Saloranta (@cowtowncoder)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,7 @@ Co-maintainers:
 
 2.19.0 (not yet released)
 
+#944: Common util is now used for member accessibility overrides.
 #937: For `readValue` and other shorthands for `ObjectMapper` deserialization methods,
   type consistency checks have been added.
   A `RuntimeJsonMappingException` will be thrown in case of inconsistency.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Converters.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Converters.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.deser.std.StdDelegatingDeserializer
 import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
 import com.fasterxml.jackson.databind.type.TypeFactory
+import com.fasterxml.jackson.databind.util.ClassUtil
 import com.fasterxml.jackson.databind.util.StdConverter
 import kotlin.reflect.KClass
 import kotlin.time.toJavaDuration
@@ -51,7 +52,7 @@ internal class ValueClassBoxConverter<S : Any?, D : Any>(
     val boxedClass: KClass<D>
 ) : StdConverter<S, D>() {
     private val boxMethod = boxedClass.java.getDeclaredMethod("box-impl", unboxedClass).apply {
-        if (!this.isAccessible) this.isAccessible = true
+        ClassUtil.checkAndFixAccess(this, false)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
+import com.fasterxml.jackson.databind.util.ClassUtil
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import kotlin.reflect.full.primaryConstructor
@@ -106,7 +107,7 @@ internal class WrapsNullableValueClassBoxDeserializer<S, D : Any>(
     private val inputType: Class<*> = creator.parameterTypes[0]
 
     init {
-        creator.apply { if (!this.isAccessible) this.isAccessible = true }
+        ClassUtil.checkAndFixAccess(creator, false)
     }
 
     // Cache the result of wrapping null, since the result is always expected to be the same.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer
 import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializers
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
+import com.fasterxml.jackson.databind.util.ClassUtil
 import java.lang.reflect.Method
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
@@ -78,7 +79,7 @@ internal class ValueClassKeyDeserializer<S, D : Any>(
     private val unboxedClass: Class<*> = creator.parameterTypes[0]
 
     init {
-        creator.apply { if (!this.isAccessible) this.isAccessible = true }
+        ClassUtil.checkAndFixAccess(creator, false)
     }
 
     // Based on databind error

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/MethodValueCreator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/MethodValueCreator.kt
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
+import com.fasterxml.jackson.databind.util.ClassUtil
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.extensionReceiverParameter
 import kotlin.reflect.full.instanceParameter
@@ -39,7 +40,7 @@ internal class MethodValueCreator<T> private constructor(
                 possibleCompanion.java.enclosingClass.declaredFields
                     .firstOrNull { it.type.kotlin.isCompanion }
                     ?.let {
-                        it.isAccessible = true
+                        ClassUtil.checkAndFixAccess(it, false)
 
                         // If the instance of the companion object cannot be obtained, accessibility will always be false
                         it.get(null) to false


### PR DESCRIPTION
This makes it easier to understand the message when an error occurs.