### PR TITLE
Remove unnecessary suppression

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -76,7 +76,6 @@ class KotlinModule private constructor(
         builder.isEnabled(NullToEmptyMap),
         builder.isEnabled(NullIsSameAsDefault),
         builder.isEnabled(SingletonSupport),
-        @Suppress("DEPRECATION_ERROR")
         builder.isEnabled(StrictNullChecks),
         builder.isEnabled(KotlinPropertyNameAsImplicitName),
         builder.isEnabled(UseJavaDurationConversion),


### PR DESCRIPTION
The deprecation removal for migration to StrictNullChecks was not reflected.