### PR TITLE
Fix #1051

### DIFF
--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github722.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/github/Github722.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class Github722 {
-    data class FailingDto @JsonCreator constructor(
+    data class FailingDto(
         @JacksonInject("foo")
         @JsonProperty("foo")
         val foo: Int = 100,


### PR DESCRIPTION
As a result of setting default arguments for all arguments, a no-argument constructor was generated, and an error occurred because multiple JsonCreator instances were defined.