### PR TITLE
Use `MethodHandle` in processing related to `value class`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,22 @@
                             <exclude>
                                 com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException#MissingKotlinParameterException(kotlin.reflect.KParameter,java.io.Closeable,java.lang.String)
                             </exclude>
+                            <exclude>
+                                com.fasterxml.jackson.module.kotlin.WrapsNullableValueClassBoxDeserializer
+                            </exclude>
+                            <exclude>com.fasterxml.jackson.module.kotlin.ValueClassUnboxKeySerializer</exclude>
+                            <exclude>com.fasterxml.jackson.module.kotlin.KotlinKeySerializersKt</exclude>
+                            <exclude>com.fasterxml.jackson.module.kotlin.ValueClassSerializer</exclude>
+                            <!-- internal -->
+                            <exclude>
+                                com.fasterxml.jackson.module.kotlin.KotlinKeySerializers#KotlinKeySerializers()
+                            </exclude>
+                            <exclude>
+                                com.fasterxml.jackson.module.kotlin.KotlinSerializers#KotlinSerializers()
+                            </exclude>
+                            <exclude>com.fasterxml.jackson.module.kotlin.ValueClassStaticJsonKeySerializer</exclude>
+                            <exclude>com.fasterxml.jackson.module.kotlin.ValueClassBoxConverter</exclude>
+                            <exclude>com.fasterxml.jackson.module.kotlin.ValueClassKeyDeserializer</exclude>
                         </excludes>
                     </parameter>
                 </configuration>

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.20.0 (not yet released)
 
 WrongWrong (@k163377)
+* #1018: Use MethodHandle in processing related to value class
 * #969: Cleanup of deprecated contents
 * #967: Update settings for 2.20
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -17,7 +17,12 @@ Co-maintainers:
 ------------------------------------------------------------------------
 
 2.20.0 (not yet released)
-
+#1018: Improved handling of `value class` has improved performance for both serialization and deserialization.
+  In particular, for serialization, proper caching has improved throughput by a factor of 2 or more in the general cases.
+  Also, replacing function execution by reflection with `MethodHandle` improved throughput by several percent for both serialization and deserialization.
+  In cases where the number of properties of a `value class` in the processing target is large, there is a possibility to obtain a larger improvement.
+  Please note that this modification causes a destructive change in that exceptions thrown during deserialization of
+  `value class` are no longer wrapped in an `InvocationTargetException`.
 #969: Deprecated content has been cleaned up with the version upgrade.
 #967: Kotlin has been upgraded to 2.0.21.
 - Generate SBOMs [JSTEP-14]

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Converters.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Converters.kt
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.deser.std.StdDelegatingDeserializer
 import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
 import com.fasterxml.jackson.databind.type.TypeFactory
-import com.fasterxml.jackson.databind.util.ClassUtil
 import com.fasterxml.jackson.databind.util.StdConverter
-import kotlin.reflect.KClass
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+import java.lang.reflect.Method
+import java.lang.reflect.Type
+import java.util.UUID
 import kotlin.time.toJavaDuration
 import kotlin.time.toKotlinDuration
 import java.time.Duration as JavaDuration
@@ -23,7 +27,7 @@ internal class SequenceToIteratorConverter(private val input: JavaType) : StdCon
 }
 
 internal object KotlinDurationValueToJavaDurationConverter : StdConverter<Long, JavaDuration>() {
-    private val boxConverter by lazy { ValueClassBoxConverter(Long::class.java, KotlinDuration::class) }
+    private val boxConverter by lazy { LongValueClassBoxConverter(KotlinDuration::class.java) }
 
     override fun convert(value: Long): JavaDuration = KotlinToJavaDurationConverter.convert(boxConverter.convert(value))
 }
@@ -45,18 +49,163 @@ internal object JavaToKotlinDurationConverter : StdConverter<JavaDuration, Kotli
     }
 }
 
