### PR TITLE
Avoid Maven Central 429 by priming the Maven cache before the CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,14 +28,49 @@ permissions:
   contents: read
 
 jobs:
+  # Populates the shared '~/.m2/repository' cache once, so that the matrix below
+  # starts from a warm local repository. Without this every matrix job downloads
+  # the same artifacts at the same moment, and Maven Central answers part of that
+  # burst with 429 (Too Many Requests).
+  prime-cache:
+    runs-on: ubuntu-latest
+    outputs:
+      kotlin_versions: ${{ steps.kotlin_versions.outputs.list }}
+    env:
+      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    steps:
+    # Single source of truth for the 'kotlin_version' axis, for every caller.
+    - name: List Kotlin versions to test against
+      id: kotlin_versions
+      run: echo 'list=["2.1.21", "2.2.21", "2.3.21", "2.4.20-RC"]' >> $GITHUB_OUTPUT
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ inputs.ref }}
+    - name: Set up JDK
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+      with:
+        distribution: 'temurin'
+        # Any JDK will do: '~/.m2/repository' is shared by every matrix job
+        # because setup-java keys its Maven cache on the pom hash only.
+        java-version: '17'
+        cache: 'maven'
+    - name: Resolve build dependencies
+      run: ./mvnw -B -q -ff -ntp -DskipTests clean package
+    - name: Resolve test dependencies of every Kotlin version
+      run: |
+        for kotlin_version in $(echo '${{ steps.kotlin_versions.outputs.list }}' | jq -r '.[]'); do
+          ./mvnw -B -q -ff -ntp -Dversion.kotlin="$kotlin_version" \
+            org.apache.maven.plugins:maven-dependency-plugin:3.11.0:resolve
+        done
+
   build:
+    needs: prime-cache
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         java_version: ${{ fromJSON(inputs.java_versions) }}
-        # Single source of truth for the Kotlin axis, for every caller.
-        kotlin_version: ['2.1.21', '2.2.21', '2.3.21', '2.4.20-RC']
+        kotlin_version: ${{ fromJSON(needs.prime-cache.outputs.kotlin_versions) }}
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
       # Only the combination matching the pom's default 'version.kotlin' deploys.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,78 @@
+name: Build
+
+# Shared implementation of the build matrix. 'main.yml', 'dep_build_v2.yml' and
+# 'dep_build_v3.yml' differ only in what they check out, which JDKs they cover
+# and whether they deploy a snapshot, so everything else lives here.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Ref to check out. Empty means the ref that triggered the caller."
+        type: string
+        default: ''
+      java_versions:
+        description: "JSON array of JDK versions to run the matrix over."
+        type: string
+        required: true
+      deploy_snapshot:
+        description: "Whether the release build combination should deploy a snapshot."
+        type: boolean
+        default: false
+    secrets:
+      CENTRAL_DEPLOY_USERNAME:
+        required: false
+      CENTRAL_DEPLOY_PASSWORD:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: ${{ fromJSON(inputs.java_versions) }}
+        # Single source of truth for the Kotlin axis, for every caller.
+        kotlin_version: ['2.1.21', '2.2.21', '2.3.21', '2.4.20-RC']
+    env:
+      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      # Only the combination matching the pom's default 'version.kotlin' deploys.
+      # A matrix 'include' cannot express this: for a caller whose 'java_versions'
+      # does not contain '8' it would match no combination and add an extra job.
+      RELEASE_BUILD: ${{ inputs.deploy_snapshot && matrix.java_version == '8' && matrix.kotlin_version == '2.1.21' }}
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ inputs.ref }}
+    - name: Set up JDK
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java_version }}
+        cache: 'maven'
+        server-id: central-snapshots
+        server-username: CI_DEPLOY_USERNAME
+        server-password: CI_DEPLOY_PASSWORD
+        # See https://github.com/actions/setup-java/blob/v2/docs/advanced-usage.md#Publishing-using-Apache-
+        # gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+        # gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+
+    - name: Build
+      # Note: build separately first using default kotlin-core
+      run: ./mvnw -B -q -ff -ntp -DskipTests clean package
+    - name: Test
+      # Note: actual testing should use matrix kotlin-core version (note: MUST specify test phase)
+      run: ./mvnw -B -q -ff -ntp -Dversion.kotlin=${{ matrix.kotlin_version }} surefire:test
+    - name: Extract project Maven version
+      id: projectVersion
+      if: ${{ env.RELEASE_BUILD == 'true' }}
+      run: echo "version=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -DforceStdout -Dexpression=project.version -q)" >> $GITHUB_OUTPUT
+    - name: Deploy snapshot
+      if: ${{ env.RELEASE_BUILD == 'true' && endsWith(steps.projectVersion.outputs.version, '-SNAPSHOT') }}
+      env:
+        CI_DEPLOY_USERNAME: ${{ secrets.CENTRAL_DEPLOY_USERNAME }}
+        CI_DEPLOY_PASSWORD: ${{ secrets.CENTRAL_DEPLOY_PASSWORD }}
+        # MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      run: ./mvnw -B -q -ff -DskipTests -ntp source:jar deploy

