### PR TITLE
Add extension functions for JsonMapper

### DIFF
--- a/src/main/kotlin/tools/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/tools/jackson/module/kotlin/Extensions.kt
@@ -152,6 +152,84 @@ inline fun <reified T> ObjectMapper.convertValue(from: Any?): T = convertValue(f
     .checkTypeMismatch()
 
 /**
+ * Shorthand for [JsonMapper.readValue].
+ * @throws DatabindException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [JsonMapper].
+ */
+inline fun <reified T> JsonMapper.readValue(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
+    .checkTypeMismatch()
+/**
+ * Shorthand for [JsonMapper.readValues].
+ * @throws DatabindException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [JsonMapper].
+ */
+inline fun <reified T> JsonMapper.readValues(jp: JsonParser): MappingIterator<T> {
+    val values = readValues(jp, jacksonTypeRef<T>())
+
+    return object : MappingIterator<T>(values) {
+        override fun nextValue(): T = super.nextValue().checkTypeMismatch()
+    }
+}
+
+/**
+ * Shorthand for [JsonMapper.readValue].
+ * @throws DatabindException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [JsonMapper].
+ */
+inline fun <reified T> JsonMapper.readValue(src: File): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
+/**
+ * Shorthand for [JsonMapper.readValue].
+ * @throws DatabindException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [JsonMapper].
+ */
+inline fun <reified T> JsonMapper.readValue(content: String): T = readValue(content, jacksonTypeRef<T>())
+    .checkTypeMismatch()
+/**
+ * Shorthand for [JsonMapper.readValue].
+ * @throws DatabindException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [JsonMapper].
+ */
+inline fun <reified T> JsonMapper.readValue(src: Reader): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
+/**
+ * Shorthand for [JsonMapper.readValue].
+ * @throws DatabindException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [JsonMapper].
+ */
+inline fun <reified T> JsonMapper.readValue(src: InputStream): T = readValue(src, jacksonTypeRef<T>())
+    .checkTypeMismatch()
+/**
+ * Shorthand for [JsonMapper.readValue].
+ * @throws DatabindException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [JsonMapper].
+ */
+inline fun <reified T> JsonMapper.readValue(src: ByteArray): T = readValue(src, jacksonTypeRef<T>())
+    .checkTypeMismatch()
+
+/**
+ * Shorthand for [JsonMapper.readValue].
+ * @throws DatabindException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [JsonMapper].
+ */
+inline fun <reified T> JsonMapper.treeToValue(n: JsonNode): T = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
+    .checkTypeMismatch()
+/**
+ * Shorthand for [JsonMapper.convertValue].
+ * @throws DatabindException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [JsonMapper].
+ */
+inline fun <reified T> JsonMapper.convertValue(from: Any?): T = convertValue(from, jacksonTypeRef<T>())
+    .checkTypeMismatch()
+
+/**
  * Shorthand for [ObjectReader.readValue].
  * @throws DatabindException Especially if [T] is non-null and the value read is null.
  *   Other cases where the read value is of a different type than [T]

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/ExtensionMethodsTests.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/ExtensionMethodsTests.kt
@@ -14,6 +14,7 @@ import tools.jackson.module.kotlin.contains
 import tools.jackson.module.kotlin.convertValue
 import tools.jackson.module.kotlin.jacksonMapperBuilder
 import tools.jackson.module.kotlin.jsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 import tools.jackson.module.kotlin.minusAssign
 import tools.jackson.module.kotlin.plusAssign
 import tools.jackson.module.kotlin.readValue
@@ -116,5 +117,51 @@ private class TestExtensionMethods {
         val serializedPerson: String = mapper.writeValueAsString(Person("test"))
 
         assertEquals("", serializedPerson)
+    }
+
+    @Test
+    fun testJsonMapperReadValue() {
+        data class Person(val name: String, val age: Int)
+
+        val jsonMapper: JsonMapper = jsonMapper { addModule(kotlinModule()) }
+        val json = """{"name":"Abuzer Komurcu","age":25}"""
+
+        val inferRightSide = jsonMapper.readValue<Person>(json)
+        val inferLeftSide: Person = jsonMapper.readValue(json)
+
+        val expectedPerson = Person("Abuzer Komurcu", 25)
+
+        assertEquals(expectedPerson, inferRightSide)
+        assertEquals(expectedPerson, inferLeftSide)
+    }
+
+    @Test
+    fun testJsonMapperReadValueList() {
+        data class Item(val a: String, val b: Int)
+
+        val jsonMapper: JsonMapper = jsonMapper { addModule(kotlinModule()) }
+        val jsonStr = """[{"a": "value1", "b": 1}, {"a": "value2", "b": 2}]"""
+
+        val myList: List<Item> = jsonMapper.readValue(jsonStr)
+
+        assertEquals(listOf(Item("value1", 1), Item("value2", 2)), myList)
+    }
+
+    @Test
+    fun testJsonMapperTreeToValueAndConvertValue() {
+        data class Person(val name: String)
+
+        val jsonMapper: JsonMapper = jsonMapper { addModule(kotlinModule()) }
+        val source = """[ { "name" : "Neo" } ]"""
+        val tree = jsonMapper.readTree(source)
+
+        val readValueResult: List<Person> = jsonMapper.readValue(source)
+        assertEquals(listOf(Person("Neo")), readValueResult)
+
+        val treeToValueResult: List<Person> = jsonMapper.treeToValue(tree)
+        assertEquals(listOf(Person("Neo")), treeToValueResult)
+
+        val convertValueResult: List<Person> = jsonMapper.convertValue(tree)
+        assertEquals(listOf(Person("Neo")), convertValueResult)
     }
 }


### PR DESCRIPTION
## Add extension functions for JsonMapper

### Summary
This PR adds reified type extension functions for `JsonMapper`, similar to the existing ones for `ObjectMapper`.

### Changes
- Added the following extension functions for `JsonMapper`:
  - `readValue(jp: JsonParser): T`
  - `readValues(jp: JsonParser): MappingIterator<T>`
  - `readValue(src: File): T`
  - `readValue(content: String): T`
  - `readValue(src: Reader): T`
  - `readValue(src: InputStream): T`
  - `readValue(src: ByteArray): T`
  - `treeToValue(n: JsonNode): T`
  - `convertValue(from: Any?): T`

- Added unit tests for the new extension functions

### Motivation
Spring Boot 4 will use Jackson 3.x, where `JsonMapper` is the recommended entry point for JSON processing instead of `ObjectMapper`. As more Kotlin developers adopt Spring Boot 4, they will primarily work with `JsonMapper` instances. Having dedicated extension functions for `JsonMapper` ensures a smooth developer experience with proper IDE support and type inference, without relying on inheritance from `ObjectMapper`.

### Example Usage
val mapper: JsonMapper = jsonMapper { addModule(kotlinModule()) }
val person: Person = mapper.readValue(jsonString)
val tree = mapper.readTree(source)
val result: List<Person> = mapper.treeToValue(tree)