-// S is nullable because value corresponds to a nullable value class
-// @see KotlinNamesAnnotationIntrospector.findNullSerializer
-internal class ValueClassBoxConverter<S : Any?, D : Any>(
-    unboxedClass: Class<S>,
-    val boxedClass: KClass<D>
-) : StdConverter<S, D>() {
-    private val boxMethod = boxedClass.java.getDeclaredMethod("box-impl", unboxedClass).apply {
-        ClassUtil.checkAndFixAccess(this, false)
-    }
+internal sealed class ValueClassBoxConverter<S : Any?, D : Any> : StdConverter<S, D>() {
+    abstract val boxedClass: Class<D>
+    abstract val boxHandle: MethodHandle
 
-    @Suppress("UNCHECKED_CAST")
-    override fun convert(value: S): D = boxMethod.invoke(null, value) as D
+    protected fun rawBoxHandle(
+        unboxedClass: Class<*>,
+    ): MethodHandle = MethodHandles.lookup().findStatic(
+        boxedClass,
+        "box-impl",
+        MethodType.methodType(boxedClass, unboxedClass),
+    )
 
     val delegatingSerializer: StdDelegatingSerializer by lazy { StdDelegatingSerializer(this) }
+
+    companion object {
+        fun create(
+            unboxedClass: Class<*>,
+            valueClass: Class<*>,
+        ): ValueClassBoxConverter<*, *> = when (unboxedClass) {
+            Int::class.java -> IntValueClassBoxConverter(valueClass)
+            Long::class.java -> LongValueClassBoxConverter(valueClass)
+            String::class.java -> StringValueClassBoxConverter(valueClass)
+            UUID::class.java -> JavaUuidValueClassBoxConverter(valueClass)
+            else -> GenericValueClassBoxConverter(unboxedClass, valueClass)
+        }
+    }
+
+    // If the wrapped type is explicitly specified, it is inherited for the sake of distinction
+    internal sealed class Specified<S : Any?, D : Any> : ValueClassBoxConverter<S, D>()
+}
+
+// region: Converters for common classes as wrapped values, add as needed.
+internal class IntValueClassBoxConverter<D : Any>(
+    override val boxedClass: Class<D>,
+) : ValueClassBoxConverter.Specified<Int, D>() {
+    override val boxHandle: MethodHandle = rawBoxHandle(Int::class.java).asType(INT_TO_ANY_METHOD_TYPE)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun convert(value: Int): D = boxHandle.invokeExact(value) as D
+}
+
+internal class LongValueClassBoxConverter<D : Any>(
+    override val boxedClass: Class<D>,
+) : ValueClassBoxConverter.Specified<Long, D>() {
+    override val boxHandle: MethodHandle = rawBoxHandle(Long::class.java).asType(LONG_TO_ANY_METHOD_TYPE)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun convert(value: Long): D = boxHandle.invokeExact(value) as D
+}
+
+internal class StringValueClassBoxConverter<D : Any>(
+    override val boxedClass: Class<D>,
+) : ValueClassBoxConverter.Specified<String?, D>() {
+    override val boxHandle: MethodHandle = rawBoxHandle(String::class.java).asType(STRING_TO_ANY_METHOD_TYPE)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun convert(value: String?): D = boxHandle.invokeExact(value) as D
+}
+
+internal class JavaUuidValueClassBoxConverter<D : Any>(
+    override val boxedClass: Class<D>,
+) : ValueClassBoxConverter.Specified<UUID?, D>() {
+    override val boxHandle: MethodHandle = rawBoxHandle(UUID::class.java).asType(JAVA_UUID_TO_ANY_METHOD_TYPE)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun convert(value: UUID?): D = boxHandle.invokeExact(value) as D
+}
+// endregion
+
+/**
+ * A converter that only performs box processing for the value class.
+ * Note that constructor-impl is not called.
+ * @param S is nullable because value corresponds to a nullable value class.
+ *   see [io.github.projectmapk.jackson.module.kogera.annotationIntrospector.KotlinFallbackAnnotationIntrospector.findNullSerializer]
+ */
+internal class GenericValueClassBoxConverter<S : Any?, D : Any>(
+    unboxedClass: Class<S>,
+    override val boxedClass: Class<D>,
+) : ValueClassBoxConverter<S, D>() {
+    override val boxHandle: MethodHandle = rawBoxHandle(unboxedClass).asType(ANY_TO_ANY_METHOD_TYPE)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun convert(value: S): D = boxHandle.invokeExact(value) as D
+}
+
+internal sealed class ValueClassUnboxConverter<S : Any, D : Any?> : StdConverter<S, D>() {
+    abstract val valueClass: Class<S>
+    abstract val unboxedType: Type
+    abstract val unboxHandle: MethodHandle
+
+    final override fun getInputType(typeFactory: TypeFactory): JavaType = typeFactory.constructType(valueClass)
+    final override fun getOutputType(typeFactory: TypeFactory): JavaType = typeFactory.constructType(unboxedType)
+
+    val delegatingSerializer: StdDelegatingSerializer by lazy { StdDelegatingSerializer(this) }
+
+    companion object {
+        fun create(valueClass: Class<*>): ValueClassUnboxConverter<*, *> {
+            val unboxMethod = valueClass.getDeclaredMethod("unbox-impl")
+            val unboxedType = unboxMethod.genericReturnType
+
+            return when (unboxedType) {
+                Int::class.java -> IntValueClassUnboxConverter(valueClass, unboxMethod)
+                Long::class.java -> LongValueClassUnboxConverter(valueClass, unboxMethod)
+                String::class.java -> StringValueClassUnboxConverter(valueClass, unboxMethod)
+                UUID::class.java -> JavaUuidValueClassUnboxConverter(valueClass, unboxMethod)
+                else -> GenericValueClassUnboxConverter(valueClass, unboxedType, unboxMethod)
+            }
+        }
+    }
+}
+
+internal class IntValueClassUnboxConverter<T : Any>(
+    override val valueClass: Class<T>,
+    unboxMethod: Method,
+) : ValueClassUnboxConverter<T, Int>() {
+    override val unboxedType: Type get() = Int::class.java
+    override val unboxHandle: MethodHandle = unreflectAsType(unboxMethod, ANY_TO_INT_METHOD_TYPE)
+
+    override fun convert(value: T): Int = unboxHandle.invokeExact(value) as Int
+}
+
+internal class LongValueClassUnboxConverter<T : Any>(
+    override val valueClass: Class<T>,
+    unboxMethod: Method,
+) : ValueClassUnboxConverter<T, Long>() {
+    override val unboxedType: Type get() = Long::class.java
+    override val unboxHandle: MethodHandle = unreflectAsType(unboxMethod, ANY_TO_LONG_METHOD_TYPE)
+
+    override fun convert(value: T): Long = unboxHandle.invokeExact(value) as Long
+}
+
+internal class StringValueClassUnboxConverter<T : Any>(
+    override val valueClass: Class<T>,
+    unboxMethod: Method,
+) : ValueClassUnboxConverter<T, String?>() {
+    override val unboxedType: Type get() = String::class.java
+    override val unboxHandle: MethodHandle = unreflectAsType(unboxMethod, ANY_TO_STRING_METHOD_TYPE)
+
+    override fun convert(value: T): String? = unboxHandle.invokeExact(value) as String?
+}
+
+internal class JavaUuidValueClassUnboxConverter<T : Any>(
+    override val valueClass: Class<T>,
+    unboxMethod: Method,
+) : ValueClassUnboxConverter<T, UUID?>() {
+    override val unboxedType: Type get() = UUID::class.java
+    override val unboxHandle: MethodHandle = unreflectAsType(unboxMethod, ANY_TO_JAVA_UUID_METHOD_TYPE)
+
+    override fun convert(value: T): UUID? = unboxHandle.invokeExact(value) as UUID?
+}
+
+internal class GenericValueClassUnboxConverter<T : Any>(
+    override val valueClass: Class<T>,
+    override val unboxedType: Type,
+    unboxMethod: Method,
+) : ValueClassUnboxConverter<T, Any?>() {
+    override val unboxHandle: MethodHandle = unreflectAsType(unboxMethod, ANY_TO_ANY_METHOD_TYPE)
+
+    override fun convert(value: T): Any? = unboxHandle.invokeExact(value)
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
@@ -2,7 +2,11 @@ package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.databind.JsonMappingException
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
 import java.lang.reflect.AnnotatedElement
+import java.lang.reflect.Method
 import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -46,3 +50,16 @@ internal fun AnnotatedElement.hasCreatorAnnotation(): Boolean = getAnnotation(Js
 // Determine if the unbox result of value class is nullable
 internal fun KClass<*>.wrapsNullable(): Boolean =
     this.memberProperties.first { it.javaField != null }.returnType.isMarkedNullable
+
+internal val ANY_TO_ANY_METHOD_TYPE by lazy {MethodType.methodType(Any::class.java, Any::class.java) }
+internal val ANY_TO_INT_METHOD_TYPE by lazy {MethodType.methodType(Int::class.java, Any::class.java) }
+internal val ANY_TO_LONG_METHOD_TYPE by lazy {MethodType.methodType(Long::class.java, Any::class.java) }
+internal val ANY_TO_STRING_METHOD_TYPE by lazy {MethodType.methodType(String::class.java, Any::class.java) }
+internal val ANY_TO_JAVA_UUID_METHOD_TYPE by lazy {MethodType.methodType(UUID::class.java, Any::class.java) }
+internal val INT_TO_ANY_METHOD_TYPE by lazy {MethodType.methodType(Any::class.java, Int::class.java) }
+internal val LONG_TO_ANY_METHOD_TYPE by lazy {MethodType.methodType(Any::class.java, Long::class.java) }
+internal val STRING_TO_ANY_METHOD_TYPE by lazy {MethodType.methodType(Any::class.java, String::class.java) }
+internal val JAVA_UUID_TO_ANY_METHOD_TYPE by lazy {MethodType.methodType(Any::class.java, UUID::class.java) }
+
+internal fun unreflect(method: Method): MethodHandle = MethodHandles.lookup().unreflect(method)
+internal fun unreflectAsType(method: Method, type: MethodType): MethodHandle = unreflect(method).asType(type)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
@@ -288,7 +288,7 @@ internal class KotlinDeserializers(
                 JavaToKotlinDurationConverter.takeIf { useJavaDurationConversion }?.delegatingDeserializer
             rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass)?.let {
                 val unboxedClass = it.returnType
-                val converter = cache.getValueClassBoxConverter(unboxedClass, rawClass.kotlin)
+                val converter = cache.getValueClassBoxConverter(unboxedClass, rawClass)
 
                 when (converter) {
                     is ValueClassBoxConverter.Specified -> {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinDeserializers.kt
@@ -11,9 +11,11 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
-import com.fasterxml.jackson.databind.util.ClassUtil
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
+import java.util.UUID
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.javaMethod
 import kotlin.time.Duration as KotlinDuration
@@ -100,14 +102,98 @@ object ULongDeserializer : StdDeserializer<ULong>(ULong::class.java) {
         )
 }
 
-internal class WrapsNullableValueClassBoxDeserializer<S, D : Any>(
-    private val creator: Method,
-    private val converter: ValueClassBoxConverter<S, D>
+// If the creator does not perform type conversion, implement a unique deserializer for each for fast invocation.
+internal sealed class NoConversionCreatorBoxDeserializer<S, D : Any>(
+    creator: Method,
+    converter: ValueClassBoxConverter<S, D>,
 ) : WrapsNullableValueClassDeserializer<D>(converter.boxedClass) {
-    private val inputType: Class<*> = creator.parameterTypes[0]
+    protected abstract val inputType: Class<*>
+    protected val handle: MethodHandle = MethodHandles
+        .filterReturnValue(unreflect(creator), converter.boxHandle)
+
+    // Since the input to handle must be strict, invoke should be implemented in each class
+    protected abstract fun invokeExact(value: S): D
+
+    // Cache the result of wrapping null, since the result is always expected to be the same.
+    @get:JvmName("boxedNullValue")
+    private val boxedNullValue: D by lazy {
+        // For the sake of commonality, it is unavoidably called without checking.
+        // It is controlled by KotlinValueInstantiator, so it is not expected to reach this branch.
+        @Suppress("UNCHECKED_CAST")
+        invokeExact(null as S)
+    }
+
+    final override fun getBoxedNullValue(): D = boxedNullValue
+
+    final override fun deserialize(p: JsonParser, ctxt: DeserializationContext): D {
+        @Suppress("UNCHECKED_CAST")
+        return invokeExact(p.readValueAs(inputType) as S)
+    }
+
+    internal class WrapsInt<D : Any>(
+        creator: Method,
+        converter: IntValueClassBoxConverter<D>,
+    ) : NoConversionCreatorBoxDeserializer<Int, D>(creator, converter) {
+        override val inputType get() = Int::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun invokeExact(value: Int): D = handle.invokeExact(value) as D
+    }
+
+    internal class WrapsLong<D : Any>(
+        creator: Method,
+        converter: LongValueClassBoxConverter<D>,
+    ) : NoConversionCreatorBoxDeserializer<Long, D>(creator, converter) {
+        override val inputType get() = Long::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun invokeExact(value: Long): D = handle.invokeExact(value) as D
+    }
+
+    internal class WrapsString<D : Any>(
+        creator: Method,
+        converter: StringValueClassBoxConverter<D>,
+    ) : NoConversionCreatorBoxDeserializer<String?, D>(creator, converter) {
+        override val inputType get() = String::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun invokeExact(value: String?): D = handle.invokeExact(value) as D
+    }
+
+    internal class WrapsJavaUuid<D : Any>(
+        creator: Method,
+        converter: JavaUuidValueClassBoxConverter<D>,
+    ) : NoConversionCreatorBoxDeserializer<UUID?, D>(creator, converter) {
+        override val inputType get() = UUID::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun invokeExact(value: UUID?): D = handle.invokeExact(value) as D
+    }
+
+    companion object {
+        fun <S, D : Any> create(creator: Method, converter: ValueClassBoxConverter.Specified<S, D>) = when (converter) {
+            is IntValueClassBoxConverter -> WrapsInt(creator, converter)
+            is LongValueClassBoxConverter -> WrapsLong(creator, converter)
+            is StringValueClassBoxConverter -> WrapsString(creator, converter)
+            is JavaUuidValueClassBoxConverter -> WrapsJavaUuid(creator, converter)
+        }
+    }
+}
+
+// Even if the creator performs type conversion, it is distinguished
+// because a speedup due to rtype matching of filterReturnValue can be expected for the specified type.
+internal class HasConversionCreatorWrapsSpecifiedBoxDeserializer<S, D : Any>(
+    creator: Method,
+    private val inputType: Class<*>,
+    converter: ValueClassBoxConverter<S, D>,
+) : WrapsNullableValueClassDeserializer<D>(converter.boxedClass) {
+    private val handle: MethodHandle
 
     init {
-        ClassUtil.checkAndFixAccess(creator, false)
+        val unreflect = unreflect(creator).run {
+            asType(type().changeParameterType(0, Any::class.java))
+        }
+        handle = MethodHandles.filterReturnValue(unreflect, converter.boxHandle)
     }
 
     // Cache the result of wrapping null, since the result is always expected to be the same.
@@ -120,7 +206,37 @@ internal class WrapsNullableValueClassBoxDeserializer<S, D : Any>(
     // it is necessary to call creator(e.g. constructor-impl) -> box-impl in that order.
     // Input is null only when called from KotlinValueInstantiator.
     @Suppress("UNCHECKED_CAST")
-    private fun instantiate(input: Any?): D = converter.convert(creator.invoke(null, input) as S)
+    private fun instantiate(input: Any?): D = handle.invokeExact(input) as D
+
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): D {
+        val input = p.readValueAs(inputType)
+        return instantiate(input)
+    }
+}
+
+internal class WrapsAnyValueClassBoxDeserializer<S, D : Any>(
+    creator: Method,
+    private val inputType: Class<*>,
+    converter: GenericValueClassBoxConverter<S, D>,
+) : WrapsNullableValueClassDeserializer<D>(converter.boxedClass) {
+    private val handle: MethodHandle
+
+    init {
+        val unreflect = unreflectAsType(creator, ANY_TO_ANY_METHOD_TYPE)
+        handle = MethodHandles.filterReturnValue(unreflect, converter.boxHandle)
+    }
+
+    // Cache the result of wrapping null, since the result is always expected to be the same.
+    @get:JvmName("boxedNullValue")
+    private val boxedNullValue: D by lazy { instantiate(null) }
+
+    override fun getBoxedNullValue(): D = boxedNullValue
+
+    // To instantiate the value class in the same way as other classes,
+    // it is necessary to call creator(e.g. constructor-impl) -> box-impl in that order.
+    // Input is null only when called from KotlinValueInstantiator.
+    @Suppress("UNCHECKED_CAST")
+    private fun instantiate(input: Any?): D = handle.invokeExact(input) as D
 
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): D {
         val input = p.readValueAs(inputType)
@@ -173,7 +289,20 @@ internal class KotlinDeserializers(
             rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass)?.let {
                 val unboxedClass = it.returnType
                 val converter = cache.getValueClassBoxConverter(unboxedClass, rawClass.kotlin)
-                WrapsNullableValueClassBoxDeserializer(it, converter)
+
+                when (converter) {
+                    is ValueClassBoxConverter.Specified -> {
+                        val inputType = it.parameterTypes[0]
+
+                        if (inputType == unboxedClass) {
+                            NoConversionCreatorBoxDeserializer.create(it, converter)
+                        } else {
+                            HasConversionCreatorWrapsSpecifiedBoxDeserializer(it, inputType, converter)
+                        }
+                    }
+                    is GenericValueClassBoxConverter ->
+                        WrapsAnyValueClassBoxDeserializer(it, it.parameterTypes[0], converter)
+                }
             }
             else -> null
         }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
@@ -6,8 +6,10 @@ import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer
 import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializers
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
-import com.fasterxml.jackson.databind.util.ClassUtil
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
 import java.lang.reflect.Method
+import java.util.UUID
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.javaMethod
@@ -72,32 +74,98 @@ internal object ULongKeyDeserializer : StdKeyDeserializer(TYPE_LONG, ULong::clas
 }
 
 // The implementation is designed to be compatible with various creators, just in case.
-internal class ValueClassKeyDeserializer<S, D : Any>(
-    private val creator: Method,
-    private val converter: ValueClassBoxConverter<S, D>
+internal sealed class ValueClassKeyDeserializer<S, D : Any>(
+    converter: ValueClassBoxConverter<S, D>,
+    creatorHandle: MethodHandle,
 ) : KeyDeserializer() {
-    private val unboxedClass: Class<*> = creator.parameterTypes[0]
+    private val boxedClass: Class<D> = converter.boxedClass
 
-    init {
-        ClassUtil.checkAndFixAccess(creator, false)
-    }
+    protected abstract val unboxedClass: Class<*>
+    protected val handle: MethodHandle = MethodHandles.filterReturnValue(creatorHandle, converter.boxHandle)
 
     // Based on databind error
     // https://github.com/FasterXML/jackson-databind/blob/341f8d360a5f10b5e609d6ee0ea023bf597ce98a/src/main/java/com/fasterxml/jackson/databind/deser/DeserializerCache.java#L624
-    private fun errorMessage(boxedType: JavaType): String =
-        "Could not find (Map) Key deserializer for types wrapped in $boxedType"
+    private fun errorMessage(boxedType: JavaType): String = "Could not find (Map) Key deserializer for types " +
+            "wrapped in $boxedType"
 
-    override fun deserializeKey(key: String?, ctxt: DeserializationContext): Any {
+    // Since the input to handle must be strict, invoke should be implemented in each class
+    protected abstract fun invokeExact(value: S): D
+
+    final override fun deserializeKey(key: String?, ctxt: DeserializationContext): Any {
         val unboxedJavaType = ctxt.constructType(unboxedClass)
 
         return try {
             // findKeyDeserializer does not return null, and an exception will be thrown if not found.
             val value = ctxt.findKeyDeserializer(unboxedJavaType, null).deserializeKey(key, ctxt)
             @Suppress("UNCHECKED_CAST")
-            converter.convert(creator.invoke(null, value) as S)
+            invokeExact(value as S)
         } catch (e: InvalidDefinitionException) {
-            throw JsonMappingException.from(ctxt, errorMessage(ctxt.constructType(converter.boxedClass)), e)
+            throw JsonMappingException.from(ctxt, errorMessage(ctxt.constructType(boxedClass)), e)
         }
+    }
+
+    internal sealed class WrapsSpecified<S, D : Any>(
+        converter: ValueClassBoxConverter<S, D>,
+        creator: Method,
+    ) : ValueClassKeyDeserializer<S, D>(
+        converter,
+        // Currently, only the primary constructor can be the creator of a key, so for specified types,
+        // the return type of the primary constructor and the input type of the box function are exactly the same.
+        // Therefore, performance is improved by omitting the asType call.
+        unreflect(creator),
+    )
+
+    internal class WrapsInt<D : Any>(
+        converter: IntValueClassBoxConverter<D>,
+        creator: Method,
+    ) : WrapsSpecified<Int, D>(converter, creator) {
+        override val unboxedClass: Class<*> get() = Int::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun invokeExact(value: Int): D = handle.invokeExact(value) as D
+    }
+
+    internal class WrapsLong<D : Any>(
+        converter: LongValueClassBoxConverter<D>,
+        creator: Method,
+    ) : WrapsSpecified<Long, D>(converter, creator) {
+        override val unboxedClass: Class<*> get() = Long::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun invokeExact(value: Long): D = handle.invokeExact(value) as D
+    }
+
+    internal class WrapsString<D : Any>(
+        converter: StringValueClassBoxConverter<D>,
+        creator: Method,
+    ) : WrapsSpecified<String?, D>(converter, creator) {
+        override val unboxedClass: Class<*> get() = String::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun invokeExact(value: String?): D = handle.invokeExact(value) as D
+    }
+
+    internal class WrapsJavaUuid<D : Any>(
+        converter: JavaUuidValueClassBoxConverter<D>,
+        creator: Method,
+    ) : WrapsSpecified<UUID?, D>(converter, creator) {
+        override val unboxedClass: Class<*> get() = UUID::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun invokeExact(value: UUID?): D = handle.invokeExact(value) as D
+    }
+
+    internal class WrapsAny<S, D : Any>(
+        converter: GenericValueClassBoxConverter<S, D>,
+        creator: Method,
+    ) : ValueClassKeyDeserializer<S, D>(
+        converter,
+        unreflectAsType(creator, ANY_TO_ANY_METHOD_TYPE),
+    ) {
+        override val unboxedClass: Class<*> = creator.returnType
+
+        @Suppress("UNCHECKED_CAST")
+        override fun invokeExact(value: S): D = handle.invokeExact(value) as D
     }
 
     companion object {
@@ -113,7 +181,13 @@ internal class ValueClassKeyDeserializer<S, D : Any>(
             val creator = boxedClass.primaryConstructor?.javaMethod ?: return null
             val converter = cache.getValueClassBoxConverter(creator.returnType, boxedClass)
 
-            return ValueClassKeyDeserializer(creator, converter)
+            return when (converter) {
+                is IntValueClassBoxConverter -> WrapsInt(converter, creator)
+                is LongValueClassBoxConverter -> WrapsLong(converter, creator)
+                is StringValueClassBoxConverter -> WrapsString(converter, creator)
+                is JavaUuidValueClassBoxConverter -> WrapsJavaUuid(converter, creator)
+                is GenericValueClassBoxConverter -> WrapsAny(converter, creator)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeyDeserializers.kt
@@ -96,7 +96,7 @@ internal class ValueClassKeyDeserializer<S, D : Any>(
             @Suppress("UNCHECKED_CAST")
             converter.convert(creator.invoke(null, value) as S)
         } catch (e: InvalidDefinitionException) {
-            throw JsonMappingException.from(ctxt, errorMessage(ctxt.constructType(converter.boxedClass.java)), e)
+            throw JsonMappingException.from(ctxt, errorMessage(ctxt.constructType(converter.boxedClass)), e)
         }
     }
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
@@ -9,18 +9,20 @@ import com.fasterxml.jackson.databind.SerializationConfig
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.ser.Serializers
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
-internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.java) {
-    private fun readResolve(): Any = ValueClassUnboxKeySerializer
-
-    override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
-        val method = value::class.java.getMethod("unbox-impl")
-        val unboxed = method.invoke(value)
+internal class ValueClassUnboxKeySerializer<T : Any>(
+    private val converter: ValueClassUnboxConverter<T, *>,
+) : StdSerializer<T>(converter.valueClass) {
+    override fun serialize(value: T, gen: JsonGenerator, provider: SerializerProvider) {
+        val unboxed = converter.convert(value)
 
         if (unboxed == null) {
-            val javaType = provider.typeFactory.constructType(method.genericReturnType)
+            val javaType = converter.getOutputType(provider.typeFactory)
             provider.findNullKeySerializer(javaType, null).serialize(null, gen, provider)
             return
         }
@@ -29,21 +31,18 @@ internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.jav
     }
 }
 
-// Class must be UnboxableValueClass.
-private fun Class<*>.getStaticJsonKeyGetter(): Method? = this.declaredMethods.find { method ->
-    Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonKey && it.value }
-}
+internal sealed class ValueClassStaticJsonKeySerializer<T : Any>(
+    converter: ValueClassUnboxConverter<T, *>,
+    staticJsonValueGetter: Method,
+    methodType: MethodType,
+) : StdSerializer<T>(converter.valueClass) {
+    private val keyType: Class<*> = staticJsonValueGetter.returnType
+    private val handle: MethodHandle = unreflectAsType(staticJsonValueGetter, methodType).let {
+        MethodHandles.filterReturnValue(converter.unboxHandle, it)
+    }
 
-internal class ValueClassStaticJsonKeySerializer<T>(
-    t: Class<T>,
-    private val staticJsonKeyGetter: Method
-) : StdSerializer<T>(t) {
-    private val keyType: Class<*> = staticJsonKeyGetter.returnType
-    private val unboxMethod: Method = t.getMethod("unbox-impl")
-
-    override fun serialize(value: T, gen: JsonGenerator, provider: SerializerProvider) {
-        val unboxed = unboxMethod.invoke(value)
-        val jsonKey: Any? = staticJsonKeyGetter.invoke(null, unboxed)
+    final override fun serialize(value: T, gen: JsonGenerator, provider: SerializerProvider) {
+        val jsonKey: Any? = handle.invokeExact(value)
 
         val serializer = jsonKey
             ?.let { provider.findKeySerializer(keyType, null) }
@@ -52,20 +51,94 @@ internal class ValueClassStaticJsonKeySerializer<T>(
         serializer.serialize(jsonKey, gen, provider)
     }
 
+    internal class WrapsInt<T : Any>(
+        converter: IntValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonKeySerializer<T>(
+        converter,
+        staticJsonValueGetter,
+        INT_TO_ANY_METHOD_TYPE,
+    )
+
+    internal class WrapsLong<T : Any>(
+        converter: LongValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonKeySerializer<T>(
+        converter,
+        staticJsonValueGetter,
+        LONG_TO_ANY_METHOD_TYPE,
+    )
+
+    internal class WrapsString<T : Any>(
+        converter: StringValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonKeySerializer<T>(
+        converter,
+        staticJsonValueGetter,
+        STRING_TO_ANY_METHOD_TYPE,
+    )
+
+    internal class WrapsJavaUuid<T : Any>(
+        converter: JavaUuidValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonKeySerializer<T>(
+        converter,
+        staticJsonValueGetter,
+        JAVA_UUID_TO_ANY_METHOD_TYPE,
+    )
+
+    internal class WrapsAny<T : Any>(
+        converter: GenericValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonKeySerializer<T>(
+        converter,
+        staticJsonValueGetter,
+        ANY_TO_ANY_METHOD_TYPE,
+
+        )
+
     companion object {
-        fun createOrNull(t: Class<*>): StdSerializer<*>? =
-            t.getStaticJsonKeyGetter()?.let { ValueClassStaticJsonKeySerializer(t, it) }
+        // Class must be UnboxableValueClass.
+        private fun Class<*>.getStaticJsonKeyGetter(): Method? = this.declaredMethods.find { method ->
+            Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonKey && it.value }
+        }
+
+        // `t` must be UnboxableValueClass.
+        // If create a function with a JsonValue in the value class,
+        // it will be compiled as a static method (= cannot be processed properly by Jackson),
+        // so use a ValueClassSerializer.StaticJsonValue to handle this.
+        fun <T : Any> createOrNull(
+            converter: ValueClassUnboxConverter<T, *>,
+        ): ValueClassStaticJsonKeySerializer<T>? = converter
+            .valueClass
+            .getStaticJsonKeyGetter()
+            ?.let {
+                when (converter) {
+                    is IntValueClassUnboxConverter -> WrapsInt(converter, it)
+                    is LongValueClassUnboxConverter -> WrapsLong(converter, it)
+                    is StringValueClassUnboxConverter -> WrapsString(converter, it)
+                    is JavaUuidValueClassUnboxConverter -> WrapsJavaUuid(converter, it)
+                    is GenericValueClassUnboxConverter -> WrapsAny(converter, it)
+                }
+            }
     }
 }
 
-internal class KotlinKeySerializers : Serializers.Base() {
+internal class KotlinKeySerializers(private val cache: ReflectionCache) : Serializers.Base() {
     override fun findSerializer(
         config: SerializationConfig,
         type: JavaType,
-        beanDesc: BeanDescription
-    ): JsonSerializer<*>? = when {
-        type.rawClass.isUnboxableValueClass() -> ValueClassStaticJsonKeySerializer.createOrNull(type.rawClass)
-            ?: ValueClassUnboxKeySerializer
-        else -> null
+        beanDesc: BeanDescription,
+    ): JsonSerializer<*>? {
+        val rawClass = type.rawClass
+
+        return when {
+            rawClass.isUnboxableValueClass() -> {
+                val unboxConverter = cache.getValueClassUnboxConverter(rawClass.kotlin)
+                ValueClassStaticJsonKeySerializer.createOrNull(unboxConverter)
+                    ?: ValueClassUnboxKeySerializer(unboxConverter)
+            }
+            else -> null
+        }
     }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinKeySerializers.kt
@@ -134,7 +134,7 @@ internal class KotlinKeySerializers(private val cache: ReflectionCache) : Serial
 
         return when {
             rawClass.isUnboxableValueClass() -> {
-                val unboxConverter = cache.getValueClassUnboxConverter(rawClass.kotlin)
+                val unboxConverter = cache.getValueClassUnboxConverter(rawClass)
                 ValueClassStaticJsonKeySerializer.createOrNull(unboxConverter)
                     ?: ValueClassUnboxKeySerializer(unboxConverter)
             }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -133,7 +133,7 @@ class KotlinModule private constructor(
 
         context.addDeserializers(KotlinDeserializers(cache, useJavaDurationConversion))
         context.addKeyDeserializers(KotlinKeyDeserializers(cache))
-        context.addSerializers(KotlinSerializers())
+        context.addSerializers(KotlinSerializers(cache))
         context.addKeySerializers(KotlinKeySerializers())
 
         // ranges

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -134,7 +134,7 @@ class KotlinModule private constructor(
         context.addDeserializers(KotlinDeserializers(cache, useJavaDurationConversion))
         context.addKeyDeserializers(KotlinKeyDeserializers(cache))
         context.addSerializers(KotlinSerializers(cache))
-        context.addKeySerializers(KotlinKeySerializers())
+        context.addKeySerializers(KotlinKeySerializers(cache))
 
         // ranges
         context.setMixInAnnotations(ClosedRange::class.java, ClosedRangeMixin::class.java)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -48,6 +48,19 @@ object ULongSerializer : StdSerializer<ULong>(ULong::class.java) {
     }
 }
 
+@Deprecated(
+    message = "This class was published by mistake. It will be removed in `2.22.0` as it is no longer used internally.",
+    level = DeprecationLevel.WARNING
+)
+object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
+    private fun readResolve(): Any = ValueClassUnboxSerializer
+
+    override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
+        val unboxed = value::class.java.getMethod("unbox-impl").invoke(value)
+        provider.defaultSerializeValue(unboxed, gen)
+    }
+}
+
 // Class must be UnboxableValueClass.
 private fun Class<*>.getStaticJsonValueGetter(): Method? = this.declaredMethods.find { method ->
     Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonValue && it.value }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -141,7 +141,7 @@ internal class KotlinSerializers(private val cache: ReflectionCache) : Serialize
             ULong::class.java == rawClass -> ULongSerializer
             // The priority of Unboxing needs to be lowered so as not to break the serialization of Unsigned Integers.
             rawClass.isUnboxableValueClass() -> {
-                val unboxConverter = cache.getValueClassUnboxConverter(rawClass.kotlin)
+                val unboxConverter = cache.getValueClassUnboxConverter(rawClass)
                 ValueClassStaticJsonValueSerializer.createOrNull(unboxConverter) ?: unboxConverter.delegatingSerializer
             }
             else -> null

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinSerializers.kt
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.SerializationConfig
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.ser.Serializers
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.math.BigInteger
@@ -51,41 +53,80 @@ private fun Class<*>.getStaticJsonValueGetter(): Method? = this.declaredMethods.
     Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonValue && it.value }
 }
 
-object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
-    private fun readResolve(): Any = ValueClassUnboxSerializer
+internal sealed class ValueClassStaticJsonValueSerializer<T : Any>(
+    converter: ValueClassUnboxConverter<T, *>,
+    staticJsonValueHandle: MethodHandle,
+) : StdSerializer<T>(converter.valueClass) {
+    private val handle: MethodHandle = MethodHandles.filterReturnValue(converter.unboxHandle, staticJsonValueHandle)
 
-    override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
-        val unboxed = value::class.java.getMethod("unbox-impl").invoke(value)
-        provider.defaultSerializeValue(unboxed, gen)
+    final override fun serialize(value: T, gen: JsonGenerator, provider: SerializerProvider) {
+        val jsonValue: Any? = handle.invokeExact(value)
+        provider.defaultSerializeValue(jsonValue, gen)
     }
-}
 
-internal sealed class ValueClassSerializer<T : Any>(t: Class<T>) : StdSerializer<T>(t) {
-    class StaticJsonValue<T : Any>(
-        t: Class<T>, private val staticJsonValueGetter: Method
-    ) : ValueClassSerializer<T>(t) {
-        private val unboxMethod: Method = t.getMethod("unbox-impl")
+    internal class WrapsInt<T : Any>(
+        converter: IntValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonValueSerializer<T>(
+        converter,
+        unreflectAsType(staticJsonValueGetter, INT_TO_ANY_METHOD_TYPE),
+    )
 
-        override fun serialize(value: T, gen: JsonGenerator, provider: SerializerProvider) {
-            val unboxed = unboxMethod.invoke(value)
-            // As shown in the processing of the factory function, jsonValueGetter is always a static method.
-            val jsonValue: Any? = staticJsonValueGetter.invoke(null, unboxed)
-            provider.defaultSerializeValue(jsonValue, gen)
-        }
-    }
+    internal class WrapsLong<T : Any>(
+        converter: LongValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonValueSerializer<T>(
+        converter,
+        unreflectAsType(staticJsonValueGetter, LONG_TO_ANY_METHOD_TYPE),
+    )
+
+    internal class WrapsString<T : Any>(
+        converter: StringValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonValueSerializer<T>(
+        converter,
+        unreflectAsType(staticJsonValueGetter, STRING_TO_ANY_METHOD_TYPE),
+    )
+
+    internal class WrapsJavaUuid<T : Any>(
+        converter: JavaUuidValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonValueSerializer<T>(
+        converter,
+        unreflectAsType(staticJsonValueGetter, JAVA_UUID_TO_ANY_METHOD_TYPE),
+    )
+
+    internal class WrapsAny<T : Any>(
+        converter: GenericValueClassUnboxConverter<T>,
+        staticJsonValueGetter: Method,
+    ) : ValueClassStaticJsonValueSerializer<T>(
+        converter,
+        unreflectAsType(staticJsonValueGetter, ANY_TO_ANY_METHOD_TYPE),
+    )
 
     companion object {
         // `t` must be UnboxableValueClass.
         // If create a function with a JsonValue in the value class,
         // it will be compiled as a static method (= cannot be processed properly by Jackson),
         // so use a ValueClassSerializer.StaticJsonValue to handle this.
-        fun from(t: Class<*>): StdSerializer<*> = t.getStaticJsonValueGetter()
-            ?.let { StaticJsonValue(t, it) }
-            ?: ValueClassUnboxSerializer
+        fun <T : Any> createOrNull(
+            converter: ValueClassUnboxConverter<T, *>,
+        ): ValueClassStaticJsonValueSerializer<T>? = converter
+            .valueClass
+            .getStaticJsonValueGetter()
+            ?.let {
+                when (converter) {
+                    is IntValueClassUnboxConverter -> WrapsInt(converter, it)
+                    is LongValueClassUnboxConverter -> WrapsLong(converter, it)
+                    is StringValueClassUnboxConverter -> WrapsString(converter, it)
+                    is JavaUuidValueClassUnboxConverter -> WrapsJavaUuid(converter, it)
+                    is GenericValueClassUnboxConverter -> WrapsAny(converter, it)
+                }
+            }
     }
 }
 
-internal class KotlinSerializers : Serializers.Base() {
+internal class KotlinSerializers(private val cache: ReflectionCache) : Serializers.Base() {
     override fun findSerializer(
         config: SerializationConfig?,
         type: JavaType,
@@ -99,7 +140,10 @@ internal class KotlinSerializers : Serializers.Base() {
             UInt::class.java == rawClass -> UIntSerializer
             ULong::class.java == rawClass -> ULongSerializer
             // The priority of Unboxing needs to be lowered so as not to break the serialization of Unsigned Integers.
-            rawClass.isUnboxableValueClass() -> ValueClassSerializer.from(rawClass)
+            rawClass.isUnboxableValueClass() -> {
+                val unboxConverter = cache.getValueClassUnboxConverter(rawClass.kotlin)
+                ValueClassStaticJsonValueSerializer.createOrNull(unboxConverter) ?: unboxConverter.delegatingSerializer
+            }
             else -> null
         }
     }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -122,7 +122,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
 
     fun getValueClassBoxConverter(unboxedClass: Class<*>, boxedClass: KClass<*>): ValueClassBoxConverter<*, *> =
         valueClassBoxConverterCache.get(boxedClass) ?: run {
-            val value = ValueClassBoxConverter(unboxedClass, boxedClass)
+            val value = ValueClassBoxConverter.create(unboxedClass, boxedClass.java)
             (valueClassBoxConverterCache.putIfAbsent(boxedClass, value) ?: value)
         }
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.jvm.kotlinFunction
 internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     companion object {
         // Increment is required when properties that use LRUMap are changed.
-        private const val serialVersionUID = 4L
+        private const val serialVersionUID = 5L
     }
 
     private val javaExecutableToKotlin = LRUMap<Executable, KFunction<*>>(reflectionCacheSize, reflectionCacheSize)
@@ -37,6 +37,8 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     // TODO: Consider whether the cache size should be reduced more,
     //       since the cache is used only twice locally at initialization per property.
     private val valueClassBoxConverterCache: LRUMap<KClass<*>, ValueClassBoxConverter<*, *>> =
+        LRUMap(0, reflectionCacheSize)
+    private val valueClassUnboxConverterCache: LRUMap<KClass<*>, ValueClassUnboxConverter<*, *>> =
         LRUMap(0, reflectionCacheSize)
 
     // If the Record type defined in Java is processed,
@@ -124,6 +126,12 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
         valueClassBoxConverterCache.get(boxedClass) ?: run {
             val value = ValueClassBoxConverter.create(unboxedClass, boxedClass.java)
             (valueClassBoxConverterCache.putIfAbsent(boxedClass, value) ?: value)
+        }
+
+    fun getValueClassUnboxConverter(boxedClass: KClass<*>): ValueClassUnboxConverter<*, *> =
+        valueClassUnboxConverterCache.get(boxedClass) ?: run {
+            val value = ValueClassUnboxConverter.create(boxedClass.java)
+            (valueClassUnboxConverterCache.putIfAbsent(boxedClass, value) ?: value)
         }
 
     fun findKotlinParameter(param: AnnotatedParameter): KParameter? = when (val owner = param.owner.member) {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -12,6 +12,7 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
 import java.lang.reflect.Method
 import java.util.*
+import kotlin.jvm.java
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
@@ -36,9 +37,9 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
 
     // TODO: Consider whether the cache size should be reduced more,
     //       since the cache is used only twice locally at initialization per property.
-    private val valueClassBoxConverterCache: LRUMap<KClass<*>, ValueClassBoxConverter<*, *>> =
+    private val valueClassBoxConverterCache: LRUMap<Class<*>, ValueClassBoxConverter<*, *>> =
         LRUMap(0, reflectionCacheSize)
-    private val valueClassUnboxConverterCache: LRUMap<KClass<*>, ValueClassUnboxConverter<*, *>> =
+    private val valueClassUnboxConverterCache: LRUMap<Class<*>, ValueClassUnboxConverter<*, *>> =
         LRUMap(0, reflectionCacheSize)
 
     // If the Record type defined in Java is processed,
@@ -122,15 +123,18 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
         }.orElse(null)
     }
 
-    fun getValueClassBoxConverter(unboxedClass: Class<*>, boxedClass: KClass<*>): ValueClassBoxConverter<*, *> =
+    fun getValueClassBoxConverter(unboxedClass: Class<*>, boxedClass: Class<*>): ValueClassBoxConverter<*, *> =
         valueClassBoxConverterCache.get(boxedClass) ?: run {
-            val value = ValueClassBoxConverter.create(unboxedClass, boxedClass.java)
+            val value = ValueClassBoxConverter.create(unboxedClass, boxedClass)
             (valueClassBoxConverterCache.putIfAbsent(boxedClass, value) ?: value)
         }
 
-    fun getValueClassUnboxConverter(boxedClass: KClass<*>): ValueClassUnboxConverter<*, *> =
+    fun getValueClassBoxConverter(unboxedClass: Class<*>, boxedClass: KClass<*>): ValueClassBoxConverter<*, *> =
+        getValueClassBoxConverter(unboxedClass, boxedClass.java)
+
+    fun getValueClassUnboxConverter(boxedClass: Class<*>): ValueClassUnboxConverter<*, *> =
         valueClassUnboxConverterCache.get(boxedClass) ?: run {
-            val value = ValueClassUnboxConverter.create(boxedClass.java)
+            val value = ValueClassUnboxConverter.create(boxedClass)
             (valueClassUnboxConverterCache.putIfAbsent(boxedClass, value) ?: value)
         }
 

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/WithoutCustomDeserializeMethodTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.lang.reflect.InvocationTargetException
 import kotlin.test.assertNotEquals
 
 class WithoutCustomDeserializeMethodTest {
@@ -132,8 +131,8 @@ class WithoutCustomDeserializeMethodTest {
 
     @Test
     fun callConstructorCheckTest() {
-        val e = assertThrows<InvocationTargetException> { defaultMapper.readValue<HasCheckConstructor>("-1") }
-        assertTrue(e.cause === throwable)
+        val e = assertThrows<IllegalArgumentException> { defaultMapper.readValue<HasCheckConstructor>("-1") }
+        assertTrue(e === throwable)
     }
 
     // If all JsonCreator tests are OK, no need to check throws from factory functions.

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/mapKey/WithoutCustomDeserializeMethodTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/kogeraIntegration/deser/valueClass/mapKey/WithoutCustomDeserializeMethodTest.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.lang.reflect.InvocationTargetException
 import com.fasterxml.jackson.databind.KeyDeserializer as JacksonKeyDeserializer
 
 class WithoutCustomDeserializeMethodTest {
@@ -98,10 +97,10 @@ class WithoutCustomDeserializeMethodTest {
 
     @Test
     fun callConstructorCheckTest() {
-        val e = assertThrows<InvocationTargetException> {
+        val e = assertThrows<IllegalArgumentException> {
             defaultMapper.readValue<Map<HasCheckConstructor, String?>>("""{"-1":null}""")
         }
-        assertTrue(e.cause === throwable)
+        assertTrue(e === throwable)
     }
 
     data class Wrapped(val first: String, val second: String) {


### PR DESCRIPTION
# Background
To seamless handling of value classes with Jackson, reflection is heavily used in the related processing.
In many cases, multiple reflective calls are performed in sequence.

For example, during deserialization, at least two reflective calls are required: invoking the primary constructor and then a call to `box`.
Similarly, serialization typically requires at least two reflective calls — one to `box` and one to `unbox`.

Replacing these reflective operations with MethodHandles is expected to performance improvement.

# Modification details
Each of the parts that used to use `Method` are replaced with `MethodHandle`.
In particular, the parts of the process in `kotlin-module` where `Method` was called continuously are further optimized by composing `MethodHandle` using `MethodHandle.filterReturnValue`.
In addition, for `Int`, `Long`, `String`, and (`Java`)`UUID`, which are particularly common types wrapped in `value class`, separate optimizations are made to speed up invocation by making the types explicit.

This change is based on the implementation in `jackson-module-kogera 2.19.0-beta25`.
https://github.com/ProjectMapK/jackson-module-kogera/releases/tag/2.19.0-beta25

It also fixes a problem where the `unbox-impl` method was not properly cached.
In particular, the problem of getting `unbox-impl` on every run in several cases related to serialization has been fixed, which will further greatly increase throughput in those cases.

## Breaking change
Due to a change in execution, exceptions thrown by the constructor of `value class` are no longer wrapped in an `InvocationTargetException`.

# Benchmark
The following repository was used for benchmarking:
[k163377/jackson\-value\-class\-benchmark](https://github.com/k163377/jackson-value-class-benchmark/tree/a93ce8933f353f3e5d04a6fe5f17b3f00d6fd49f)

The commits to be compared are f54ef6e(before improvement) and d81fb82(after improvement).

## Benchmark Details
The benchmark should compare performance with and without the aforementioned type-specific optimization.
Additionally, the benchmark was designed to minimize the overall processing done by `Jackson` itself, in order to better isolate and observe the impact of the `MethodHandle` based performance enhancements.

With these considerations in mind, the benchmarks were structured as follows:

- Input/output JSON is kept minimal: single-digit integers and minimal JSON structure
- Benchmark target types have only one property
- Two `value class` types were tested: one wrapping an `Int` (with type-specific optimization), and one wrapping a `Short` (without type-specific optimization)

Since the benefits of this optimization increase with the number of `value class` properties involved, this benchmark serves as a lower bound for the performance improvements achievable in `value class` handling.

However, a preliminary check by `kogera` did not explicitly confirm the effect of type-specific optimizations in this benchmark because the percentage of processing related to `value class` was too low.
This is summarized in the following article(sorry, only in Japanese).
https://wrongwrong163377.hatenablog.com/entry/2025/07/05/175237

Also, `kotlin-module` has lower deserialization performance than `kogera`, so the amount of improvement seen from the benchmark is lower than that of `kogera`.

## Throughput
A ratio greater than 1 indicates improvement.
summarized at: https://docs.google.com/spreadsheets/d/1Qi60pL8SEXJA5dx-CJA_NrON-OahTyb9RM5jDUhVk94

The overall trend is read as an improvement.

### Serialize
In all cases, the scores showed a speedup in all cases.
In particular, the most common case, `unbox.IntBenchmark.wrapped`, showed more than a 2X speedup.

|                                      | 2.20.0-f54ef6e | 2.20.0-d81fb82 | 2.20.0-d81fb82 / 2.20.0-f54ef6e | 
| ------------------------------------ | -------------- | -------------- | ------------------------------- | 
| key.jsonKey.IntBenchmark.benchmark   | 1706154.900296 | 1721112.539959 | 1.008766871                     | 
| key.jsonKey.ShortBenchmark.benchmark | 1698948.371451 | 1753370.740705 | 1.032032974                     | 
| key.unbox.IntBenchmark.benchmark     | 799204.108578  | 1516485.136584 | 1.89749417                      | 
| key.unbox.ShortBenchmark.benchmark   | 548820.103790  | 844800.639366  | 1.539303377                     | 
| jsonValue.IntBenchmark.direct        | 2492853.948175 | 2571880.673728 | 1.031701306                     | 
| jsonValue.IntBenchmark.wrapped       | 1443995.099096 | 1575917.996655 | 1.091359657                     | 
| jsonValue.ShortBenchmark.direct      | 2500459.150115 | 2570723.387372 | 1.028100534                     | 
| jsonValue.ShortBenchmark.wrapped     | 1504655.607564 | 1608109.260028 | 1.068755702                     | 
| unbox.IntBenchmark.direct            | 1334725.665322 | 2947865.011420 | 2.208592438                     | 
| unbox.IntBenchmark.wrapped           | 879039.316159  | 1885195.465026 | 2.144608814                     | 
| unbox.ShortBenchmark.direct          | 1212085.783568 | 2847329.922591 | 2.349115847                     | 
| unbox.ShortBenchmark.wrapped         | 775937.494873  | 1669918.473655 | 2.152130145                     | 

### Deserialize
In all cases, the scores showed a speedup in all cases.
In particular, the most common `byPrimaryConstructor.IntBenchmark.wrapped` case showed an improvement of about 3%.

|                                             | 2.20.0-f54ef6e | 2.20.0-d81fb82 | 2.20.0-d81fb82 / 2.20.0-f54ef6e | 
| ------------------------------------------- | -------------- | -------------- | ------------------------------- | 
| KeyBenchmark._int                           | 668132.908060  | 680694.531489  | 1.018801085                     | 
| KeyBenchmark._short                         | 542229.395140  | 574232.929115  | 1.05902213                      | 
| byJsonCreator.IntBenchmark.direct           | 1453474.420878 | 1573540.213031 | 1.082606058                     | 
| byJsonCreator.IntBenchmark.wrapped          | 651989.179429  | 681764.839236  | 1.045668948                     | 
| byJsonCreator.ShortBenchmark.direct         | 1462410.784333 | 1582137.367836 | 1.081869325                     | 
| byJsonCreator.ShortBenchmark.wrapped        | 663867.442290  | 700544.137815  | 1.055247016                     | 
| byPrimaryConstructor.IntBenchmark.direct    | 1765387.321922 | 1823197.083530 | 1.03274622                      | 
| byPrimaryConstructor.IntBenchmark.wrapped   | 702921.993057  | 721451.216566  | 1.026360284                     | 
| byPrimaryConstructor.ShortBenchmark.direct  | 1541583.072049 | 1607385.550890 | 1.042685004                     | 
| byPrimaryConstructor.ShortBenchmark.wrapped | 661545.715857  | 685665.869853  | 1.036460298                     | 

## Single Shot
A ratio less than 1 indicates improvement.
summarized at: https://docs.google.com/spreadsheets/d/1zAr0zH6AVeOGdWz6WJd5-42jz3FrK1aHR-AmIiVNaaY

Since the amount of initialization processing is increasing, the overall trend can be read as degradation.
However, the amount of degradation itself is at worst about 6%, and in many cases it is less than 3%.

### Serialize
|                                      | 2.20.0-f54ef6e | 2.20.0-d81fb82 | 2.20.0-d81fb82 / 2.20.0-f54ef6e | 
| ------------------------------------ | -------------- | -------------- | ------------------------------- | 
| key.jsonKey.IntBenchmark.benchmark   | 184.196196     | 189.523739     | 1.028923198                     | 
| key.jsonKey.ShortBenchmark.benchmark | 185.018549     | 193.959258     | 1.048323312                     | 
| key.unbox.IntBenchmark.benchmark     | 183.889096     | 186.475984     | 1.014067653                     | 
| key.unbox.ShortBenchmark.benchmark   | 186.652562     | 189.655012     | 1.016085769                     | 
| jsonValue.IntBenchmark.direct        | 169.141279     | 171.238232     | 1.012397642                     | 
| jsonValue.IntBenchmark.wrapped       | 512.207452     | 507.520491     | 0.9908494869                    | 
| jsonValue.ShortBenchmark.direct      | 165.888227     | 175.493462     | 1.057901849                     | 
| jsonValue.ShortBenchmark.wrapped     | 498.692123     | 511.300525     | 1.025282938                     | 
| unbox.IntBenchmark.direct            | 168.211594     | 171.327832     | 1.018525703                     | 
| unbox.IntBenchmark.wrapped           | 498.314552     | 505.338075     | 1.014094557                     | 
| unbox.ShortBenchmark.direct          | 180.360599     | 175.208861     | 0.9714364555                    | 
| unbox.ShortBenchmark.wrapped         | 505.856824     | 504.002529     | 0.9963343482                    | 

### Deserialize
|                                             | 2.20.0-f54ef6e | 2.20.0-d81fb82 | 2.20.0-d81fb82 / 2.20.0-f54ef6e | 
| ------------------------------------------- | -------------- | -------------- | ------------------------------- | 
| KeyBenchmark._int                           | 451.009276     | 454.054573     | 1.006752183                     | 
| KeyBenchmark._short                         | 449.179668     | 457.888895     | 1.019389183                     | 
| byJsonCreator.IntBenchmark.direct           | 181.099398     | 177.060612     | 0.9776985123                    | 
| byJsonCreator.IntBenchmark.wrapped          | 510.137011     | 515.377331     | 1.010272378                     | 
| byJsonCreator.ShortBenchmark.direct         | 180.280929     | 179.065832     | 0.9932599804                    | 
| byJsonCreator.ShortBenchmark.wrapped        | 517.763954     | 527.208727     | 1.018241465                     | 
| byPrimaryConstructor.IntBenchmark.direct    | 441.188473     | 449.284595     | 1.018350711                     | 
| byPrimaryConstructor.IntBenchmark.wrapped   | 514.552782     | 525.378941     | 1.021039939                     | 
| byPrimaryConstructor.ShortBenchmark.direct  | 444.235007     | 453.849633     | 1.021643107                     | 
| byPrimaryConstructor.ShortBenchmark.wrapped | 516.214738     | 529.817651     | 1.026351268                     | 