--- a/.github/workflows/dep_build_v2.yml
+++ b/.github/workflows/dep_build_v2.yml
@@ -10,30 +10,11 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        java_version: ['8', '17', '21', '25', '26']
-        # Versions need to align with ones in 'main.yml' workflow
-        kotlin_version: ['2.1.21', '2.2.21', '2.3.21', '2.4.20-RC']
-    env:
-      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        ref: 2.x
-    - name: Set up JDK
-      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java_version }}
-        cache: 'maven'
-    - name: Build
-      # Note: build separately first using default kotlin-core
-      run: ./mvnw -B -q -ff -ntp -DskipTests clean package
-    - name: Test
-      # Note: actual testing should use matrix kotlin-core version (note: MUST specify test phase)
-      run: ./mvnw -B -q -ff -ntp -Dversion.kotlin=${{ matrix.kotlin_version }} surefire:test
+    uses: ./.github/workflows/build.yml
+    with:
+      ref: '2.x'
+      # A subset of the JDKs covered by 'main.yml'. The Kotlin axis is shared
+      # by every caller and lives in 'build.yml'.
+      java_versions: '["8", "17", "21", "25", "26"]'
 
 # No recursive rebuild (yet?)

--- a/.github/workflows/dep_build_v2.yml
+++ b/.github/workflows/dep_build_v2.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# databind pushes arrive in bursts; only the newest one is worth a full matrix.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/dep_build_v3.yml
+++ b/.github/workflows/dep_build_v3.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# databind pushes arrive in bursts; only the newest one is worth a full matrix.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/dep_build_v3.yml
+++ b/.github/workflows/dep_build_v3.yml
@@ -10,28 +10,9 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        java_version: ['17', '21', '25', '26']
-        # Versions need to align with ones in 'main.yml' workflow
-        kotlin_version: ['2.1.21', '2.2.21', '2.3.21', '2.4.20-RC']
-    env:
-      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        ref: 3.x
-    - name: Set up JDK
-      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java_version }}
-        cache: 'maven'
-    - name: Build
-      # Note: build separately first using default kotlin-core
-      run: ./mvnw -B -q -ff -ntp -DskipTests clean package
-    - name: Test
-      # Note: actual testing should use matrix kotlin-core version (note: MUST specify test phase)
-      run: ./mvnw -B -q -ff -ntp -Dversion.kotlin=${{ matrix.kotlin_version }} surefire:test
+    uses: ./.github/workflows/build.yml
+    with:
+      ref: '3.x'
+      # A subset of the JDKs covered by 'main.yml'. The Kotlin axis is shared
+      # by every caller and lives in 'build.yml'.
+      java_versions: '["17", "21", "25", "26"]'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,13 @@ on:
 permissions:
   contents: read
 
