### PR TITLE
Fixed old `StrictNullChecks` to throw exceptions similar to those thrown by new `StrictNullChecks`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -18,6 +18,7 @@ Contributors:
 # 2.20.0 (not yet released)
 
 WrongWrong (@k163377)
+* #1020: Fixed old StrictNullChecks to throw exceptions similar to those thrown by new StrictNullChecks
 * #1018: Use MethodHandle in processing related to value class
 * #969: Cleanup of deprecated contents
 * #967: Update settings for 2.20

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -17,6 +17,9 @@ Co-maintainers:
 ------------------------------------------------------------------------
 
 2.20.0 (not yet released)
+#1020: Exceptions thrown by the old StrictNullChecks are now the similar to the new StrictNullChecks.
+  This means that the old StrictNullChecks will no longer throw MissingKotlinParameterException.
+  See PR for what is thrown and how error messages change.
 #1018: Improved handling of `value class` has improved performance for both serialization and deserialization.
   In particular, for serialization, proper caching has improved throughput by a factor of 2 or more in the general cases.
   Also, replacing function execution by reflection with `MethodHandle` improved throughput by several percent for both serialization and deserialization.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.deser.ValueInstantiator
 import com.fasterxml.jackson.databind.deser.ValueInstantiators
 import com.fasterxml.jackson.databind.deser.impl.PropertyValueBuffer
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
+import com.fasterxml.jackson.databind.exc.InvalidNullException
 import java.lang.reflect.TypeVariable
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
@@ -103,31 +104,32 @@ internal class KotlinValueInstantiator(
             } else if (strictNullChecks) {
                 val arguments = paramType.arguments
 
-                var paramTypeStr: String? = null
-                var itemType: KType? = null
-
-                if (propType.isCollectionLikeType && arguments.markedNonNullAt(0) && (paramVal as Collection<*>).any { it == null }) {
-                    paramTypeStr = "collection"
-                    itemType = arguments[0].type
+                // To make the behavior the same as deserialization of each element using NullsFailProvider,
+                // first wrapWithPath with paramVal and key.
+                val ex = when {
+                    propType.isCollectionLikeType && arguments.markedNonNullAt(0) -> {
+                        (paramVal as Collection<*>).indexOf(null).takeIf { it >= 0 }?.let {
+                            InvalidNullException.from(ctxt, jsonProp.fullName, jsonProp.type)
+                                .wrapWithPath(paramVal, it)
+                        }
+                    }
+                    propType.isMapLikeType && arguments.markedNonNullAt(1) -> {
+                        (paramVal as Map<*, *>).entries.find { (_, v) -> v == null }?.let { (k, _) ->
+                            InvalidNullException.from(ctxt, jsonProp.fullName, jsonProp.type)
+                                .wrapWithPath(paramVal, k.toString())
+                        }
+                    }
+                    propType.isArrayType && arguments.markedNonNullAt(0) -> {
+                        (paramVal as Array<*>).indexOf(null).takeIf { it >= 0 }?.let {
+                            InvalidNullException.from(ctxt, jsonProp.fullName, jsonProp.type)
+                                .wrapWithPath(paramVal, it)
+                        }
+                    }
+                    else -> null
                 }
 
-                if (propType.isMapLikeType && arguments.markedNonNullAt(1) && (paramVal as Map<*, *>).any { it.value == null }) {
-                    paramTypeStr = "map"
-                    itemType = arguments[1].type
-                }
-
-                if (propType.isArrayType && arguments.markedNonNullAt(0) && (paramVal as Array<*>).any { it == null }) {
-                    paramTypeStr = "array"
-                    itemType = arguments[0].type
-                }
-
-                if (paramTypeStr != null && itemType != null) {
-                    throw MissingKotlinParameterException(
-                        parameter = paramDef,
-                        processor = ctxt.parser,
-                        msg = "Instantiation of $itemType $paramType failed for JSON property ${jsonProp.name} due to null value in a $paramType that does not allow null values"
-                    ).wrapWithPath(this.valueClass, jsonProp.name)
-                }
+                // Then, wrapWithPath with this property.
+                ex?.let { throw it.wrapWithPath(this.valueClass, jsonProp.name) }
             }
 
             bucket[paramDef] = paramVal

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTestOld.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/StrictNullChecksTestOld.kt
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.test
 
+import com.fasterxml.jackson.databind.exc.InvalidNullException
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
-import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -32,7 +32,7 @@ class StrictNullChecksTestOld {
 
     @Test
     fun testListOfInt() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<ClassWithListOfInt>(json)
         }
@@ -62,7 +62,7 @@ class StrictNullChecksTestOld {
 
     @Test
     fun testArrayOfInt() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<ClassWithArrayOfInt>(json)
         }
@@ -92,7 +92,7 @@ class StrictNullChecksTestOld {
 
     @Test
     fun testMapOfStringToIntWithNullValue() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{ "samples": { "key": null } }"""
             mapper.readValue<ClassWithMapOfStringToInt>(json)
         }
@@ -121,7 +121,7 @@ class StrictNullChecksTestOld {
     @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testListOfGenericWithNullValue() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<TestClass<List<Int>>>(json)
         }
@@ -137,7 +137,7 @@ class StrictNullChecksTestOld {
     @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testMapOfGenericWithNullValue() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{ "samples": { "key": null } }"""
             mapper.readValue<TestClass<Map<String, Int>>>(json)
         }
@@ -153,7 +153,7 @@ class StrictNullChecksTestOld {
     @Disabled // this is a hard problem to solve and is currently not addressed
     @Test
     fun testArrayOfGenericWithNullValue() {
-        assertThrows<MissingKotlinParameterException> {
+        assertThrows<InvalidNullException> {
             val json = """{"samples":[1, null]}"""
             mapper.readValue<TestClass<Array<Int>>>(json)
         }


### PR DESCRIPTION
To deprecate the old `StrictNullChecks` option, changes were made to make the exceptions thrown by the old process the similar to the new `StrictNullChecks`.
This means that the old `StrictNullChecks` will no longer throw `MissingKotlinParameterException`.

In the situation where this error occurs, it was inappropriate to use `MissingKotlinParameterException` because the input was not missing.
This is also relevant for #617.

---

The following is a comparison of the respective messages displayed when `printStackTrace` is performed on the result of `assertThrows` for `com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTest`(NewStrictNullChecks) and `StrictNullChecksTestOld`.
As for messages, it has been improved so that even the key of a value that was `null` can be checked.

#### ClassWithArrayOfInt
##### NewStrictNullChecks
```
com.fasterxml.jackson.databind.exc.InvalidNullException: Invalid `null` value encountered for property "samples"
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 16] (through reference chain: com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTest$ClassWithArrayOfInt["samples"]->java.lang.Object[][1])
```

##### Fixed old `StrictNullChecks`
```
com.fasterxml.jackson.databind.exc.InvalidNullException: Invalid `null` value encountered for property "samples"
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 21] (through reference chain: com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTestOld$ClassWithArrayOfInt["samples"]->java.lang.Integer[][1])
```

##### Conventional old `StrictNullChecks`
```
com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of kotlin.Int kotlin.Array<kotlin.Int> failed for JSON property samples due to null value in a kotlin.Array<kotlin.Int> that does not allow null values
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 21] (through reference chain: com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTestOld$ClassWithArrayOfInt["samples"])
```

#### ClassWithListOfInt
##### NewStrictNullChecks
```
com.fasterxml.jackson.databind.exc.InvalidNullException: Invalid `null` value encountered for property "samples"
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 16] (through reference chain: com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTest$ClassWithListOfInt["samples"]->java.util.ArrayList[1])
```

##### Fixed old `StrictNullChecks`
```
com.fasterxml.jackson.databind.exc.InvalidNullException: Invalid `null` value encountered for property "samples"
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 21] (through reference chain: com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTestOld$ClassWithListOfInt["samples"]->java.util.ArrayList[1])
```

##### Conventional old `StrictNullChecks`
```
com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of kotlin.Int kotlin.collections.List<kotlin.Int> failed for JSON property samples due to null value in a kotlin.collections.List<kotlin.Int> that does not allow null values
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 21] (through reference chain: com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTestOld$ClassWithListOfInt["samples"])
```

#### ClassWithMapOfStringToInt
##### NewStrictNullChecks
```
com.fasterxml.jackson.databind.exc.InvalidNullException: Invalid `null` value encountered for property "samples"
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 23] (through reference chain: com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTest$ClassWithMapOfStringToInt["samples"]->java.util.LinkedHashMap["key"])
```

##### Fixed old `StrictNullChecks`
```
com.fasterxml.jackson.databind.exc.InvalidNullException: Invalid `null` value encountered for property "samples"
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 30] (through reference chain: com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTestOld$ClassWithMapOfStringToInt["samples"]->java.util.LinkedHashMap["key"])
```

##### Conventional old `StrictNullChecks`
```
com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of kotlin.Int kotlin.collections.Map<kotlin.String, kotlin.Int> failed for JSON property samples due to null value in a kotlin.collections.Map<kotlin.String, kotlin.Int> that does not allow null values
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 30] (through reference chain: com.fasterxml.jackson.module.kotlin.test.StrictNullChecksTestOld$ClassWithMapOfStringToInt["samples"])
```