### PR TITLE
Minor change to test for #56: annotations needed due to https://github.com/FasterXML/jackson-databind/pull/5466

### DIFF
--- a/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github56.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github56.kt
@@ -11,6 +11,8 @@ class TestGithub56 {
     data class TestGalleryWidget_BAD(
             val widgetReferenceId: String,
             // IMPORTANT! Need _at least_ @get one (@param optional, not sufficient)
+            // (see https://github.com/FasterXML/jackson-databind/pull/5466 for change
+            // that made this necessary in 3.1 )
             @get:JsonUnwrapped var gallery: TestGallery
     )
 

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github56.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/github/Github56.kt
@@ -10,7 +10,8 @@ import kotlin.test.assertEquals
 class TestGithub56 {
     data class TestGalleryWidget_BAD(
             val widgetReferenceId: String,
-            @JsonUnwrapped var gallery: TestGallery
+            // IMPORTANT! Need _at least_ @get one (@param optional, not sufficient)
+            @get:JsonUnwrapped var gallery: TestGallery
     )
 
     data class TestGalleryWidget_GOOD(val widgetReferenceId: String) {


### PR DESCRIPTION
So: while unfortunate wrt compatibility, databind fix for https://github.com/FasterXML/jackson-databind/issues/5115 requires small change to use of `@JsonUnwrapped` from Kotlin. At least until/unless further fix found that works for both usages.

This PR adds minimal annotation tweak to make #56 test pass. I will also add a test on databind side to catch future regressions.
