### PR TITLE
Remove ref to `ObjectMapper.readValue(URL, type)` (wrt databind/5263)

### DIFF
--- a/src/main/kotlin/tools/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/tools/jackson/module/kotlin/Extensions.kt
@@ -107,13 +107,6 @@ inline fun <reified T> ObjectMapper.readValue(src: File): T = readValue(src, jac
  *   Other cases where the read value is of a different type than [T]
  *   due to an incorrect customization to [ObjectMapper].
  */
-inline fun <reified T> ObjectMapper.readValue(src: URL): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
-/**
- * Shorthand for [ObjectMapper.readValue].
- * @throws DatabindException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
- */
 inline fun <reified T> ObjectMapper.readValue(content: String): T = readValue(content, jacksonTypeRef<T>())
     .checkTypeMismatch()
 /**


### PR DESCRIPTION
Change to sync with https://github.com/FasterXML/jackson-databind/issues/5263
