### PR TITLE
Update Java version in WFs

### DIFF
--- a/.github/workflows/dep_build_v2.yml
+++ b/.github/workflows/dep_build_v2.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: ['8', '17', '21', '24']
+        java_version: ['8', '17', '21', '25']
         # Versions need to align with ones in 'main.yml' workflow
         kotlin_version: ['2.1.21', '2.2.20']
     env:

--- a/.github/workflows/dep_build_v3.yml
+++ b/.github/workflows/dep_build_v3.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: ['17', '21', '24']
+        java_version: ['17', '21', '25']
         # Versions need to align with ones in 'main.yml' workflow
         kotlin_version: ['2.1.21', '2.2.20']
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        java_version: ['8', '11', '17', '21', '24']
+        java_version: ['8', '11', '17', '21', '25']
         kotlin_version: ['2.1.21', '2.2.20']
         include:
           - java_version: '8'


### PR DESCRIPTION
Since it fails in Kotlin 2.0.x, Java 25 checks will be performed in Kotlin 2.1.x and later.
https://youtrack.jetbrains.com/issue/KT-73967