### PR TITLE
Update deprecation message

### DIFF
--- a/src/main/kotlin/tools/jackson/module/kotlin/KotlinFeature.kt
+++ b/src/main/kotlin/tools/jackson/module/kotlin/KotlinFeature.kt
@@ -86,7 +86,7 @@ enum class KotlinFeature(internal val enabledByDefault: Boolean) {
      */
     @Deprecated(
         level = DeprecationLevel.WARNING,
-        message = "This option will be merged into StrictNullChecks in 2.23.",
+        message = "This option will be merged into StrictNullChecks in 3.2.",
         replaceWith = ReplaceWith("StrictNullChecks")
     )
     NewStrictNullChecks(enabledByDefault = false);


### PR DESCRIPTION
Because Jackson migrated to 3.x.
Since 2.21 corresponds to 3.0, 2.23 corresponds to 3.2.