### PR TITLE
Remove NewStrictNullChecks option

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -17,6 +17,10 @@ Authors:
 
 Contributors:
 
+# 3.2.0 (not yet released)
+
+* #1113: Remove NewStrictNullChecks option
+
 # 3.1.0 (23-Feb-2026)
 
 WrongWrong (@k163377)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -24,7 +24,7 @@ Former maintainers:
 
 3.2.0 (not yet released)
 
-No changes since 3.1
+#1113: The deprecated `NewStrictNullChecks` option has been removed and unified under the `StrictNullChecks` option.
 
 3.1.0 (23-Feb-2026)
 

--- a/src/main/kotlin/tools/jackson/module/kotlin/KotlinFeature.kt
+++ b/src/main/kotlin/tools/jackson/module/kotlin/KotlinFeature.kt
@@ -73,23 +73,7 @@ enum class KotlinFeature(internal val enabledByDefault: Boolean) {
      * `@JsonFormat` annotations need to be declared either on getter using `@get:JsonFormat` or field using `@field:JsonFormat`.
      * See [jackson-module-kotlin#651] for details.
      */
-    UseJavaDurationConversion(enabledByDefault = false),
-
-    /**
-     * New [StrictNullChecks] feature with improved throughput.
-     * Internally, it will be the same as if [JsonSetter] (contentNulls = FAIL) had been granted.
-     * Benchmarks show that it can check for illegal nulls with throughput nearly identical to the default (see [jackson-module-kotlin#719]).
-     *
-     * This is a temporary option for a phased backend migration,
-     * which will eventually be merged into [StrictNullChecks].
-     * Also, specifying both this and [StrictNullChecks] is not permitted.
-     */
-    @Deprecated(
-        level = DeprecationLevel.ERROR,
-        message = "This option will be merged into StrictNullChecks in 3.2.",
-        replaceWith = ReplaceWith("StrictNullChecks")
-    )
-    NewStrictNullChecks(enabledByDefault = false);
+    UseJavaDurationConversion(enabledByDefault = false);
 
     internal val bitSet: BitSet = (1 shl ordinal).toBitSet()
 

--- a/src/main/kotlin/tools/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/tools/jackson/module/kotlin/KotlinModule.kt
@@ -34,23 +34,10 @@ class KotlinModule private constructor(
     val nullToEmptyMap: Boolean = NullToEmptyMap.enabledByDefault,
     val nullIsSameAsDefault: Boolean = NullIsSameAsDefault.enabledByDefault,
     val singletonSupport: Boolean = SingletonSupport.enabledByDefault,
-    strictNullChecks: Boolean = StrictNullChecks.enabledByDefault,
+    val strictNullChecks: Boolean = StrictNullChecks.enabledByDefault,
     val kotlinPropertyNameAsImplicitName: Boolean = KotlinPropertyNameAsImplicitName.enabledByDefault,
     val useJavaDurationConversion: Boolean = UseJavaDurationConversion.enabledByDefault,
-    @Suppress("DEPRECATION_ERROR")
-    newStrictNullChecks: Boolean = NewStrictNullChecks.enabledByDefault,
 ) : SimpleModule(KotlinModule::class.java.name, PackageVersion.VERSION) {
-    // To reduce the amount of destructive changes, no properties will be added to the public.
-    val strictNullChecks: Boolean = if (strictNullChecks) {
-        if (newStrictNullChecks) {
-            throw IllegalArgumentException("Enabling both StrictNullChecks and NewStrictNullChecks is not permitted.")
-        }
-
-        true
-    } else {
-        newStrictNullChecks
-    }
-
     companion object {
         // Increment when option is added
         private const val serialVersionUID = 3L
@@ -71,8 +58,6 @@ class KotlinModule private constructor(
         builder.isEnabled(StrictNullChecks),
         builder.isEnabled(KotlinPropertyNameAsImplicitName),
         builder.isEnabled(UseJavaDurationConversion),
-        @Suppress("DEPRECATION_ERROR")
-        builder.isEnabled(NewStrictNullChecks),
     )
 
     override fun setupModule(context: SetupContext) {

--- a/src/test/kotlin/tools/jackson/module/kotlin/KotlinModuleTest.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/KotlinModuleTest.kt
@@ -4,10 +4,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import tools.jackson.databind.json.JsonMapper
 import tools.jackson.module.kotlin.KotlinFeature.KotlinPropertyNameAsImplicitName
-import tools.jackson.module.kotlin.KotlinFeature.NewStrictNullChecks
 import tools.jackson.module.kotlin.KotlinFeature.NullIsSameAsDefault
 import tools.jackson.module.kotlin.KotlinFeature.NullToEmptyCollection
 import tools.jackson.module.kotlin.KotlinFeature.NullToEmptyMap
@@ -17,27 +15,6 @@ import tools.jackson.module.kotlin.KotlinFeature.UseJavaDurationConversion
 import kotlin.test.assertNotNull
 
 class KotlinModuleTest {
-    // After the final migration is complete, this test will be removed.
-    @Test
-    fun strictNullChecksTests() {
-        assertTrue(
-            kotlinModule {
-                @Suppress("DEPRECATION_ERROR")
-                disable(NewStrictNullChecks)
-                enable(StrictNullChecks)
-            }.strictNullChecks
-        )
-        assertTrue(kotlinModule { enable(StrictNullChecks) }.strictNullChecks)
-
-        assertThrows<IllegalArgumentException> {
-            kotlinModule {
-                enable(StrictNullChecks)
-                @Suppress("DEPRECATION_ERROR")
-                enable(NewStrictNullChecks)
-            }
-        }
-    }
-
     @Test
     fun builder_Defaults() {
         val module = KotlinModule.Builder().build()


### PR DESCRIPTION
This completes the replacement for the `StrictNullChecks` option.