### PR TITLE
Improved KDoc of read functions to clarify Kotlin null safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,39 @@ arrayNode += "bar".toByteArray()
 println(arrayNode.toString()) // ["foo",true,1,1.0,"YmFy"]
 ```
 
+## Shorthands for deserialization
+Shorthands for the deserialization methods of `ObjectMapper` and `ObjectReader` are provided as extension functions.  
+Since their type parameters are reified, `Class` and `TypeReference` do not need to be passed explicitly.
+
+| Receiver       | Shorthands                                               |
+|----------------|----------------------------------------------------------|
+| `ObjectMapper` | `readValue`, `readValues`, `treeToValue`, `convertValue` |
+| `ObjectReader` | `readValueTyped`, `readValuesTyped`, `treeToValue`       |
+
+`ObjectMapper.readValue` accepts the same sources as the original,
+namely `JsonParser`, `File`, `URL`, `String`, `Reader`, `InputStream` and `ByteArray`.
+
+Note that these are not merely shorthands: since 2.19.0,
+most of them check the deserialized value to preserve `Kotlin` null safety.  
+If a `null` is deserialized while the reified type is non-null,
+`RuntimeJsonMappingException` is thrown instead of returning it.
+
+```kotlin
+// Throws RuntimeJsonMappingException, because String is non-null but null was deserialized
+mapper.readValue<String>("null")
+
+// Returns null, because the reified type is nullable
+mapper.readValue<String?>("null")
+```
+
+The same check also detects values whose type is unrelated to the reified type,
+which indicates that `ObjectMapper` is incorrectly customized.
+
+For `readValues` / `readValuesTyped`, the check is applied to each value by the returned iterator,
+so the exception is thrown from `next()` / `nextValue()` rather than from the function itself.  
+`ObjectReader.treeToValue` is the only function that does not perform the check
+and declares a nullable return type instead.
+
 # Compatibility
 ## Kotlin
 (NOTE: incomplete! Please submit corrections/additions via PRs!)

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -15,6 +15,11 @@ Authors:
 
 Contributors:
 
+# 2.21.6 (not yet released)
+
+WrongWrong (@k163377)
+* #1192: Improved KDoc of read functions to clarify Kotlin null safety
+
 # 2.21.2 (20-Mar-2026)
 
 WrongWrong (@k163377)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,12 @@ Co-maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.21.6 (not yet released)
+
+#1192: Improved documentation for the shorthands of deserialization methods.
+  The KDoc and README now state that most of them check the deserialized value
+  to preserve `Kotlin` null safety.
+
 2.21.5 (06-Jul-2026)
 2.21.4 (28-May-2026)
 2.21.3 (28-Apr-2026)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/Extensions.kt
@@ -73,18 +73,24 @@ internal inline fun <reified T> Any?.checkTypeMismatch(): T {
 }
 
 /**
- * Shorthand for [ObjectMapper.readValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.readValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was deserialized.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the deserialized value is of a type unrelated to [T],
+ *   which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.readValue(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
     .checkTypeMismatch()
+
 /**
- * Shorthand for [ObjectMapper.readValues].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.readValues], whose iterator additionally preserves `Kotlin` null safety.
+ *
+ * Note that this function itself never throws;
+ * the check is performed per value, so [RuntimeJsonMappingException] is thrown from
+ * [MappingIterator.next] / [MappingIterator.nextValue] if [T] is non-null but `null` was deserialized.
+ * It is also thrown if the deserialized value is of a type unrelated to [T],
+ * which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.readValues(jp: JsonParser): MappingIterator<T> {
     val values = readValues(jp, jacksonTypeRef<T>())
@@ -95,81 +101,109 @@ inline fun <reified T> ObjectMapper.readValues(jp: JsonParser): MappingIterator<
 }
 
 /**
- * Shorthand for [ObjectMapper.readValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.readValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was deserialized.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the deserialized value is of a type unrelated to [T],
+ *   which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.readValue(src: File): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
+
 /**
- * Shorthand for [ObjectMapper.readValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.readValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was deserialized.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the deserialized value is of a type unrelated to [T],
+ *   which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.readValue(src: URL): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
+
 /**
- * Shorthand for [ObjectMapper.readValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.readValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was deserialized.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the deserialized value is of a type unrelated to [T],
+ *   which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.readValue(content: String): T = readValue(content, jacksonTypeRef<T>())
     .checkTypeMismatch()
+
 /**
- * Shorthand for [ObjectMapper.readValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.readValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was deserialized.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the deserialized value is of a type unrelated to [T],
+ *   which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.readValue(src: Reader): T = readValue(src, jacksonTypeRef<T>()).checkTypeMismatch()
+
 /**
- * Shorthand for [ObjectMapper.readValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.readValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was deserialized.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the deserialized value is of a type unrelated to [T],
+ *   which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.readValue(src: InputStream): T = readValue(src, jacksonTypeRef<T>())
     .checkTypeMismatch()
+
 /**
- * Shorthand for [ObjectMapper.readValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.readValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was deserialized.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the deserialized value is of a type unrelated to [T],
+ *   which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.readValue(src: ByteArray): T = readValue(src, jacksonTypeRef<T>())
     .checkTypeMismatch()
 
 /**
- * Shorthand for [ObjectMapper.readValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.treeToValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was deserialized.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the deserialized value is of a type unrelated to [T],
+ *   which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.treeToValue(n: TreeNode): T = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
     .checkTypeMismatch()
+
 /**
- * Shorthand for [ObjectMapper.convertValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectMapper].
+ * Shorthand for [ObjectMapper.convertValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was converted.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the converted value is of a type unrelated to [T],
+ *   which indicates that [ObjectMapper] is incorrectly customized.
  */
 inline fun <reified T> ObjectMapper.convertValue(from: Any?): T = convertValue(from, jacksonTypeRef<T>())
     .checkTypeMismatch()
 
 /**
- * Shorthand for [ObjectReader.readValue].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectReader].
+ * Shorthand for [ObjectReader.readValue], which additionally preserves `Kotlin` null safety.
+ *
+ * @throws RuntimeJsonMappingException if [T] is non-null but `null` was deserialized.
+ *   Returning it as-is would silently break null safety, so it is reported as an error instead.
+ *   Also thrown if the deserialized value is of a type unrelated to [T],
+ *   which indicates that [ObjectReader] is incorrectly customized.
  */
 inline fun <reified T> ObjectReader.readValueTyped(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
     .checkTypeMismatch()
+
 /**
- * Shorthand for [ObjectReader.readValues].
- * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
- *   Other cases where the read value is of a different type than [T]
- *   due to an incorrect customization to [ObjectReader].
+ * Shorthand for [ObjectReader.readValues], whose iterator additionally preserves `Kotlin` null safety.
+ *
+ * Note that this function itself never throws;
+ * the check is performed per value, so [RuntimeJsonMappingException] is thrown from
+ * [Iterator.next] if [T] is non-null but `null` was deserialized.
+ * It is also thrown if the deserialized value is of a type unrelated to [T],
+ * which indicates that [ObjectReader] is incorrectly customized.
  */
 inline fun <reified T> ObjectReader.readValuesTyped(jp: JsonParser): Iterator<T> {
     val values = readValues(jp, jacksonTypeRef<T>())
@@ -178,6 +212,14 @@ inline fun <reified T> ObjectReader.readValuesTyped(jp: JsonParser): Iterator<T>
         override fun next(): T = values.next().checkTypeMismatch<T>()
     }
 }
+
+/**
+ * Shorthand for [ObjectReader.treeToValue].
+ *
+ * Unlike the other extensions in this file, this function does **not** preserve `Kotlin` null safety.
+ * Instead of throwing, it declares a nullable return type,
+ * so `null` may be returned even if [T] is non-null.
+ */
 inline fun <reified T> ObjectReader.treeToValue(n: TreeNode): T? = readValue(this.treeAsTokens(n), jacksonTypeRef<T>())
 
 inline fun <reified T, reified U> ObjectMapper.addMixIn(): ObjectMapper = this.addMixIn(T::class.java, U::class.java)


### PR DESCRIPTION
The KDoc of `readValue` and other deserialization shorthands described them only as shorthands for `ObjectMapper` methods, so the check added in 2.19.0 by #937 (#399) was hard to notice.
Reworded it to state preserving `Kotlin` null safety as its purpose.

The following were also fixed:

- `readValues` / `readValuesTyped` documented the throw on the function itself, though it is actually performed by the returned iterator.
- `ObjectReader.treeToValue` had no KDoc, even though it is the only function that does not perform the check.
- `ObjectMapper.treeToValue` referred to `ObjectMapper.readValue`.

Additionally, as a side note, a `Shorthands for deserialization` section was added to the README usage, which previously listed neither what is provided nor the checks some of them perform.

This PR contains no functional changes.