+# One matrix run is a sizable burst of Maven Central traffic, so do not keep
+# superseded runs of the same PR alive. Pushes to '2.*' are not cancelled
+# because their last job deploys a snapshot.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,46 +17,10 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        java_version: ['8', '11', '17', '21', '25', '26']
-        kotlin_version: ['2.1.21', '2.2.21', '2.3.21', '2.4.20-RC']
-        include:
-          - java_version: '8'
-            kotlin_version: '2.1.21'
-            release_build: 'R'
-    env:
-      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - name: Set up JDK
-      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java_version }}
-        cache: 'maven'
-        server-id: central-snapshots
-        server-username: CI_DEPLOY_USERNAME
-        server-password: CI_DEPLOY_PASSWORD
-        # See https://github.com/actions/setup-java/blob/v2/docs/advanced-usage.md#Publishing-using-Apache-
-        # gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
-        # gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
-
-    - name: Build
-      # Note: build separately first using default kotlin-core
-      run: ./mvnw -B -q -ff -ntp -DskipTests clean package
-    - name: Test
-      # Note: actual testing should use matrix kotlin-core version (note: MUST specify test phase)
-      run: ./mvnw -B -q -ff -ntp -Dversion.kotlin=${{ matrix.kotlin_version }} surefire:test
-    - name: Extract project Maven version
-      id: projectVersion
-      run: echo "version=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -DforceStdout -Dexpression=project.version -q)" >> $GITHUB_OUTPUT
-    - name: Deploy snapshot
-      if: ${{ github.event_name != 'pull_request' && matrix.release_build && endsWith(steps.projectVersion.outputs.version, '-SNAPSHOT') }}
-      env:
-        CI_DEPLOY_USERNAME: ${{ secrets.CENTRAL_DEPLOY_USERNAME }}
-        CI_DEPLOY_PASSWORD: ${{ secrets.CENTRAL_DEPLOY_PASSWORD }}
-        # MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-      run: ./mvnw -B -q -ff -DskipTests -ntp source:jar deploy
+    uses: ./.github/workflows/build.yml
+    with:
+      java_versions: '["8", "11", "17", "21", "25", "26"]'
+      deploy_snapshot: ${{ github.event_name != 'pull_request' }}
+    secrets:
+      CENTRAL_DEPLOY_USERNAME: ${{ secrets.CENTRAL_DEPLOY_USERNAME }}
+      CENTRAL_DEPLOY_PASSWORD: ${{ secrets.CENTRAL_DEPLOY_PASSWORD }}


### PR DESCRIPTION
Two commits: a no-behaviour-change refactor first, then the actual fix on top.

## Problem

CI fans out to 24 jobs (`main.yml`), 20 (`dep_build_v2.yml`) and 16 (`dep_build_v3.yml`).
Every one of them starts with a cold `~/.m2/repository` and asks Maven Central for the same
artifacts at the same moment, from the same GitHub Actions egress range. Central rate-limits
part of that burst:

```
[FATAL] Non-resolvable parent POM for com.fasterxml.jackson:jackson-bom:2.21.7-SNAPSHOT:
  The following artifacts could not be resolved: com.fasterxml.jackson:jackson-parent:pom:2.21 (absent):
  Could not transfer artifact com.fasterxml.jackson:jackson-parent:pom:2.21
  from/to central (https://repo.maven.apache.org/maven2):
  status code: 429, reason phrase: Too Many Requests (429)
```

