### PR TITLE
Allow null contents for use-site `in` projections in StrictNullChecks

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -18,6 +18,11 @@ Authors:
 
 Contributors:
 
+# 3.2.2 (not yet released)
+
+WrongWrong (@k163377)
+* #1191: Allow null contents for use-site in projections in StrictNullChecks
+
 # 3.2.0 (08-Jun-2026)
 
 Dmitry Sulman (@dmitrysulman)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -26,6 +26,12 @@ Former maintainers:
 
 No changes since 3.2
 
+3.2.2 (not yet released)
+
+#1191: Fixed a problem where null contents in use-site `in` projected positions (e.g. `Array<in String>`)
+ were rejected by `StrictNullChecks` even though they may contain null
+ regardless of the nullability of the type argument.
+
 3.2.1 (10-Jul-2026)
 
 No changes since 3.2.1

--- a/src/main/kotlin/tools/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/tools/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -26,6 +26,7 @@ import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
+import kotlin.reflect.KVariance
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.hasAnnotation
@@ -223,7 +224,18 @@ internal class KotlinNamesAnnotationIntrospector(
     }
 }
 
-private fun KParameter.markedNonNullAt(index: Int) = type.arguments.getOrNull(index)?.type?.isMarkedNullable == false
+private fun KParameter.markedNonNullAt(index: Int): Boolean {
+    val projection = type.arguments.getOrNull(index) ?: return false
+
+    // Contents in a use-site `in` projected position are not checked
+    // because null may be entered regardless of the nullability of the type argument
+    // (e.g. Array<in String> may actually be Array<Any?>).
+    return if (projection.variance == KVariance.IN) {
+        false
+    } else {
+        projection.type?.isMarkedNullable == false
+    }
+}
 
 private fun KParameter.requireStrictNullCheck(type: JavaType): Boolean =
     ((type.isArrayType || type.isCollectionLikeType) && this.markedNonNullAt(0)) ||

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/StrictNullChecksTest.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/StrictNullChecksTest.kt
@@ -165,12 +165,11 @@ class StrictNullChecksTest {
 
     @Test
     fun testInProjectionArray() {
-        // The check is applied regardless of the variance, so null contents are rejected
-        // even though Array<in String> may actually be Array<Any?>.
-        assertThrows<InvalidNullException> {
-            val json = """{"samples":["str", null]}"""
-            mapper.readValue<ClassWithInProjectionArray>(json)
-        }
+        // Null contents for an in projection are allowed regardless of the nullability
+        // of the type argument because Array<in String> may actually be Array<Any?>.
+        val json = """{"samples":["str", null]}"""
+        val stateObj = mapper.readValue<ClassWithInProjectionArray>(json)
+        assertEquals(listOf("str", null), stateObj.samples.toList())
     }
 
     private data class ClassWithNullableInProjectionArray(val samples: Array<in String?>)
@@ -187,19 +186,17 @@ class StrictNullChecksTest {
 
     @Test
     fun testInProjectionList() {
-        assertThrows<InvalidNullException> {
-            val json = """{"samples":["str", null]}"""
-            mapper.readValue<ClassWithInProjectionList>(json)
-        }
+        val json = """{"samples":["str", null]}"""
+        val stateObj = mapper.readValue<ClassWithInProjectionList>(json)
+        assertEquals(listOf("str", null), stateObj.samples.toList())
     }
 
     private data class ClassWithInProjectionMap(val samples: MutableMap<String, in Int>)
 
     @Test
     fun testInProjectionMapValue() {
-        assertThrows<InvalidNullException> {
-            val json = """{ "samples": { "key": null } }"""
-            mapper.readValue<ClassWithInProjectionMap>(json)
-        }
+        val json = """{ "samples": { "key": null } }"""
+        val stateObj = mapper.readValue<ClassWithInProjectionMap>(json)
+        assertEquals(mapOf<String, Int?>("key" to null), stateObj.samples.toMap())
     }
 }

--- a/src/test/kotlin/tools/jackson/module/kotlin/test/StrictNullChecksTest.kt
+++ b/src/test/kotlin/tools/jackson/module/kotlin/test/StrictNullChecksTest.kt
@@ -158,4 +158,48 @@ class StrictNullChecksTest {
             mapper.readValue<TestClass<Array<Int>>>(json)
         }
     }
+
+    /** use-site projection tests */
+
+    private data class ClassWithInProjectionArray(val samples: Array<in String>)
+
+    @Test
+    fun testInProjectionArray() {
+        // The check is applied regardless of the variance, so null contents are rejected
+        // even though Array<in String> may actually be Array<Any?>.
+        assertThrows<InvalidNullException> {
+            val json = """{"samples":["str", null]}"""
+            mapper.readValue<ClassWithInProjectionArray>(json)
+        }
+    }
+
+    private data class ClassWithNullableInProjectionArray(val samples: Array<in String?>)
+
+    @Test
+    fun testNullableInProjectionArray() {
+        // If the projected type is marked nullable, the check is not applied.
+        val json = """{"samples":["str", null]}"""
+        val stateObj = mapper.readValue<ClassWithNullableInProjectionArray>(json)
+        assertEquals(listOf("str", null), stateObj.samples.toList())
+    }
+
+    private data class ClassWithInProjectionList(val samples: MutableList<in String>)
+
+    @Test
+    fun testInProjectionList() {
+        assertThrows<InvalidNullException> {
+            val json = """{"samples":["str", null]}"""
+            mapper.readValue<ClassWithInProjectionList>(json)
+        }
+    }
+
+    private data class ClassWithInProjectionMap(val samples: MutableMap<String, in Int>)
+
+    @Test
+    fun testInProjectionMapValue() {
+        assertThrows<InvalidNullException> {
+            val json = """{ "samples": { "key": null } }"""
+            mapper.readValue<ClassWithInProjectionMap>(json)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Contents in a use-site `in` projected position (e.g. `Array<in String>`) may contain `null` regardless of the nullability of the type argument, since the actual runtime type may be `Array<Any?>`. `StrictNullChecks` rejected such contents anyway, which was a false positive: a value legally constructed without any unchecked casts could not be round-tripped through serialize/deserialize.

## Changes
1. Add tests to `StrictNullChecksTest` covering contents in use-site projected positions (`in`, `out`, star), asserting the pre-fix behavior.
2. Fix `markedNonNullAt` in `KotlinNamesAnnotationIntrospector` to skip the null check when the projection's variance is `KVariance.IN`, and flip the affected test expectations accordingly. Also documents this in the `StrictNullChecks` KDoc.

Based on `3.2` since this is a bugfix of limited scope.

## Test plan
- `mvnw clean test` -- 710 tests, BUILD SUCCESS