### PR TITLE
Add release notes for #1192 to 3.x

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -21,6 +21,7 @@ Contributors:
 # 3.2.2 (not yet released)
 
 WrongWrong (@k163377)
+* #1192: Improved KDoc of read functions to clarify Kotlin null safety
 * #1191: Allow null contents for use-site in projections in StrictNullChecks
 
 # 3.2.0 (08-Jun-2026)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -28,6 +28,9 @@ No changes since 3.2
 
 3.2.2 (not yet released)
 
+#1192: Improved documentation for the shorthands of deserialization methods.
+  The KDoc and README now state that most of them check the deserialized value
+  to preserve `Kotlin` null safety.
 #1191: Fixed a problem where null contents in use-site `in` projected positions (e.g. `Array<in String>`)
  were rejected by `StrictNullChecks` even though they may contain null
  regardless of the nullability of the type argument.


### PR DESCRIPTION
Added the release notes entry for #1192 to the 3.x files, since it was only recorded in `VERSION-2.x` / `CREDITS-2.x`.

Note that the KDoc merged into 3.x refers to `DatabindException` instead of `RuntimeJsonMappingException`, but the entry is worded so that it applies to both.
