### PR TITLE
Take the build matrix axes and the release build from 'build.yml' inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,9 @@
 name: Build
 
 # Shared implementation of the build matrix. 'main.yml', 'dep_build_v2.yml' and
-# 'dep_build_v3.yml' differ only in what they check out, which JDKs they cover
-# and whether they deploy a snapshot, so everything else lives here.
+# 'dep_build_v3.yml' differ only in what they check out, which JDK and Kotlin
+# versions they cover and whether they deploy a snapshot, so everything else
+# lives here.
 on:
   workflow_call:
     inputs:
@@ -14,10 +15,22 @@ on:
         description: "JSON array of JDK versions to run the matrix over."
         type: string
         required: true
+      kotlin_versions:
+        description: "JSON array of Kotlin versions to run the matrix over."
+        type: string
+        required: true
       deploy_snapshot:
         description: "Whether the release build combination should deploy a snapshot."
         type: boolean
         default: false
+      release_java_version:
+        description: "JDK version of the release build combination. Read only when 'deploy_snapshot' is set."
+        type: string
+        default: ''
+      release_kotlin_version:
+        description: "Kotlin version of the release build combination. Read only when 'deploy_snapshot' is set."
+        type: string
+        default: ''
     secrets:
       CENTRAL_DEPLOY_USERNAME:
         required: false
@@ -34,15 +47,9 @@ jobs:
   # burst with 429 (Too Many Requests).
   prime-cache:
     runs-on: ubuntu-latest
-    outputs:
-      kotlin_versions: ${{ steps.kotlin_versions.outputs.list }}
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:
-    # Single source of truth for the 'kotlin_version' axis, for every caller.
-    - name: List Kotlin versions to test against
-      id: kotlin_versions
-      run: echo 'list=["2.1.21", "2.2.21", "2.3.21", "2.4.20-RC3"]' >> $GITHUB_OUTPUT
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ inputs.ref }}
@@ -58,7 +65,7 @@ jobs:
       run: ./mvnw -B -q -ff -ntp -DskipTests clean package
     - name: Resolve test dependencies of every Kotlin version
       run: |
-        for kotlin_version in $(echo '${{ steps.kotlin_versions.outputs.list }}' | jq -r '.[]'); do
+        for kotlin_version in $(echo '${{ inputs.kotlin_versions }}' | jq -r '.[]'); do
           ./mvnw -B -q -ff -ntp -Dversion.kotlin="$kotlin_version" \
             org.apache.maven.plugins:maven-dependency-plugin:3.11.0:resolve
         done
@@ -70,13 +77,12 @@ jobs:
       fail-fast: false
       matrix:
         java_version: ${{ fromJSON(inputs.java_versions) }}
-        kotlin_version: ${{ fromJSON(needs.prime-cache.outputs.kotlin_versions) }}
+        kotlin_version: ${{ fromJSON(inputs.kotlin_versions) }}
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
-      # Only the combination matching the pom's default 'version.kotlin' deploys.
-      # A matrix 'include' cannot express this: for a caller whose 'java_versions'
-      # does not contain '8' it would match no combination and add an extra job.
-      RELEASE_BUILD: ${{ inputs.deploy_snapshot && matrix.java_version == '8' && matrix.kotlin_version == '2.1.21' }}
+      # The release build is the combination the pom builds with by default, and
+      # it is the only one allowed to deploy.
+      RELEASE_BUILD: ${{ inputs.deploy_snapshot && matrix.java_version == inputs.release_java_version && matrix.kotlin_version == inputs.release_kotlin_version }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/.github/workflows/dep_build_v2.yml
+++ b/.github/workflows/dep_build_v2.yml
@@ -18,8 +18,9 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       ref: '2.x'
-      # A subset of the JDKs covered by 'main.yml'. The Kotlin axis is shared
-      # by every caller and lives in 'build.yml'.
+      # A subset of the JDKs covered by 'main.yml'. The Kotlin versions need to
+      # align with the ones there.
       java_versions: '["8", "17", "21", "25", "26"]'
+      kotlin_versions: '["2.1.21", "2.2.21", "2.3.21", "2.4.20-RC3"]'
 
 # No recursive rebuild (yet?)

--- a/.github/workflows/dep_build_v3.yml
+++ b/.github/workflows/dep_build_v3.yml
@@ -18,6 +18,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       ref: '3.x'
-      # A subset of the JDKs covered by 'main.yml'. The Kotlin axis is shared
-      # by every caller and lives in 'build.yml'.
+      # A subset of the JDKs covered by 'main.yml'. The Kotlin versions need to
+      # align with the ones there.
       java_versions: '["17", "21", "25", "26"]'
+      kotlin_versions: '["2.1.21", "2.2.21", "2.3.21", "2.4.20-RC3"]'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,10 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       java_versions: '["8", "11", "17", "21", "25", "26"]'
+      kotlin_versions: '["2.1.21", "2.2.21", "2.3.21", "2.4.20-RC3"]'
       deploy_snapshot: ${{ github.event_name != 'pull_request' }}
+      release_java_version: '8'
+      release_kotlin_version: '2.1.21'
     secrets:
       CENTRAL_DEPLOY_USERNAME: ${{ secrets.CENTRAL_DEPLOY_USERNAME }}
       CENTRAL_DEPLOY_PASSWORD: ${{ secrets.CENTRAL_DEPLOY_PASSWORD }}


### PR DESCRIPTION
`build.yml` fixes the Kotlin axis and the JDK/Kotlin pair that deploys a snapshot as constants, so it can only serve callers that use those exact values. Both become `workflow_call` inputs, and `main.yml`, `dep_build_v2.yml` and `dep_build_v3.yml` each state their own, the same way `java_versions` already works.

Every matrix is unchanged: each caller passes exactly the versions it runs today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)