(from https://github.com/FasterXML/jackson-module-kotlin/actions/runs/33763306119/job/100674732651)

Note the source is Maven Central itself, not the Central Portal snapshot repository.
The same run logs `maven cache is not found`. Whenever that entry misses — the pom hash changed,
or the cache was evicted — the whole matrix goes cold at the same moment, which is exactly when
the burst is largest.

## Commit 1 — extract the shared build matrix into a reusable workflow

The three workflows were already near-identical: `dep_build_v2.yml` and `dep_build_v3.yml`
differed in **5 lines out of 39**. Copying the `prime-cache` job of commit 2 into each of them
would have tripled it, so the extraction comes first.

```yaml
  build:
    uses: ./.github/workflows/build.yml
    with:
      ref: '2.x'
      java_versions: '["8", "17", "21", "25", "26"]'
```

| | before | after |
|---|---|---|
| `main.yml` | 62 | 33 |
| `dep_build_v2.yml` | 39 | 25 |
| `dep_build_v3.yml` | 37 | 23 |
| `build.yml` | — | 114 |
| Kotlin list declared in | 3 files | 1 file |
| Pinned action SHAs live in | 3 files | 1 file |

The commit itself is line-neutral (+98 / -93); the `# Versions need to align with ones in
'main.yml' workflow` comments are gone, and a dependabot bump now touches one file.

The matrix `include` that carried `release_build` is replaced by a `RELEASE_BUILD` env
expression. An `include` cannot be shared: for a caller whose `java_versions` does not contain
`'8'` it would fail to match an existing combination and would silently **add an extra job**.
The deployed combination is unchanged (JDK 8 / Kotlin 2.1.21), and "Extract project Maven
version" now runs only in that combination instead of in all 24.

## Commit 2 — the 429 fix

The `java_version` x `kotlin_version` grid is unchanged; nothing here reduces coverage.

### A `prime-cache` job runs before the matrix

It resolves the build once and then resolves the test dependencies of each Kotlin version,
which populates the `setup-java` Maven cache. setup-java v6.0.0 builds that key as
`setup-java-${RUNNER_OS}-${arch}-maven-${fileHash}` — no JDK version — so a cache primed on
JDK 17 is an exact hit for every matrix job. Exactly one job now talks to Central with a cold
cache instead of 24. `prime-cache` also owns the Kotlin version list, so the loop that primes
each version and the matrix axis cannot drift apart.

If the cache save ever fails, the matrix simply falls back to today's behaviour.

### `concurrency` groups

Pushing twice to a PR used to leave two full matrices racing for the same artifacts.
Superseded PR runs are now cancelled; pushes to `2.*` are **not** cancelled, because their
last job deploys a snapshot. The `dep_build_*` workflows cancel too, since only the newest
`jackson-databind` state is worth a matrix.

### No resolver retry tuning

Maven 3.9.9 already retries `429`/`503` three times on its own. Raising those limits would
mean a `.mvn/maven.config`, which changes **every local and IDE build** in the repository and
spreads on merge-forward - a poor trade for a CI-only problem. If 429 does resurface,
`MAVEN_ARGS` in `build.yml` keeps the workaround scoped to CI.

## What this does *not* do

`max-parallel` is deliberately **not** reintroduced. It was removed in #1158 to keep CI latency
low; warming the cache addresses the cause instead of capping the fan-out.

## Trade-offs

- `prime-cache` is serial and takes ~1m30s, but every matrix job it feeds starts warm, so the
  measured cost on the critical path is about **50s**: 3m31s for a 24-job matrix without it
  (run 33763306119, attempt 1) against 4m22s, 4m26s and 4m13s with it (runs 33773902684, 33774854899 and 33776161836). That attempt-1 run is also the one that lost a job to 429 and needed a re-run
  to go green, which put real time-to-green at 5m44s.
- It is a new hard dependency: if `prime-cache` fails, the matrix does not run. In exchange a
  failing prime job is one cheap re-run instead of a re-run of the whole matrix, and its
  `clean package` surfaces compile errors before the matrix starts.

- Check names change from `build (8, 2.1.21)` to `build / build (8, 2.1.21)`. Branch protection
  on `2.21` has no `required_status_checks`, so nothing breaks there, but `2.22` and `3.x` are
  worth a look before merging forward.

## Verified on CI

Run https://github.com/FasterXML/jackson-module-kotlin/actions/runs/33776161836 is green:
25/25 jobs, `build / prime-cache` plus exactly the 6 x 4 matrix - the `fromJSON` axes expand
correctly and no phantom combination appears.

The shared cache key is confirmed in the logs: `build / prime-cache` (JDK 17) and
`build / build (26, 2.4.20-RC)` (JDK 26) both resolve to
`setup-java-Linux-x64-maven-0c2c36832c33e49dd896b8ec616053189d9c73df...`, which is the point
the design rests on.

Caveat: in every run so far `prime-cache` found an existing cache under this pom hash and
restored it rather than creating it. The cold-start path - one job populating the cache for the
other 24 - has therefore not been exercised end to end; what is proven is that all 25 jobs
resolve to a single cache key.


## Notes for review

- `dep_build_v2.yml` / `dep_build_v3.yml` are triggered by `repository_dispatch`, so they run
  from the default branch (`3.x`), and only take effect once this is merged forward.
- `maven-dependency-plugin` is pinned at `3.11.0`, matching the existing pinning style of
  `maven-help-plugin:3.5.1`.
- Context availability was checked against the docs: `strategy` accepts `needs`/`inputs`,
  `jobs.<id>.env` accepts `matrix`/`inputs`, and `steps.if` accepts `env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




